### PR TITLE
fix(gateway): ltm.db path under profile HOLIX_HOME

### DIFF
--- a/api/gateway.py
+++ b/api/gateway.py
@@ -56,7 +56,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 async def lifespan(app: FastAPI):
     """Initialize multi-profile registry, stores, and API key DB."""
     from core.env_loader import init_holix_home
-    from core.paths import resolve_api_keys_db_path
+    from core.paths import ensure_profile_memory_dirs, resolve_api_keys_db_path
 
     init_holix_home()
 
@@ -80,6 +80,7 @@ async def lifespan(app: FastAPI):
     gateway_deps.api_key_manager = state.api_key_manager
     gateway_deps.rate_limiter = state.rate_limiter
 
+    ensure_profile_memory_dirs(host_profile)
     await state.registry.get_agent(host_profile)
     await state.companions.start_cron(host_profile)
     await state.companions.start_telegram(host_profile)

--- a/cli/core.py
+++ b/cli/core.py
@@ -149,16 +149,50 @@ def resolve_profile_storage_paths(
     """Bind profile storage paths to ~/.holix/profiles/<name>/ (not process CWD)."""
     base = (profile_dir or (profiles_dir() / profile)).resolve()
 
-    def _resolve(path: str | None, default: Path) -> str:
-        if not path or not str(path).strip():
-            return str(default.resolve())
-        expanded = Path(path).expanduser()
-        if expanded.is_absolute():
-            return str(expanded.resolve())
-        return str((base / expanded).resolve())
+    def _path_is_writable(path: Path, *, mkdir_target: bool) -> bool:
+        try:
+            if mkdir_target:
+                path.mkdir(parents=True, exist_ok=True)
+                probe = path / ".holix_write_probe"
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                probe = path.parent / ".holix_write_probe"
+            probe.write_text("", encoding="utf-8")
+            probe.unlink(missing_ok=True)
+            return True
+        except OSError:
+            return False
+
+    def _resolve(
+        path: str | None,
+        default: Path,
+        *,
+        mkdir_target: bool = False,
+    ) -> str:
+        """Resolve under profile dir; fall back when outside paths are not writable."""
+        target = default.resolve()
+        if path and str(path).strip():
+            expanded = Path(path).expanduser()
+            if expanded.is_absolute():
+                candidate = expanded.resolve()
+                try:
+                    candidate.relative_to(base)
+                    target = candidate
+                except ValueError:
+                    if _path_is_writable(candidate, mkdir_target=mkdir_target):
+                        target = candidate
+            else:
+                target = (base / expanded).resolve()
+
+        if not mkdir_target and target.exists() and target.is_dir():
+            target = default.resolve()
+        if not _path_is_writable(target, mkdir_target=mkdir_target):
+            target = default.resolve()
+            _path_is_writable(target, mkdir_target=mkdir_target)
+        return str(target)
 
     config.profile_name = profile
-    config.data_dir = _resolve(config.data_dir, base / "data")
+    config.data_dir = _resolve(config.data_dir, base / "data", mkdir_target=True)
     config.memory_db_path = _resolve(
         config.memory_db_path,
         base / "data" / "memory" / "memory.db",
@@ -166,6 +200,7 @@ def resolve_profile_storage_paths(
     config.vector_db_path = _resolve(
         config.vector_db_path,
         base / "data" / "memory" / "vector_db",
+        mkdir_target=True,
     )
     config.ltm_db_path = _resolve(
         config.ltm_db_path,
@@ -175,7 +210,11 @@ def resolve_profile_storage_paths(
         config.langgraph_checkpoint_db_path,
         base / "data" / "memory" / "checkpoints.db",
     )
-    config.skills_dir = _resolve(config.skills_dir, base / "data" / "skills")
+    config.skills_dir = _resolve(
+        config.skills_dir,
+        base / "data" / "skills",
+        mkdir_target=True,
+    )
     if config.workspace_root and str(config.workspace_root).strip():
         config.workspace_root = _resolve(config.workspace_root, base / "workspace")
     else:

--- a/core/memory/conversation.py
+++ b/core/memory/conversation.py
@@ -13,6 +13,7 @@ import chromadb
 from chromadb.config import Settings as ChromaSettings
 
 from core.di.runtime_config import HolixRuntimeConfig
+from core.paths import ensure_sqlite_parent
 from core.memory.chroma_embeddings import get_or_create_collection
 
 logger = logging.getLogger(__name__)
@@ -31,10 +32,10 @@ class ConversationStore:
     def __init__(self, config: HolixRuntimeConfig | None = None):
         cfg = config or HolixRuntimeConfig.from_settings()
         self.config = cfg
-        self.db_path = Path(cfg.memory_db_path)
+        self.db_path = ensure_sqlite_parent(cfg.memory_db_path)
         self.vector_db_path = Path(cfg.vector_db_path)
 
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.vector_db_path.mkdir(parents=True, exist_ok=True)
         self.vector_db_path.mkdir(parents=True, exist_ok=True)
 
         self.chroma_client = chromadb.PersistentClient(
@@ -49,7 +50,7 @@ class ConversationStore:
         )
 
     async def initialize_db(self) -> None:
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             await db.execute("""
                 CREATE TABLE IF NOT EXISTS conversations (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -77,7 +78,7 @@ class ConversationStore:
         content: str,
         metadata: dict[str, Any] | None = None,
     ) -> int:
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             cursor = await db.execute(
                 """INSERT INTO conversations (conversation_id, role, content, metadata)
                    VALUES (?, ?, ?, ?)""",
@@ -114,7 +115,7 @@ class ConversationStore:
         conversation_id: str,
         limit: int = 30,
     ) -> list[dict[str, Any]]:
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
                 """SELECT role, content, timestamp, metadata
@@ -177,7 +178,7 @@ class ConversationStore:
         conversation_id: str,
         new_messages: list[dict[str, Any]],
     ) -> int:
-        async with aiosqlite.connect(self.db_path) as db:
+        async with aiosqlite.connect(str(self.db_path)) as db:
             await db.execute(
                 "DELETE FROM conversations WHERE conversation_id = ?",
                 (conversation_id,),
@@ -232,7 +233,7 @@ class ConversationStore:
 
     async def delete_conversation(self, conversation_id: str) -> bool:
         try:
-            async with aiosqlite.connect(self.db_path) as db:
+            async with aiosqlite.connect(str(self.db_path)) as db:
                 await db.execute(
                     "DELETE FROM conversations WHERE conversation_id = ?",
                     (conversation_id,),
@@ -248,7 +249,7 @@ class ConversationStore:
 
     async def list_recent_conversations(self, limit: int = 10) -> list[dict]:
         try:
-            async with aiosqlite.connect(self.db_path) as db:
+            async with aiosqlite.connect(str(self.db_path)) as db:
                 db.row_factory = aiosqlite.Row
                 cursor = await db.execute(
                     """

--- a/core/memory/ltm.py
+++ b/core/memory/ltm.py
@@ -9,6 +9,7 @@ from typing import Any
 import aiosqlite
 
 from core.di.runtime_config import HolixRuntimeConfig
+from core.paths import ensure_sqlite_parent
 from core.memory.episodic import EpisodicMemoryStore
 from core.memory.procedural import ProceduralMemoryStore
 from core.memory.semantic import SemanticMemoryStore
@@ -24,8 +25,7 @@ class LongTermMemoryStore:
     def __init__(self, config: HolixRuntimeConfig | None = None):
         cfg = config or HolixRuntimeConfig.from_settings()
         self.config = cfg
-        self._ltm_db_path = Path(cfg.ltm_db_path)
-        self._ltm_db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ltm_db_path = ensure_sqlite_parent(cfg.ltm_db_path)
 
         self._vector_store = VectorMemoryStore(vector_db_path=cfg.vector_db_path)
 
@@ -47,7 +47,7 @@ class LongTermMemoryStore:
         )
 
     async def initialize_db(self) -> None:
-        async with aiosqlite.connect(self._ltm_db_path) as db:
+        async with aiosqlite.connect(str(self._ltm_db_path)) as db:
             await db.execute("""
                 CREATE TABLE IF NOT EXISTS ltm_entries (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/core/paths.py
+++ b/core/paths.py
@@ -46,6 +46,24 @@ def resolve_holix_storage_path(path: str | None, *, default: Path) -> Path:
     return (resolve_holix_home() / expanded).resolve()
 
 
+def ensure_sqlite_parent(path: str | Path) -> Path:
+    """Create parent directory for a SQLite file and return the path."""
+    db_path = Path(path).expanduser().resolve()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return db_path
+
+
+def ensure_profile_memory_dirs(profile: str) -> None:
+    """Ensure SQLite/Chroma memory directories exist for a profile."""
+    from cli.core import ProfileManager
+
+    cfg = ProfileManager().load_profile(profile)
+    ensure_sqlite_parent(cfg.memory_db_path)
+    ensure_sqlite_parent(cfg.ltm_db_path)
+    ensure_sqlite_parent(cfg.langgraph_checkpoint_db_path)
+    Path(cfg.vector_db_path).expanduser().resolve().mkdir(parents=True, exist_ok=True)
+
+
 def resolve_api_keys_db_path(path: str | None = None) -> Path:
     """Gateway API key SQLite DB — global under ``HOLIX_HOME``."""
     from config import settings

--- a/tests/test_no_cwd_data_leak.py
+++ b/tests/test_no_cwd_data_leak.py
@@ -91,6 +91,22 @@ async def test_action_guard_audit_log_in_profile(tmp_path, monkeypatch) -> None:
     assert not (tmp_path / "repo" / "data").exists()
 
 
+def test_stale_absolute_ltm_path_reset_to_profile(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("cli.core.PROFILES_DIR", tmp_path / "profiles")
+    profile_dir = ProfileManager().get_profile_dir("default")
+    profile_dir.mkdir(parents=True)
+
+    cfg = ProfileConfig(
+        profile_name="default",
+        ltm_db_path="/root/.holix-stale/ltm.db",
+        memory_db_path="/root/.holix-stale/memory.db",
+    )
+    resolved = resolve_profile_storage_paths("default", cfg, profile_dir=profile_dir)
+    expected = (profile_dir / "data" / "memory" / "ltm.db").resolve()
+    assert Path(resolved.ltm_db_path) == expected
+    assert Path(resolved.memory_db_path) == (profile_dir / "data" / "memory" / "memory.db").resolve()
+
+
 def test_api_keys_db_resolves_under_holix_home(tmp_path, monkeypatch) -> None:
     holix_home = tmp_path / "holix"
     monkeypatch.setenv("HOLIX_HOME", str(holix_home))


### PR DESCRIPTION
## Problem
Gateway startup failed opening `ltm.db`:
```
sqlite3.OperationalError: unable to open database file
```

Profile `config.yaml` could contain stale absolute paths (e.g. `~/Holix/data/memory/ltm.db`) outside `~/.holix/profiles/<name>/`.

## Fix
- Reset non-writable/out-of-profile absolute paths to standard profile memory paths
- `mkdir` parents before SQLite connect; use `str()` for aiosqlite
- `ensure_profile_memory_dirs()` at gateway lifespan before agent init

754 tests passed