### PR TITLE
fix(gateway): SQLite api_keys path under HOLIX_HOME

### DIFF
--- a/api/gateway.py
+++ b/api/gateway.py
@@ -55,6 +55,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize multi-profile registry, stores, and API key DB."""
+    from core.env_loader import init_holix_home
+    from core.paths import resolve_api_keys_db_path
+
+    init_holix_home()
+
     if settings.is_production and not settings.api_key_pepper.strip():
         raise RuntimeError("HOLIX_API_KEY_PEPPER is required when HOLIX_ENV=production")
 
@@ -70,7 +75,7 @@ async def lifespan(app: FastAPI):
 
     import api.deps as gateway_deps
 
-    state.api_key_manager = APIKeyManager(settings.api_keys_db_path)
+    state.api_key_manager = APIKeyManager(str(resolve_api_keys_db_path()))
     await state.api_key_manager.initialize_db()
     gateway_deps.api_key_manager = state.api_key_manager
     gateway_deps.rate_limiter = state.rate_limiter

--- a/config.py
+++ b/config.py
@@ -101,7 +101,7 @@ class Settings(BaseSettings):
     require_auth: bool = True
     cors_origins: str = "http://127.0.0.1:8000,http://localhost:8000"
     api_keys_db_path: str = Field(
-        default="data/security/api_keys.db",
+        default="security/api_keys.db",
         validation_alias=AliasChoices("HOLIX_API_KEYS_DB", "API_KEYS_DB"),
     )
     api_key_pepper: str = Field(

--- a/core/paths.py
+++ b/core/paths.py
@@ -31,6 +31,30 @@ def resolve_profile_data_dir(profile: str | None = None) -> Path:
     return resolve_holix_default_data_dir(profile or "default")
 
 
+def resolve_holix_storage_path(path: str | None, *, default: Path) -> Path:
+    """Resolve storage paths under ``HOLIX_HOME`` (never process CWD)."""
+    from core.env_loader import init_holix_home
+    from core.platform_compat import resolve_holix_home
+
+    init_holix_home()
+    raw = (path or "").strip()
+    if not raw:
+        return default.resolve()
+    expanded = Path(raw).expanduser()
+    if expanded.is_absolute():
+        return expanded.resolve()
+    return (resolve_holix_home() / expanded).resolve()
+
+
+def resolve_api_keys_db_path(path: str | None = None) -> Path:
+    """Gateway API key SQLite DB — global under ``HOLIX_HOME``."""
+    from config import settings
+    from core.platform_compat import resolve_holix_home
+
+    default = resolve_holix_home() / "security" / "api_keys.db"
+    return resolve_holix_storage_path(path or settings.api_keys_db_path, default=default)
+
+
 def memory_paths_from_data_dir(data_dir: str | Path) -> dict[str, str]:
     """Derive memory-related paths under a profile data directory."""
     base = Path(data_dir).expanduser().resolve()

--- a/core/security/auth.py
+++ b/core/security/auth.py
@@ -8,17 +8,18 @@ from typing import Any
 import aiosqlite
 
 from config import settings
+from core.paths import resolve_api_keys_db_path
 
 
 class APIKeyManager:
     """Manages API keys for authentication."""
 
     def __init__(self, db_path: str | None = None):
-        self.db_path = Path(db_path or settings.api_keys_db_path)
+        self.db_path = resolve_api_keys_db_path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
     async def initialize_db(self) -> None:
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             await db.execute(
                 """
                 CREATE TABLE IF NOT EXISTS api_keys (
@@ -67,7 +68,7 @@ class APIKeyManager:
         key_hash = self.hash_key(api_key)
         limit = rate_limit if rate_limit is not None else settings.rate_limit_rpm
 
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             await db.execute(
                 """
                 INSERT INTO api_keys (key_hash, name, permissions, rate_limit)
@@ -85,7 +86,7 @@ class APIKeyManager:
 
         key_hash = self.hash_key(api_key)
 
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
                 """
@@ -113,7 +114,7 @@ class APIKeyManager:
 
     async def revoke_api_key(self, api_key: str) -> bool:
         key_hash = self.hash_key(api_key)
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             cursor = await db.execute(
                 "UPDATE api_keys SET is_active = 0 WHERE key_hash = ?",
                 (key_hash,),
@@ -122,7 +123,7 @@ class APIKeyManager:
             return cursor.rowcount > 0
 
     async def list_api_keys(self) -> list:
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
                 """

--- a/tests/test_no_cwd_data_leak.py
+++ b/tests/test_no_cwd_data_leak.py
@@ -91,6 +91,41 @@ async def test_action_guard_audit_log_in_profile(tmp_path, monkeypatch) -> None:
     assert not (tmp_path / "repo" / "data").exists()
 
 
+def test_api_keys_db_resolves_under_holix_home(tmp_path, monkeypatch) -> None:
+    holix_home = tmp_path / "holix"
+    monkeypatch.setenv("HOLIX_HOME", str(holix_home))
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    from core.paths import resolve_api_keys_db_path
+
+    resolved = resolve_api_keys_db_path("security/api_keys.db")
+    assert resolved == (holix_home / "security" / "api_keys.db").resolve()
+    assert not resolved.is_relative_to(repo)
+
+
+@pytest.mark.asyncio
+async def test_api_key_manager_opens_resolved_db(tmp_path, monkeypatch) -> None:
+    holix_home = tmp_path / "holix"
+    monkeypatch.setenv("HOLIX_HOME", str(holix_home))
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    from config import settings
+    from core.security.auth import APIKeyManager
+
+    updated = settings.model_copy(update={"api_key_pepper": "test-pepper"})
+    monkeypatch.setattr("config.settings", updated)
+    monkeypatch.setattr("core.security.auth.settings", updated)
+
+    mgr = APIKeyManager()
+    await mgr.initialize_db()
+    assert mgr.db_path == (holix_home / "security" / "api_keys.db").resolve()
+    assert mgr.db_path.exists()
+
+
 def test_doctor_migrates_stray_project_data(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr("cli.core.PROFILES_DIR", tmp_path / "profiles")
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Problem
Gateway startup failed:
```
sqlite3.OperationalError: unable to open database file
```

`api_keys.db` used default path `data/security/api_keys.db` relative to process CWD. Under systemd/uv tool the CWD is often not writable or not the Holix home dir.

## Fix
- Resolve `api_keys_db_path` under `HOLIX_HOME` (default: `~/.holix/security/api_keys.db`)
- Call `init_holix_home()` before opening DB at gateway lifespan
- Tests: 753 passed