### PR TITLE
fix(memory): ltm.db SQLite open failures on gateway start

### DIFF
--- a/cli/core.py
+++ b/cli/core.py
@@ -202,18 +202,20 @@ def resolve_profile_storage_paths(
         base / "data" / "memory" / "vector_db",
         mkdir_target=True,
     )
-    config.ltm_db_path = _resolve(
-        config.ltm_db_path,
-        base / "data" / "memory" / "ltm.db",
-    )
-    config.langgraph_checkpoint_db_path = _resolve(
-        config.langgraph_checkpoint_db_path,
-        base / "data" / "memory" / "checkpoints.db",
-    )
     config.skills_dir = _resolve(
         config.skills_dir,
         base / "data" / "skills",
         mkdir_target=True,
+    )
+    # Keep all SQLite memory stores next to memory.db (fixes stale ltm/checkpoint paths).
+    memory_dir = Path(config.memory_db_path).resolve().parent
+    config.ltm_db_path = _resolve(
+        str(memory_dir / "ltm.db"),
+        memory_dir / "ltm.db",
+    )
+    config.langgraph_checkpoint_db_path = _resolve(
+        str(memory_dir / "checkpoints.db"),
+        memory_dir / "checkpoints.db",
     )
     if config.workspace_root and str(config.workspace_root).strip():
         config.workspace_root = _resolve(config.workspace_root, base / "workspace")

--- a/core/memory/conversation.py
+++ b/core/memory/conversation.py
@@ -13,7 +13,7 @@ import chromadb
 from chromadb.config import Settings as ChromaSettings
 
 from core.di.runtime_config import HolixRuntimeConfig
-from core.paths import ensure_sqlite_parent
+from core.paths import prepare_sqlite_db_file
 from core.memory.chroma_embeddings import get_or_create_collection
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ class ConversationStore:
     def __init__(self, config: HolixRuntimeConfig | None = None):
         cfg = config or HolixRuntimeConfig.from_settings()
         self.config = cfg
-        self.db_path = ensure_sqlite_parent(cfg.memory_db_path)
+        self.db_path = prepare_sqlite_db_file(cfg.memory_db_path)
         self.vector_db_path = Path(cfg.vector_db_path)
 
         self.vector_db_path.mkdir(parents=True, exist_ok=True)

--- a/core/memory/ltm.py
+++ b/core/memory/ltm.py
@@ -9,7 +9,7 @@ from typing import Any
 import aiosqlite
 
 from core.di.runtime_config import HolixRuntimeConfig
-from core.paths import ensure_sqlite_parent
+from core.paths import prepare_sqlite_db_file
 from core.memory.episodic import EpisodicMemoryStore
 from core.memory.procedural import ProceduralMemoryStore
 from core.memory.semantic import SemanticMemoryStore
@@ -25,7 +25,7 @@ class LongTermMemoryStore:
     def __init__(self, config: HolixRuntimeConfig | None = None):
         cfg = config or HolixRuntimeConfig.from_settings()
         self.config = cfg
-        self._ltm_db_path = ensure_sqlite_parent(cfg.ltm_db_path)
+        self._ltm_db_path = prepare_sqlite_db_file(cfg.ltm_db_path)
 
         self._vector_store = VectorMemoryStore(vector_db_path=cfg.vector_db_path)
 

--- a/core/paths.py
+++ b/core/paths.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+import os
+import sqlite3
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_holix_default_data_dir(profile: str = "default") -> Path:
@@ -46,11 +51,50 @@ def resolve_holix_storage_path(path: str | None, *, default: Path) -> Path:
     return (resolve_holix_home() / expanded).resolve()
 
 
-def ensure_sqlite_parent(path: str | Path) -> Path:
-    """Create parent directory for a SQLite file and return the path."""
+def _rename_blocking_path(path: Path) -> Path | None:
+    """Move a file/dir blocking SQLite creation aside; return backup path if moved."""
+    if not path.exists():
+        return None
+    backup = path.with_name(f"{path.name}.holix-bak")
+    index = 0
+    while backup.exists():
+        index += 1
+        backup = path.with_name(f"{path.name}.holix-bak{index}")
+    try:
+        path.rename(backup)
+        logger.warning("Moved blocking SQLite path %s -> %s", path, backup)
+        return backup
+    except OSError as exc:
+        logger.error("Cannot move blocking SQLite path %s: %s", path, exc)
+        return None
+
+
+def prepare_sqlite_db_file(path: str | Path) -> Path:
+    """Ensure a SQLite file path exists and is openable (not a directory / read-only)."""
     db_path = Path(path).expanduser().resolve()
     db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if db_path.exists() and db_path.is_dir():
