### PR TITLE
feat(telegram): inline admin approval for bot access

### DIFF
--- a/api/services/telegram_ops.py
+++ b/api/services/telegram_ops.py
@@ -5,28 +5,20 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Any
 
-from cli.core import (
-    ProfileManager,
-    enable_profile_workspace_isolation,
-    validate_profile_name_for_env,
+from integrations.telegram.access_approval import (
+    approve_access_request as approve_access_request_core,
+    reject_access_request_op as reject_access_request_core,
 )
-from core.profile_keys import profile_has_access_key, store_profile_access_key
 from integrations.telegram.access_requests import (
-    STATUS_PENDING,
     TelegramAccessRequest,
-    get_access_request,
     list_pending_requests,
     register_access_request,
-    reject_access_request,
-    resolve_access_request,
 )
 from integrations.telegram.admin import (
     clear_admin_user,
     load_admin_holix_profile,
     load_admin_user_id,
-    set_admin_user,
 )
-from integrations.telegram.allowlist import add_allowed_user
 from integrations.telegram.env_store import (
     load_telegram_env_files,
     mask_token,
@@ -54,33 +46,6 @@ def _request_dict(req: TelegramAccessRequest) -> dict[str, Any]:
     data = asdict(req)
     data["display_name"] = req.display_name
     return data
-
-
-def _prepare_profile_for_user(
-    manager: ProfileManager,
-    target_profile: str,
-    *,
-    create_new: bool,
-) -> tuple[str | None, bool]:
-    target_profile = validate_profile_name_for_env(target_profile)
-    access_key: str | None = None
-    key_already_set = False
-
-    if create_new:
-        if manager.profile_exists(target_profile):
-            if profile_has_access_key(target_profile):
-                key_already_set = True
-            else:
-                access_key = store_profile_access_key(target_profile)
-                enable_profile_workspace_isolation(manager, target_profile)
-        else:
-            manager.create_profile(target_profile, with_access_key=True)
-            access_key = manager.pop_last_created_access_key()
-        return access_key, key_already_set
-
-    if not manager.profile_exists(target_profile):
-        raise TelegramOpError(f"Profile '{target_profile}' not found", status_code=404)
-    return None, profile_has_access_key(target_profile)
 
 
 def get_telegram_status(profile_id: str) -> dict[str, Any]:
@@ -173,88 +138,43 @@ async def approve_access_request(
 ) -> dict[str, Any]:
     if set_admin and (holix_profile or create_profile):
         raise TelegramOpError("--set-admin cannot be combined with profile or create_profile")
-
-    load_telegram_env_files(profile_id)
-    req = get_access_request(profile_id, user_id)
-    if req is None or req.status != STATUS_PENDING:
-        raise TelegramOpError(f"No pending request for user id {user_id}", status_code=404)
-
-    if set_admin:
-        existing_admin = load_admin_user_id(profile_id)
-        if existing_admin is not None and int(existing_admin) != int(user_id):
-            raise TelegramOpError(
-                f"Admin already assigned (user id {existing_admin})",
-                status_code=409,
-            )
-
-    target_profile: str | None = None
-    if set_admin:
-        target_profile = load_admin_holix_profile(profile_id)
-    elif create_profile:
-        target_profile = create_profile.strip()
-    elif holix_profile:
-        target_profile = holix_profile.strip()
-
-    if not target_profile:
+    if not set_admin and not holix_profile and not create_profile:
         raise TelegramOpError("profile or create_profile is required")
 
-    manager = ProfileManager()
-    if set_admin and not manager.profile_exists(target_profile):
-        manager.create_profile(target_profile, inherit_global=True)
-
-    access_key, key_already_set = _prepare_profile_for_user(
-        manager,
-        target_profile,
-        create_new=bool(create_profile) and not set_admin,
-    )
-
-    if set_admin:
-        set_admin_user(profile_id, user_id, holix_profile=target_profile)
-
-    add_allowed_user(profile_id, user_id)
-    set_user_profile(profile_id, user_id, target_profile)
-    resolve_access_request(
-        profile_id,
-        user_id,
-        status="approved",
-        holix_profile=target_profile,
-    )
-
-    notify_error: str | None = None
     try:
-        from integrations.telegram.notify import notify_access_approved_sync
-
-        notify_access_approved_sync(
+        result = approve_access_request_core(
             profile_id,
             user_id,
-            target_profile,
-            access_key=access_key,
-            key_already_set=key_already_set and not access_key,
+            holix_profile=holix_profile,
+            create_profile=create_profile,
+            set_admin=set_admin,
         )
-    except TelegramApiError as exc:
-        notify_error = str(exc)
-    except Exception as exc:
-        notify_error = str(exc)
+    except ValueError as exc:
+        msg = str(exc)
+        status = 409 if "Admin already" in msg else 404
+        raise TelegramOpError(msg, status_code=status) from exc
 
-    result: dict[str, Any] = {
+    payload: dict[str, Any] = {
         "user_id": user_id,
-        "holix_profile": target_profile,
+        "holix_profile": result.holix_profile,
         "set_admin": set_admin,
         "reload_required": True,
     }
-    if access_key:
-        result["access_key"] = access_key
-    if notify_error:
-        result["notify_error"] = notify_error
-    return result
+    if result.access_key:
+        payload["access_key"] = result.access_key
+    return payload
 
 
 def reject_access_request_op(profile_id: str, user_id: int) -> dict[str, Any]:
-    load_telegram_env_files(profile_id)
-    req = reject_access_request(profile_id, user_id)
-    if req is None:
-        raise TelegramOpError(f"No pending request for user id {user_id}", status_code=404)
-    return {"user_id": user_id, "status": "rejected", "display_name": req.display_name}
+    try:
+        result = reject_access_request_core(profile_id, user_id)
+    except ValueError as exc:
+        raise TelegramOpError(str(exc), status_code=404) from exc
+    return {
+        "user_id": user_id,
+        "status": "rejected",
+        "display_name": result.user_display,
+    }
 
 
 def get_telegram_admin(profile_id: str) -> dict[str, Any]:

--- a/cli/commands/telegram_requests.py
+++ b/cli/commands/telegram_requests.py
@@ -2,65 +2,18 @@
 
 from __future__ import annotations
 
-from integrations.telegram.access_requests import (
-    STATUS_PENDING,
-    get_access_request,
-    list_pending_requests,
-    reject_access_request,
-    resolve_access_request,
+from integrations.telegram.access_approval import (
+    approve_access_request,
+    reject_access_request_op,
 )
-from integrations.telegram.allowlist import add_allowed_user
+from integrations.telegram.access_requests import STATUS_PENDING, list_pending_requests
+from integrations.telegram.admin import load_admin_holix_profile, load_admin_user_id, set_admin_user
 from integrations.telegram.env_store import load_telegram_env_files
-from integrations.telegram.user_profiles import set_user_profile
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from cli.core import ProfileManager
 from cli.utils.rich_console import console, print_error, print_info, print_success, print_warning
-
-
-def _prepare_profile_for_user(
-    manager: ProfileManager,
-    target_profile: str,
-    *,
-    create_new: bool,
-    bot_profile: str,
-) -> tuple[str | None, bool]:
-    """Create or protect profile; return (access_key_plaintext, key_already_set)."""
-    from core.profile_keys import profile_has_access_key, store_profile_access_key
-
-    from cli.core import enable_profile_workspace_isolation, validate_profile_name_for_env
-
-    target_profile = validate_profile_name_for_env(target_profile)
-    access_key: str | None = None
-    key_already_set = False
-
-    if create_new:
-        if manager.profile_exists(target_profile):
-            print_warning(f"Профиль '{target_profile}' уже существует — используем его")
-            if profile_has_access_key(target_profile):
-                key_already_set = True
-            else:
-                access_key = store_profile_access_key(target_profile)
-                workspace = enable_profile_workspace_isolation(manager, target_profile)
-                print_info(f"Workspace jail: {workspace}")
-        else:
-            manager.create_profile(target_profile, with_access_key=True)
-            access_key = manager.pop_last_created_access_key()
-            workspace = manager.get_profile_dir(target_profile) / "workspace"
-            print_success(f"Создан защищённый профиль '{target_profile}'")
-            print_info(f"Изолированная директория: {workspace}")
-        return access_key, key_already_set
-
-    if not manager.profile_exists(target_profile):
-        print_error(f"Профиль '{target_profile}' не найден.")
-        print_info(f"Создать: holix profile create {target_profile}")
-        print_info(
-            f"Или: holix -p {bot_profile} telegram requests approve … --create-profile NAME"
-        )
-        raise SystemExit(1)
-
-    return None, profile_has_access_key(target_profile)
 
 
 def _profiles_list() -> list[str]:
@@ -93,18 +46,14 @@ def telegram_requests_list(bot_profile: str) -> None:
         )
     console.print(table)
     console.print()
-    print_info("Одобрить:")
+    print_info("В Telegram администратор получает кнопки «Одобрить» / «Отклонить».")
+    print_info("CLI (если нужно):")
     print_info(
         f"  holix -p {bot_profile} telegram requests approve USER_ID --profile PROFILE"
     )
     print_info(
         f"  holix -p {bot_profile} telegram requests approve USER_ID --create-profile NAME"
     )
-    print_info(
-        f"  holix -p {bot_profile} telegram requests approve USER_ID --set-admin"
-    )
-    print_info("  (--create-profile создаёт защищённый профиль и шлёт ключ в Telegram)")
-    print_info("  (--set-admin — первый администратор, профиль Holix admin; только CLI)")
 
 
 def telegram_requests_approve(
@@ -116,18 +65,7 @@ def telegram_requests_approve(
     interactive: bool = False,
     set_admin: bool = False,
 ) -> None:
-    from integrations.telegram.admin import (
-        load_admin_holix_profile,
-        load_admin_user_id,
-        set_admin_user,
-    )
-
     load_telegram_env_files(bot_profile)
-    req = get_access_request(bot_profile, user_id)
-    if req is None or req.status != STATUS_PENDING:
-        print_error(f"Нет ожидающего запроса для user id {user_id}.")
-        print_info(f"Список: holix -p {bot_profile} telegram requests list")
-        raise SystemExit(1)
 
     if set_admin:
         if profile or create_profile:
@@ -150,6 +88,12 @@ def telegram_requests_approve(
         target_profile = profile.strip()
 
     if target_profile is None and interactive:
+        from integrations.telegram.access_requests import get_access_request
+
+        req = get_access_request(bot_profile, user_id)
+        if req is None or req.status != STATUS_PENDING:
+            print_error(f"Нет ожидающего запроса для user id {user_id}.")
+            raise SystemExit(1)
         profiles = _profiles_list()
         console.print()
         console.print(
@@ -158,6 +102,7 @@ def telegram_requests_approve(
         )
         if Confirm.ask("Создать новый профиль Holix для этого пользователя?", default=False):
             target_profile = Prompt.ask("Имя нового профиля").strip()
+            create_profile = target_profile
         else:
             if len(profiles) == 1:
                 target_profile = profiles[0]
@@ -168,71 +113,41 @@ def telegram_requests_approve(
                     default=bot_profile,
                 ).strip()
 
-    if not target_profile:
-        print_error("Укажите --profile или --create-profile (или запустите без флагов для мастера).")
+    if not target_profile and not set_admin and not create_profile:
+        print_error("Укажите --profile или --create-profile (или запустите с -i).")
         raise SystemExit(1)
 
-    manager = ProfileManager()
-    if set_admin and not manager.profile_exists(target_profile):
-        manager.create_profile(target_profile, inherit_global=True)
-        print_success(f"Создан профиль администратора '{target_profile}'")
-
-    access_key, key_already_set = _prepare_profile_for_user(
-        manager,
-        target_profile,
-        create_new=bool(create_profile) and not set_admin,
-        bot_profile=bot_profile,
-    )
-
-    if set_admin:
-        set_admin_user(bot_profile, user_id, holix_profile=target_profile)
-
-    add_allowed_user(bot_profile, user_id)
-    set_user_profile(bot_profile, user_id, target_profile)
-    resolve_access_request(
-        bot_profile,
-        user_id,
-        status="approved",
-        holix_profile=target_profile,
-    )
+    if set_admin and not ProfileManager().profile_exists(load_admin_holix_profile(bot_profile)):
+        ProfileManager().create_profile(load_admin_holix_profile(bot_profile), inherit_global=True)
+        print_success(f"Создан профиль администратора '{load_admin_holix_profile(bot_profile)}'")
 
     try:
-        from integrations.telegram.notify import notify_access_approved_sync
-        from integrations.telegram.setup_api import TelegramApiError
-
-        notify_access_approved_sync(
+        result = approve_access_request(
             bot_profile,
             user_id,
-            target_profile,
-            access_key=access_key,
-            key_already_set=key_already_set and not access_key,
+            holix_profile=target_profile if not create_profile and not set_admin else None,
+            create_profile=create_profile,
+            set_admin=set_admin,
         )
-    except TelegramApiError as exc:
-        print_warning(f"Не удалось отправить сообщение в Telegram: {exc}")
-        if access_key:
-            print_info(f"Передайте ключ пользователю вручную: {access_key}")
-    except Exception as exc:
-        print_warning(f"Уведомление в Telegram не отправлено: {exc}")
-        if access_key:
-            print_info(f"Ключ профиля: {access_key}")
+    except ValueError as exc:
+        print_error(str(exc))
+        raise SystemExit(1) from exc
 
-    print_success(
-        f"Доступ одобрен: {req.display_name} (id={user_id}) → профиль '{target_profile}'"
-    )
+    print_success(result.message)
     if set_admin:
         print_success(
-            f"Назначен Telegram-администратор (user id={user_id}, профиль '{target_profile}')"
+            f"Назначен Telegram-администратор (user id={user_id}, "
+            f"профиль '{load_admin_holix_profile(bot_profile)}')"
         )
-        print_info("Новые запросы доступа будут приходить этому пользователю в Telegram.")
-    if access_key:
+    if result.access_key:
         print_info("Ключ профиля отправлен пользователю в Telegram.")
-    print_info("Пользователь может снова отправить /start или написать боту.")
 
 
 def telegram_requests_reject(bot_profile: str, user_id: int) -> None:
     load_telegram_env_files(bot_profile)
-    req = reject_access_request(bot_profile, user_id)
-    if req is None:
-        print_error(f"Нет ожидающего запроса для user id {user_id}.")
-        raise SystemExit(1)
-    print_success(f"Запрос отклонён: {req.display_name} (id={user_id})")
+    try:
+        result = reject_access_request_op(bot_profile, user_id)
+    except ValueError as exc:
+        print_error(str(exc))
+        raise SystemExit(1) from exc
+    print_success(result.message)

--- a/integrations/telegram/access_approval.py
+++ b/integrations/telegram/access_approval.py
@@ -1,0 +1,310 @@
+"""Approve or reject Telegram access requests (CLI, API, and bot callbacks)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from cli.core import ProfileManager, enable_profile_workspace_isolation, validate_profile_name_for_env
+from core.profile_keys import profile_has_access_key, store_profile_access_key
+from integrations.telegram.access_requests import (
+    STATUS_PENDING,
+    TelegramAccessRequest,
+    get_access_request,
+    reject_access_request,
+    resolve_access_request,
+)
+from integrations.telegram.admin import (
+    load_admin_holix_profile,
+    load_admin_user_id,
+    set_admin_user,
+)
+from integrations.telegram.allowlist import add_allowed_user
+from integrations.telegram.env_store import load_telegram_env_files
+from integrations.telegram.user_profiles import set_user_profile
+
+
+@dataclass(frozen=True, slots=True)
+class AccessApprovalResult:
+    ok: bool
+    message: str
+    holix_profile: str | None = None
+    access_key: str | None = None
+    user_display: str | None = None
+
+
+def is_telegram_admin(bot_profile: str, actor_user_id: int) -> bool:
+    admin_id = load_admin_user_id(bot_profile)
+    return admin_id is not None and int(admin_id) == int(actor_user_id)
+
+
+def suggest_holix_profile_name(req: TelegramAccessRequest) -> str:
+    """Derive a safe Holix profile name from Telegram user metadata."""
+    if req.username:
+        slug = re.sub(r"[^a-z0-9_-]", "", req.username.lower())
+        if len(slug) >= 2:
+            return slug[:32]
+    first = (req.first_name or "").strip().lower()
+    if first:
+        slug = re.sub(r"[^a-z0-9_-]", "", first.replace(" ", "-"))
+        if len(slug) >= 2:
+            return slug[:32]
+    return f"user_{req.user_id}"
+
+
+def _prepare_profile_for_user(
+    manager: ProfileManager,
+    target_profile: str,
+    *,
+    create_new: bool,
+) -> tuple[str | None, bool]:
+    target_profile = validate_profile_name_for_env(target_profile)
+    access_key: str | None = None
+    key_already_set = False
+
+    if create_new:
+        if manager.profile_exists(target_profile):
+            if profile_has_access_key(target_profile):
+                key_already_set = True
+            else:
+                access_key = store_profile_access_key(target_profile)
+                enable_profile_workspace_isolation(manager, target_profile)
+        else:
+            manager.create_profile(target_profile, with_access_key=True)
+            access_key = manager.pop_last_created_access_key()
+        return access_key, key_already_set
+
+    if not manager.profile_exists(target_profile):
+        raise ValueError(f"Profile '{target_profile}' not found")
+    return None, profile_has_access_key(target_profile)
+
+
+def approve_access_request(
+    bot_profile: str,
+    user_id: int,
+    *,
+    holix_profile: str | None = None,
+    create_profile: str | None = None,
+    set_admin: bool = False,
+) -> AccessApprovalResult:
+    """Grant Telegram user access and map to a Holix profile."""
+    if set_admin and (holix_profile or create_profile):
+        raise ValueError("set_admin cannot be combined with holix_profile or create_profile")
+
+    load_telegram_env_files(bot_profile)
+    req = get_access_request(bot_profile, user_id)
+    if req is None or req.status != STATUS_PENDING:
+        raise ValueError(f"No pending request for user id {user_id}")
+
+    if set_admin:
+        existing_admin = load_admin_user_id(bot_profile)
+        if existing_admin is not None and int(existing_admin) != int(user_id):
+            raise ValueError(f"Admin already assigned (user id {existing_admin})")
+
+    target_profile: str | None = None
+    if set_admin:
+        target_profile = load_admin_holix_profile(bot_profile)
+    elif create_profile:
+        target_profile = create_profile.strip()
+    elif holix_profile:
+        target_profile = holix_profile.strip()
+
+    manager = ProfileManager()
+    if not target_profile:
+        suggested = suggest_holix_profile_name(req)
+        if manager.profile_exists(suggested):
+            target_profile = suggested
+        else:
+            target_profile = suggested
+            create_profile = suggested
+    if set_admin and not manager.profile_exists(target_profile):
+        manager.create_profile(target_profile, inherit_global=True)
+
+    access_key, key_already_set = _prepare_profile_for_user(
+        manager,
+        target_profile,
+        create_new=bool(create_profile) and not set_admin,
+    )
+
+    if set_admin:
+        set_admin_user(bot_profile, user_id, holix_profile=target_profile)
+
+    add_allowed_user(bot_profile, user_id)
+    set_user_profile(bot_profile, user_id, target_profile)
+    resolve_access_request(
+        bot_profile,
+        user_id,
+        status="approved",
+        holix_profile=target_profile,
+    )
+
+    notify_error: str | None = None
+    try:
+        from integrations.telegram.notify import notify_access_approved_sync
+
+        notify_access_approved_sync(
+            bot_profile,
+            user_id,
+            target_profile,
+            access_key=access_key,
+            key_already_set=key_already_set and not access_key,
+        )
+    except Exception as exc:
+        notify_error = str(exc)
+
+    message = (
+        f"Доступ одобрен: {req.display_name} → профиль «{target_profile}»"
+    )
+    if access_key:
+        message += ". Ключ отправлен пользователю в Telegram."
+    if notify_error:
+        message += f" (уведомление: {notify_error})"
+
+    return AccessApprovalResult(
+        ok=True,
+        message=message,
+        holix_profile=target_profile,
+        access_key=access_key,
+        user_display=req.display_name,
+    )
+
+
+def reject_access_request_op(bot_profile: str, user_id: int) -> AccessApprovalResult:
+    load_telegram_env_files(bot_profile)
+    req = reject_access_request(bot_profile, user_id)
+    if req is None:
+        raise ValueError(f"No pending request for user id {user_id}")
+
+    notify_error: str | None = None
+    try:
+        from integrations.telegram.notify import notify_access_rejected_sync
+
+        notify_access_rejected_sync(bot_profile, user_id)
+    except Exception as exc:
+        notify_error = str(exc)
+
+    message = f"Запрос отклонён: {req.display_name}"
+    if notify_error:
+        message += f" ({notify_error})"
+    return AccessApprovalResult(
+        ok=True,
+        message=message,
+        user_display=req.display_name,
+    )
+
+
+def list_profiles_for_picker() -> list[str]:
+    try:
+        profiles = ProfileManager().list_profiles()
+        return profiles or ["default"]
+    except Exception:
+        return ["default"]
+
+
+async def handle_access_admin_callback(
+    bot_profile: str,
+    *,
+    actor_user_id: int,
+    action: str,
+    value: str,
+    message: Any | None = None,
+    bot: Any | None = None,
+) -> str:
+    """Process admin inline buttons for access requests."""
+    from integrations.telegram.keyboards import (
+        access_request_profile_keyboard,
+        format_access_resolved_admin_text,
+    )
+
+    if not is_telegram_admin(bot_profile, actor_user_id):
+        return "Только администратор бота может одобрять доступ."
+
+    if action == "ara":
+        user_id = int(value)
+        result = approve_access_request(bot_profile, user_id, create_profile=None)
+        if message is not None and bot is not None:
+            await message.edit_text(
+                format_access_resolved_admin_text(result, approved=True),
+                parse_mode="HTML",
+            )
+        return result.message
+
+    if action == "arr":
+        user_id = int(value)
+        result = reject_access_request_op(bot_profile, user_id)
+        if message is not None and bot is not None:
+            await message.edit_text(
+                format_access_resolved_admin_text(result, approved=False),
+                parse_mode="HTML",
+            )
+        return result.message
+
+    if action == "arb":
+        user_id = int(value)
+        req = get_access_request(bot_profile, user_id)
+        if req is None:
+            return "Запрос не найден."
+        if message is not None and bot is not None:
+            from integrations.telegram.keyboards import access_request_admin_keyboard
+            from integrations.telegram.notify import format_access_request_admin_message
+
+            await message.edit_text(
+                format_access_request_admin_message(req, bot_profile),
+                parse_mode="HTML",
+                reply_markup=access_request_admin_keyboard(user_id),
+            )
+        return "Запрос доступа"
+
+    if action == "arl":
+        user_id = int(value)
+        req = get_access_request(bot_profile, user_id)
+        if req is None or req.status != STATUS_PENDING:
+            return "Запрос уже обработан."
+        profiles = list_profiles_for_picker()
+        suggested = suggest_holix_profile_name(req)
+        if message is not None and bot is not None:
+            from integrations.telegram.notify import format_access_request_admin_message
+
+            await message.edit_text(
+                format_access_request_admin_message(req, bot_profile, pick_profile=True),
+                parse_mode="HTML",
+                reply_markup=access_request_profile_keyboard(
+                    user_id,
+                    profiles,
+                    suggested=suggested,
+                ),
+            )
+        return "Выберите профиль"
+
+    if action == "arp":
+        user_part, _, idx_part = value.partition(":")
+        user_id = int(user_part)
+        idx = int(idx_part)
+        req = get_access_request(bot_profile, user_id)
+        if req is None or req.status != STATUS_PENDING:
+            return "Запрос уже обработан."
+        profiles = list_profiles_for_picker()
+        suggested = suggest_holix_profile_name(req)
+        if idx == len(profiles):
+            result = approve_access_request(
+                bot_profile,
+                user_id,
+                create_profile=suggested,
+            )
+        elif 0 <= idx < len(profiles):
+            result = approve_access_request(
+                bot_profile,
+                user_id,
+                holix_profile=profiles[idx],
+            )
+        else:
+            return "Неверный профиль"
+        if message is not None and bot is not None:
+            await message.edit_text(
+                format_access_resolved_admin_text(result, approved=True),
+                parse_mode="HTML",
+            )
+        return result.message
+
+    return "Неизвестное действие"

--- a/integrations/telegram/access_requests.py
+++ b/integrations/telegram/access_requests.py
@@ -1,4 +1,4 @@
-"""Telegram access requests — users apply via /start, admins approve from CLI."""
+"""Telegram access requests — users apply via /start, admins approve in Telegram or CLI."""
 
 from __future__ import annotations
 

--- a/integrations/telegram/admin.py
+++ b/integrations/telegram/admin.py
@@ -1,4 +1,4 @@
-"""Telegram bot administrator — single user, CLI-only assignment."""
+"""Telegram bot administrator — single user; assigned via bootstrap or CLI."""
 
 from __future__ import annotations
 

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -550,9 +550,38 @@ class HolixTelegramBot:
             except Exception as exc:
                 await query.answer(f"Error: {exc}"[:200], show_alert=True)
 
+        @dp.callback_query(F.data.startswith("hx:ar"))
+        async def on_access_admin_cb(query: CallbackQuery) -> None:
+            if query.from_user is None or not query.data or query.message is None:
+                return
+            from integrations.telegram.access_approval import handle_access_admin_callback
+            from integrations.telegram.keyboards import parse_callback
+
+            parsed = parse_callback(query.data)
+            if not parsed:
+                await query.answer("Неверная кнопка.", show_alert=True)
+                return
+            action, value = parsed
+            try:
+                msg = await handle_access_admin_callback(
+                    self.settings.profile,
+                    actor_user_id=int(query.from_user.id),
+                    action=action,
+                    value=value,
+                    message=query.message,
+                    bot=bot,
+                )
+                await query.answer(msg[:200] if msg else "OK")
+            except ValueError as exc:
+                await query.answer(str(exc)[:200], show_alert=True)
+            except Exception as exc:
+                await query.answer(f"Ошибка: {exc}"[:200], show_alert=True)
+
         @dp.callback_query(F.data.startswith("hx:"))
         async def on_holix_ui_cb(query: CallbackQuery) -> None:
             if query.from_user is None or not query.data or query.message is None:
+                return
+            if query.data.startswith("hx:ar"):
                 return
             if not self._allowed(query.from_user.id):
                 await query.answer("Access denied.", show_alert=True)

--- a/integrations/telegram/keyboards.py
+++ b/integrations/telegram/keyboards.py
@@ -354,6 +354,89 @@ def status_menu_keyboard(locale: str | None = None) -> Any:
     )
 
 
+def access_request_admin_keyboard(user_id: int) -> Any:
+    from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+    uid = str(int(user_id))
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="✅ Одобрить",
+                    callback_data=_cb("ara", uid),
+                ),
+                InlineKeyboardButton(
+                    text="❌ Отклонить",
+                    callback_data=_cb("arr", uid),
+                ),
+            ],
+            [
+                InlineKeyboardButton(
+                    text="📁 Выбрать профиль",
+                    callback_data=_cb("arl", uid),
+                ),
+            ],
+        ]
+    )
+
+
+def access_request_profile_keyboard(
+    user_id: int,
+    profiles: list[str],
+    *,
+    suggested: str,
+) -> Any:
+    from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+    uid = str(int(user_id))
+    rows: list[list[Any]] = []
+    row: list[Any] = []
+    for i, name in enumerate(profiles[:10]):
+        short = name if len(name) <= 18 else name[:16] + "…"
+        row.append(
+            InlineKeyboardButton(
+                text=short,
+                callback_data=_cb("arp", f"{uid}:{i}"),
+            )
+        )
+        if len(row) == 2:
+            rows.append(row)
+            row = []
+    if row:
+        rows.append(row)
+    rows.append(
+        [
+            InlineKeyboardButton(
+                text=f"＋ Создать «{suggested[:14]}»",
+                callback_data=_cb("arp", f"{uid}:{len(profiles[:10])}"),
+            )
+        ]
+    )
+    rows.append(
+        [
+            InlineKeyboardButton(
+                text="← Назад",
+                callback_data=_cb("arb", uid),
+            )
+        ]
+    )
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def format_access_resolved_admin_text(result: Any, *, approved: bool) -> str:
+    from integrations.telegram.access_approval import AccessApprovalResult
+    from integrations.telegram.markdown import escape_html
+
+    if not isinstance(result, AccessApprovalResult):
+        return "Готово."
+    status = "одобрен" if approved else "отклонён"
+    name = escape_html(result.user_display or "пользователь")
+    lines = [f"✅ <b>Запрос {status}</b>", "", f"<b>Пользователь:</b> {name}"]
+    if approved and result.holix_profile:
+        lines.append(f"<b>Профиль Holix:</b> <code>{escape_html(result.holix_profile)}</code>")
+    return "\n".join(lines)
+
+
 def mode_picker_html(current: str) -> str:
     lines = ["<b>Режим выполнения</b>", f"Сейчас: <code>{current}</code>", ""]
     for mode, (title, hint) in MODE_LABELS.items():

--- a/integrations/telegram/notify.py
+++ b/integrations/telegram/notify.py
@@ -112,29 +112,36 @@ async def notify_access_approved(
 def format_access_request_admin_message(
     req: TelegramAccessRequest,
     bot_profile: str,
+    *,
+    pick_profile: bool = False,
 ) -> str:
-    profile_esc = escape_html(bot_profile)
+    from integrations.telegram.access_approval import suggest_holix_profile_name
+
     name_esc = escape_html(req.display_name)
     username_line = (
         f"\n<b>Username:</b> @{escape_html(req.username)}"
         if req.username
         else ""
     )
+    suggested = suggest_holix_profile_name(req)
+    if pick_profile:
+        header = "📁 <b>Выбор профиля Holix</b>"
+        footer = "Нажмите кнопку профиля или создайте новый."
+    else:
+        header = "🔔 <b>Новый запрос доступа</b>"
+        footer = (
+            "Одобрите или отклоните кнопками ниже.\n"
+            f"Быстрое одобрение создаст профиль <code>{escape_html(suggested)}</code> "
+            "(если его ещё нет)."
+        )
     return "\n".join(
         [
-            "🔔 <b>Новый запрос доступа</b>",
+            header,
             "",
             f"<b>Пользователь:</b> {name_esc}{username_line}",
             f"<b>Telegram ID:</b> <code>{req.user_id}</code>",
             "",
-            "Одобрить в CLI (выбор или создание профиля):",
-            f"<code>holix -p {profile_esc} telegram requests approve {req.user_id} -i</code>",
-            "",
-            "Или сразу создать профиль:",
-            f"<code>holix -p {profile_esc} telegram requests approve {req.user_id} --create-profile NAME</code>",
-            "",
-            "Отклонить:",
-            f"<code>holix -p {profile_esc} telegram requests reject {req.user_id}</code>",
+            footer,
         ]
     )
 
@@ -157,8 +164,50 @@ async def notify_admin_access_request(
     if not token:
         return
 
+    from integrations.telegram.keyboards import access_request_admin_keyboard
+
     text = format_access_request_admin_message(req, bot_profile)
-    await send_user_message(token, int(admin_id), text)
+    keyboard = access_request_admin_keyboard(req.user_id)
+    try:
+        from aiogram import Bot
+
+        bot = Bot(token=token)
+        try:
+            await bot.send_message(
+                int(admin_id),
+                text,
+                parse_mode="HTML",
+                reply_markup=keyboard,
+            )
+        finally:
+            await bot.session.close()
+    except ImportError:
+        await send_user_message(token, int(admin_id), text)
+
+
+async def notify_access_rejected(
+    bot_profile: str,
+    user_id: int,
+) -> None:
+    from integrations.telegram.config import load_telegram_settings
+    from integrations.telegram.env_store import load_telegram_env_files
+
+    load_telegram_env_files(bot_profile)
+    settings = load_telegram_settings(bot_profile)
+    token = settings.bot_token.strip()
+    if not token:
+        raise TelegramApiError("TELEGRAM_BOT_TOKEN is not configured")
+
+    text = (
+        "❌ <b>Доступ не одобрен</b>\n\n"
+        "Администратор отклонил запрос. "
+        "Если это ошибка — свяжитесь с администратором Holix."
+    )
+    await send_user_message(token, int(user_id), text)
+
+
+def notify_access_rejected_sync(bot_profile: str, user_id: int) -> None:
+    asyncio.run(notify_access_rejected(bot_profile, user_id))
 
 
 def notify_access_approved_sync(

--- a/tests/test_telegram_access_approval.py
+++ b/tests/test_telegram_access_approval.py
@@ -1,0 +1,119 @@
+"""Telegram inline approval for access requests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from integrations.telegram.access_approval import (
+    approve_access_request,
+    handle_access_admin_callback,
+    is_telegram_admin,
+    reject_access_request_op,
+    suggest_holix_profile_name,
+)
+from integrations.telegram.access_requests import register_access_request
+from integrations.telegram.admin import set_admin_user
+from integrations.telegram.allowlist import load_allowed_user_ids
+from integrations.telegram.user_profiles import resolve_user_profile
+
+
+@pytest.fixture
+def holix_home(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import cli.core as cli_core
+
+    root = tmp_path / "holix"
+    profiles = root / "profiles"
+    profiles.mkdir(parents=True)
+    monkeypatch.setenv("HOLIX_HOME", str(root))
+    monkeypatch.setattr(cli_core, "HOLIX_HOME", root)
+    monkeypatch.setattr(cli_core, "PROFILES_DIR", profiles)
+    return root
+
+
+def test_suggest_profile_from_username(holix_home) -> None:
+    req, _ = register_access_request("default", user_id=1, username="Alice_Test")
+    assert suggest_holix_profile_name(req) == "alice_test"
+
+
+@pytest.mark.asyncio
+async def test_admin_callback_approve(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    from integrations.telegram.env_store import save_telegram_env
+
+    save_telegram_env(
+        {
+            "TELEGRAM_BOT_TOKEN": "123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw",
+            "HOLIX_TELEGRAM_ACCESS_REQUESTS": "true",
+        },
+        profile="default",
+    )
+    set_admin_user("default", 900)
+    register_access_request("default", user_id=77, username="newbie")
+
+    monkeypatch.setattr(
+        "integrations.telegram.notify.notify_access_approved_sync",
+        lambda *args, **kwargs: None,
+    )
+
+    message = MagicMock()
+    message.edit_text = AsyncMock()
+    msg = await handle_access_admin_callback(
+        "default",
+        actor_user_id=900,
+        action="ara",
+        value="77",
+        message=message,
+        bot=MagicMock(),
+    )
+    assert "одобрен" in msg.lower()
+    assert load_allowed_user_ids("default") == {77}
+    assert resolve_user_profile("default", 77) == "newbie"
+    message.edit_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_approve(holix_home) -> None:
+    from integrations.telegram.env_store import save_telegram_env
+
+    save_telegram_env({"TELEGRAM_BOT_TOKEN": "1:abc"}, profile="default")
+    set_admin_user("default", 900)
+    register_access_request("default", user_id=77)
+
+    msg = await handle_access_admin_callback(
+        "default",
+        actor_user_id=42,
+        action="ara",
+        value="77",
+    )
+    assert "администратор" in msg.lower()
+    assert not is_telegram_admin("default", 42)
+
+
+def test_reject_notifies_user(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    from integrations.telegram.env_store import save_telegram_env
+
+    save_telegram_env({"TELEGRAM_BOT_TOKEN": "1:abc"}, profile="default")
+    register_access_request("default", user_id=55, username="x")
+    rejected_mock = MagicMock()
+    monkeypatch.setattr(
+        "integrations.telegram.notify.notify_access_rejected_sync",
+        rejected_mock,
+    )
+    result = reject_access_request_op("default", 55)
+    assert "отклонён" in result.message.lower()
+    rejected_mock.assert_called_once_with("default", 55)
+
+
+def test_approve_creates_profile(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    from integrations.telegram.env_store import save_telegram_env
+    from cli.core import ProfileManager
+
+    save_telegram_env({"TELEGRAM_BOT_TOKEN": "1:abc"}, profile="default")
+    register_access_request("default", user_id=88, username="carol")
+    monkeypatch.setattr(
+        "integrations.telegram.notify.notify_access_approved_sync",
+        lambda *args, **kwargs: None,
+    )
+    result = approve_access_request("default", 88)
+    assert result.holix_profile == "carol"
+    assert ProfileManager().profile_exists("carol")

--- a/tests/test_telegram_admin.py
+++ b/tests/test_telegram_admin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from integrations.telegram.access_requests import register_access_request
@@ -55,8 +55,7 @@ def test_format_access_request_admin_message(holix_home) -> None:
     )
     text = format_access_request_admin_message(req, "default")
     assert "55" in text
-    assert "approve 55" in text
-    assert "reject 55" in text
+    assert "Одобрите" in text or "кнопками" in text
     assert "Bob" in text
 
 
@@ -97,13 +96,25 @@ async def test_notify_admin_access_request_sends_to_admin(
     set_admin_user("default", 900)
     req, _ = register_access_request("default", user_id=77, username="newbie")
     send_mock = AsyncMock()
-    monkeypatch.setattr(
-        "integrations.telegram.notify.send_user_message",
-        send_mock,
-    )
+    bot_instance = MagicMock()
+    bot_instance.send_message = send_mock
+    bot_instance.session = MagicMock()
+    bot_instance.session.close = AsyncMock()
+
+    class _FakeBot:
+        def __init__(self, token: str) -> None:
+            pass
+
+        async def __aenter__(self):
+            return bot_instance
+
+        def __call__(self, token: str):
+            return bot_instance
+
+    monkeypatch.setattr("aiogram.Bot", lambda token: bot_instance)
     await notify_admin_access_request("default", req)
     send_mock.assert_awaited_once()
-    assert send_mock.await_args.args[1] == 900
+    assert send_mock.await_args.args[0] == 900
 
 
 def test_approve_set_admin_creates_admin_profile(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Admin gets inline buttons: ✅ Одобрить / ❌ Отклонить / 📁 Выбрать профиль
- Quick approve auto-creates Holix profile from @username (or `user_<id>`)
- User receives approval/rejection message in Telegram
- CLI/API reuse shared `access_approval` module

761 tests passed