### PR TITLE
fix: remove timeout on confirmation approvals

### DIFF
--- a/api/services/telegram_ops.py
+++ b/api/services/telegram_ops.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from integrations.telegram.access_approval import (
     approve_access_request as approve_access_request_core,
+)
+from integrations.telegram.access_approval import (
     reject_access_request_op as reject_access_request_core,
 )
 from integrations.telegram.access_requests import (

--- a/cli/commands/telegram_requests.py
+++ b/cli/commands/telegram_requests.py
@@ -7,13 +7,13 @@ from integrations.telegram.access_approval import (
     reject_access_request_op,
 )
 from integrations.telegram.access_requests import STATUS_PENDING, list_pending_requests
-from integrations.telegram.admin import load_admin_holix_profile, load_admin_user_id, set_admin_user
+from integrations.telegram.admin import load_admin_holix_profile, load_admin_user_id
 from integrations.telegram.env_store import load_telegram_env_files
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from cli.core import ProfileManager
-from cli.utils.rich_console import console, print_error, print_info, print_success, print_warning
+from cli.utils.rich_console import console, print_error, print_info, print_success
 
 
 def _profiles_list() -> list[str]:

--- a/cli/installer/__init__.py
+++ b/cli/installer/__init__.py
@@ -1,6 +1,8 @@
 """Cross-platform Holix installation helpers."""
 
+from cli.installer.bootstrap import BootstrapOptions, run_bootstrap_setup_sync
 from cli.installer.manifest import InstallManifest, load_manifest, save_manifest
+from cli.installer.pypi import PyPIInstallResult, install_from_pypi
 from cli.installer.system import (
     InstallOptions,
     InstallResult,
@@ -10,8 +12,6 @@ from cli.installer.system import (
     scripts_bin_dir,
     verify_holix_on_path,
 )
-from cli.installer.bootstrap import BootstrapOptions, run_bootstrap_setup_sync
-from cli.installer.pypi import PyPIInstallResult, install_from_pypi
 from cli.installer.update import UpdateOptions, UpdateResult, update_holix
 
 __all__ = [

--- a/cli/installer/bootstrap.py
+++ b/cli/installer/bootstrap.py
@@ -8,12 +8,6 @@ import re
 import sys
 from dataclasses import dataclass
 
-from rich.panel import Panel
-from rich.prompt import Confirm, Prompt
-
-from cli.core import ProfileManager, get_current_config, init_profile
-from cli.installer.bootstrap_i18n import bootstrap_preset_labels, bt
-from cli.utils.rich_console import console, print_error, print_info, print_success, print_warning
 from core.i18n.system_locale import apply_profile_locale, resolve_install_locale
 from core.models.catalog import get_provider_preset, resolve_preset_base_url
 from core.models.setup_helpers import (
@@ -24,6 +18,12 @@ from core.models.setup_helpers import (
     resolve_api_key_for_preset,
     resolve_preset_api_key_interactive,
 )
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+
+from cli.core import ProfileManager, get_current_config, init_profile
+from cli.installer.bootstrap_i18n import bootstrap_preset_labels, bt
+from cli.utils.rich_console import console, print_error, print_info, print_success, print_warning
 
 
 @dataclass(frozen=True, slots=True)
@@ -281,9 +281,8 @@ async def _configure_telegram(profile: str, lang: str) -> bool:
 
 
 def _configure_search(profile: str, lang: str) -> bool:
-    from rich.prompt import Confirm
-
     from core.search.setup_helpers import configure_search_interactive
+    from rich.prompt import Confirm
 
     console.print()
     if not Confirm.ask(bt("search_configure", lang), default=True):

--- a/cli/installer/pypi.py
+++ b/cli/installer/pypi.py
@@ -10,7 +10,6 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-
 MIN_PYTHON = (3, 12)
 
 

--- a/cli/shared/commands/agent_commands.py
+++ b/cli/shared/commands/agent_commands.py
@@ -251,8 +251,9 @@ class AgentCommands:
             await h._sync_telegram_menu()
 
     async def _profile(self, command: str) -> None:
-        from cli.core import ProfileManager
         from core.profile_keys import profile_has_access_key
+
+        from cli.core import ProfileManager
 
         h = self.host
         lang = host_locale(h)

--- a/config.py
+++ b/config.py
@@ -49,7 +49,7 @@ class Settings(BaseSettings):
     # Confirmation / Safety Configuration
     auto_allow_threshold: str = "low"
     non_interactive: bool = False
-    confirmation_timeout: int = 300
+    confirmation_timeout: int = 0  # 0 = wait indefinitely for user approval
 
     # Plan Review Configuration
     plan_review_enabled: bool = True

--- a/core/memory/conversation.py
+++ b/core/memory/conversation.py
@@ -13,8 +13,8 @@ import chromadb
 from chromadb.config import Settings as ChromaSettings
 
 from core.di.runtime_config import HolixRuntimeConfig
-from core.paths import prepare_sqlite_db_file
 from core.memory.chroma_embeddings import get_or_create_collection
+from core.paths import prepare_sqlite_db_file
 
 logger = logging.getLogger(__name__)
 

--- a/core/memory/ltm.py
+++ b/core/memory/ltm.py
@@ -3,18 +3,17 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any
 
 import aiosqlite
 
 from core.di.runtime_config import HolixRuntimeConfig
-from core.paths import prepare_sqlite_db_file
 from core.memory.episodic import EpisodicMemoryStore
 from core.memory.procedural import ProceduralMemoryStore
 from core.memory.semantic import SemanticMemoryStore
 from core.memory.strategic import StrategicMemoryStore
 from core.memory.vector import VectorMemoryStore
+from core.paths import prepare_sqlite_db_file
 
 logger = logging.getLogger(__name__)
 

--- a/core/search/setup_helpers.py
+++ b/core/search/setup_helpers.py
@@ -154,13 +154,12 @@ def configure_search_interactive(
     test_query: str = "open source ai agents",
 ) -> bool:
     """Interactive provider picker; saves config to the profile."""
+    from cli.installer.bootstrap_i18n import bt
+    from cli.utils.rich_console import print_error, print_info, print_success, print_warning
     from rich.console import Console
     from rich.panel import Panel
     from rich.prompt import Confirm, Prompt
     from rich.table import Table
-
-    from cli.installer.bootstrap_i18n import bt
-    from cli.utils.rich_console import print_error, print_info, print_success, print_warning
 
     console = Console()
     current = SearchConfig.from_dict(load_profile_search(profile))

--- a/core/security/auth.py
+++ b/core/security/auth.py
@@ -2,7 +2,6 @@ import hashlib
 import hmac
 import secrets
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Any
 
 import aiosqlite

--- a/core/security/confirmation.py
+++ b/core/security/confirmation.py
@@ -398,6 +398,16 @@ class ConfirmationChoice(StrEnum):
     DENY = "deny"                    # Block this tool call
 
 
+def normalize_confirmation_timeout(value: int | float | None, *, default: int = 0) -> int:
+    """Seconds to wait for user approval. 0 or negative = no timeout."""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 # ─── Action Guard ──────────────────────────────────────────────────────────
 
 class ActionGuard:
@@ -419,7 +429,7 @@ class ActionGuard:
         risk_classifier: RiskClassifier | None = None,
         auto_allow_threshold: RiskLevel = RiskLevel.LOW,
         interactive: bool = True,
-        confirmation_timeout: int = 300,
+        confirmation_timeout: int = 0,
         data_dir: str | Path | None = None,
     ):
         self._event_bus = event_bus
@@ -655,7 +665,7 @@ def init_action_guard(
     event_bus: Any,
     auto_allow_threshold: RiskLevel = RiskLevel.LOW,
     interactive: bool = True,
-    confirmation_timeout: int = 300,
+    confirmation_timeout: int = 0,
     data_dir: str | Path | None = None,
 ) -> ActionGuard:
     """Initialize the global ActionGuard instance.

--- a/core/subagents/interaction.py
+++ b/core/subagents/interaction.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class SubAgentInteractionBridge:
     """Routes sub-agent IPC prompts to the parent event bus and awaits replies."""
 
-    def __init__(self, parent_agent: Any, *, confirmation_timeout: int = 300):
+    def __init__(self, parent_agent: Any, *, confirmation_timeout: int = 0):
         self._parent = parent_agent
         self._confirmation_timeout = confirmation_timeout
         self._pending_confirmations: dict[str, asyncio.Future] = {}

--- a/core/subagents/manager.py
+++ b/core/subagents/manager.py
@@ -43,7 +43,9 @@ class SubAgentManager:
         self._parent = parent_agent
         self._comm_bus = AgentCommunicationBus()
         cfg = getattr(parent_agent, "config", None)
-        timeout = int(getattr(cfg, "confirmation_timeout", 300) or 300)
+        from core.security.confirmation import normalize_confirmation_timeout
+
+        timeout = normalize_confirmation_timeout(getattr(cfg, "confirmation_timeout", None))
         self.interactions = SubAgentInteractionBridge(
             parent_agent,
             confirmation_timeout=timeout,

--- a/core/subagents/process.py
+++ b/core/subagents/process.py
@@ -103,7 +103,7 @@ def run_sub_agent_in_process(
     skills_dir: str = "",
     skill_assignments: dict[str, list[str]] | None = None,
     auto_allow_threshold: str = "low",
-    confirmation_timeout: float = 300.0,
+    confirmation_timeout: float = 0.0,
     interactive: bool = True,
     search_config: dict[str, Any] | None = None,
 ) -> None:
@@ -713,8 +713,10 @@ class SubAgentProcessManager:
         auto_allow_threshold = str(
             getattr(parent_cfg, "auto_allow_threshold", "low") or "low"
         )
+        from core.security.confirmation import normalize_confirmation_timeout
+
         confirmation_timeout = float(
-            getattr(parent_cfg, "confirmation_timeout", 300) or 300
+            normalize_confirmation_timeout(getattr(parent_cfg, "confirmation_timeout", None))
         )
         interactive = not bool(getattr(parent_cfg, "non_interactive", False))
         search_config = dict(getattr(parent_cfg, "search", None) or {})

--- a/integrations/telegram/access_approval.py
+++ b/integrations/telegram/access_approval.py
@@ -6,8 +6,13 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from cli.core import ProfileManager, enable_profile_workspace_isolation, validate_profile_name_for_env
+from cli.core import (
+    ProfileManager,
+    enable_profile_workspace_isolation,
+    validate_profile_name_for_env,
+)
 from core.profile_keys import profile_has_access_key, store_profile_access_key
+
 from integrations.telegram.access_requests import (
     STATUS_PENDING,
     TelegramAccessRequest,

--- a/integrations/telegram/agent_setup.py
+++ b/integrations/telegram/agent_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from cli.core import ProfileConfig, init_profile
 from core.agent import HolixAgent
+
 from integrations.telegram.profile_auth import authorize_telegram_profile_access
 
 
@@ -19,6 +20,7 @@ async def create_agent(
         authorize_telegram_profile_access(bot_profile, telegram_user_id, profile)
         if config is None:
             from cli.core import ProfileManager
+
             from integrations.telegram.profile_seed import seed_telegram_user_profile_from_bot
 
             seed_telegram_user_profile_from_bot(

--- a/integrations/telegram/file_handler.py
+++ b/integrations/telegram/file_handler.py
@@ -219,6 +219,7 @@ def profile_files_dir(
     telegram_user_id: int | None = None,
 ) -> Path:
     from cli.core import ProfileManager, resolve_profile_storage_paths
+
     from integrations.telegram.profile_auth import init_profile_for_telegram
 
     mgr = ProfileManager()

--- a/tests/test_confirmation.py
+++ b/tests/test_confirmation.py
@@ -479,6 +479,39 @@ class TestActionGuard:
         result = guard.resolve_confirmation("nonexistent_id", ConfirmationChoice.ALLOW_ONCE)
         assert result is False
 
+    @pytest.mark.asyncio
+    async def test_default_confirmation_has_no_timeout(self):
+        """Default confirmation_timeout=0 waits until the user responds."""
+        guard = ActionGuard(
+            event_bus=None,
+            permission_manager=self.pm,
+            risk_classifier=self.classifier,
+            auto_allow_threshold=RiskLevel.NO,
+            interactive=True,
+        )
+        assert guard._confirmation_timeout == 0
+
+        async def fake_execute(**kwargs):
+            return "late approval ok"
+
+        class FakeTool:
+            risk_level = "high"
+
+        task = asyncio.create_task(
+            guard.check_and_execute(
+                tool_name="run_terminal_command",
+                tool_instance=FakeTool(),
+                arguments={"command": "ls"},
+                execute_fn=fake_execute,
+            )
+        )
+        await asyncio.sleep(0.1)
+        confirmation_id = list(guard._pending_confirmations.keys())[0]
+        guard.resolve_confirmation(confirmation_id, ConfirmationChoice.ALLOW_ONCE)
+        result = await asyncio.wait_for(task, timeout=2.0)
+        assert result == "late approval ok"
+
+
 class TestPlanExecutionAutoApprove:
     """Tests for auto-approve flag during plan execution."""
 

--- a/tests/test_no_cwd_data_leak.py
+++ b/tests/test_no_cwd_data_leak.py
@@ -125,10 +125,17 @@ def test_stale_absolute_ltm_path_reset_to_profile(tmp_path, monkeypatch) -> None
     profile_dir = ProfileManager().get_profile_dir("default")
     profile_dir.mkdir(parents=True)
 
+    # Absolute paths pointing at directories must fall back to profile defaults
+    # (portable across OSes; /root/... is writable on some Windows CI runners).
+    stale_dir = tmp_path / "stale_abs"
+    stale_dir.mkdir(parents=True)
+    stale_memory_dir = stale_dir / "memory"
+    stale_memory_dir.mkdir()
+
     cfg = ProfileConfig(
         profile_name="default",
-        ltm_db_path="/root/.holix-stale/ltm.db",
-        memory_db_path="/root/.holix-stale/memory.db",
+        ltm_db_path=str(stale_dir.resolve()),
+        memory_db_path=str(stale_memory_dir.resolve()),
     )
     resolved = resolve_profile_storage_paths("default", cfg, profile_dir=profile_dir)
     expected = (profile_dir / "data" / "memory" / "ltm.db").resolve()
@@ -162,7 +169,12 @@ async def test_api_key_manager_opens_resolved_db(tmp_path, monkeypatch) -> None:
 
     from config import settings
 
-    updated = settings.model_copy(update={"api_key_pepper": "test-pepper"})
+    updated = settings.model_copy(
+        update={
+            "api_key_pepper": "test-pepper",
+            "api_keys_db_path": "security/api_keys.db",
+        }
+    )
     monkeypatch.setattr("config.settings", updated)
     monkeypatch.setattr("core.security.auth.settings", updated)
 

--- a/tests/test_no_cwd_data_leak.py
+++ b/tests/test_no_cwd_data_leak.py
@@ -158,8 +158,9 @@ async def test_api_key_manager_opens_resolved_db(tmp_path, monkeypatch) -> None:
     repo.mkdir(parents=True)
     monkeypatch.chdir(repo)
 
-    from config import settings
     from core.security.auth import APIKeyManager
+
+    from config import settings
 
     updated = settings.model_copy(update={"api_key_pepper": "test-pepper"})
     monkeypatch.setattr("config.settings", updated)

--- a/tests/test_system_locale.py
+++ b/tests/test_system_locale.py
@@ -23,6 +23,9 @@ def test_detect_system_locale_en_default(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_resolve_install_locale_russian_system(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANG", "ru_RU.UTF-8")
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LC_MESSAGES", raising=False)
+    monkeypatch.delenv("LANGUAGE", raising=False)
     assert resolve_install_locale(interactive=False) == "ru"
 
 

--- a/tests/test_telegram_access_approval.py
+++ b/tests/test_telegram_access_approval.py
@@ -105,8 +105,8 @@ def test_reject_notifies_user(holix_home, monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_approve_creates_profile(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
-    from integrations.telegram.env_store import save_telegram_env
     from cli.core import ProfileManager
+    from integrations.telegram.env_store import save_telegram_env
 
     save_telegram_env({"TELEGRAM_BOT_TOKEN": "1:abc"}, profile="default")
     register_access_request("default", user_id=88, username="carol")

--- a/tests/test_telegram_profile_auth.py
+++ b/tests/test_telegram_profile_auth.py
@@ -48,7 +48,6 @@ def test_telegram_user_may_access_mapped_profile(holix_home) -> None:
 
 def test_authorize_unlocks_mapped_profile_without_key(holix_home) -> None:
     import cli.core as cli_core
-
     from integrations.telegram.user_profiles import set_user_profile
 
     manager = ProfileManager()


### PR DESCRIPTION
## Summary

- Default `confirmation_timeout` is now `0` (wait indefinitely) so users can approve dangerous actions via TUI or Telegram at any time — including the next day.
- Added `normalize_confirmation_timeout()` to avoid `getattr(...) or 300` treating `0` as falsy and restoring a 300s timeout.
- Sub-agent confirmation bridge uses the same semantics.

## Test plan

- [x] `pytest tests/test_confirmation.py tests/test_subagent_interaction.py` — 44 passed locally
- [ ] CI matrix (Ubuntu/Windows/macOS, Python 3.12–3.14)

Profiles can still set a finite timeout in `config.yaml`:

```yaml
confirmation_timeout: 300
```