+        _rename_blocking_path(db_path)
+
+    if db_path.exists() and not os.access(db_path, os.W_OK):
+        _rename_blocking_path(db_path)
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA user_version")
+        conn.close()
+    except sqlite3.Error as exc:
+        raise RuntimeError(
+            f"Cannot open SQLite database at {db_path} "
+            f"(parent={db_path.parent}, writable={os.access(db_path.parent, os.W_OK)}): {exc}"
+        ) from exc
     return db_path
+
+
+def ensure_sqlite_parent(path: str | Path) -> Path:
+    """Backward-compatible alias for :func:`prepare_sqlite_db_file`."""
+    return prepare_sqlite_db_file(path)
 
 
 def ensure_profile_memory_dirs(profile: str) -> None:
@@ -58,9 +102,9 @@ def ensure_profile_memory_dirs(profile: str) -> None:
     from cli.core import ProfileManager
 
     cfg = ProfileManager().load_profile(profile)
-    ensure_sqlite_parent(cfg.memory_db_path)
-    ensure_sqlite_parent(cfg.ltm_db_path)
-    ensure_sqlite_parent(cfg.langgraph_checkpoint_db_path)
+    prepare_sqlite_db_file(cfg.memory_db_path)
+    prepare_sqlite_db_file(cfg.ltm_db_path)
+    prepare_sqlite_db_file(cfg.langgraph_checkpoint_db_path)
     Path(cfg.vector_db_path).expanduser().resolve().mkdir(parents=True, exist_ok=True)
 
 

--- a/tests/test_no_cwd_data_leak.py
+++ b/tests/test_no_cwd_data_leak.py
@@ -91,6 +91,35 @@ async def test_action_guard_audit_log_in_profile(tmp_path, monkeypatch) -> None:
     assert not (tmp_path / "repo" / "data").exists()
 
 
+def test_ltm_path_always_colocated_with_memory_db(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("cli.core.PROFILES_DIR", tmp_path / "profiles")
+    profile_dir = ProfileManager().get_profile_dir("default")
+    profile_dir.mkdir(parents=True)
+
+    cfg = ProfileConfig(
+        profile_name="default",
+        memory_db_path=str(profile_dir / "data" / "memory" / "memory.db"),
+        ltm_db_path="/tmp/other/ltm.db",
+    )
+    resolved = resolve_profile_storage_paths("default", cfg, profile_dir=profile_dir)
+    memory_dir = profile_dir / "data" / "memory"
+    assert Path(resolved.ltm_db_path) == (memory_dir / "ltm.db").resolve()
+    assert Path(resolved.langgraph_checkpoint_db_path) == (memory_dir / "checkpoints.db").resolve()
+
+
+def test_prepare_sqlite_recovers_when_db_path_is_directory(tmp_path) -> None:
+    from core.paths import prepare_sqlite_db_file
+
+    db_path = tmp_path / "ltm.db"
+    db_path.mkdir()
+    opened = prepare_sqlite_db_file(db_path)
+    assert opened == db_path.resolve()
+    assert db_path.is_file()
+    assert not db_path.is_dir()
+    backups = list(tmp_path.glob("ltm.db.holix-bak*"))
+    assert backups
+
+
 def test_stale_absolute_ltm_path_reset_to_profile(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr("cli.core.PROFILES_DIR", tmp_path / "profiles")
     profile_dir = ProfileManager().get_profile_dir("default")


### PR DESCRIPTION
## Problem
Gateway still failed at `ltm.db` with `unable to open database file` while `memory.db` could open — typically when `ltm_db_path` in config pointed elsewhere or `ltm.db` existed as a directory/read-only file.

## Fix
- Force `ltm.db` and `checkpoints.db` next to resolved `memory.db`
- `prepare_sqlite_db_file()`: mkdir, rename blocking dirs/files, probe sqlite open
- Clear RuntimeError includes full path when open fails

756 tests passed