### PR TITLE
fix(subagents): return results reliably after spawn

### DIFF
--- a/core/graph/nodes/collect_subagent_node.py
+++ b/core/graph/nodes/collect_subagent_node.py
@@ -57,4 +57,25 @@ async def collect_subagent_node(
         }
     except Exception as exc:
         logger.warning("collect_subagent failed for %s: %s", pending, exc)
-        return {"pending_subagent": None}
+        messages = list(state.get("messages", []))
+        messages.append(
+            {
+                "role": "user",
+                "content": (
+                    f"[Sub-agent '{pending}' failed]\n"
+                    f"success=false\n\n{exc}"
+                ),
+            }
+        )
+        results = dict(state.get("sub_agent_results", {}))
+        results[pending] = {
+            "response": "",
+            "success": False,
+            "error": str(exc),
+        }
+        return {
+            "pending_subagent": None,
+            "sub_agent_results": results,
+            "messages": messages,
+            "is_step_complete": True,
+        }

--- a/core/subagents/manager.py
+++ b/core/subagents/manager.py
@@ -53,6 +53,7 @@ class SubAgentManager:
         self._async_runner = AsyncSubAgentRunner(parent_agent, self._comm_bus.async_bus)
         self._process_manager = SubAgentProcessManager(parent_agent, self._comm_bus.process_bus)
         self._handles: dict[str, SubAgentHandle] = {}
+        self._pending_done: set[str] = set()
 
     def _max_concurrent(self) -> int:
         cfg = getattr(self._parent, "config", None)
@@ -141,9 +142,16 @@ class SubAgentManager:
 
         handle.task_preview = (task or "")[:240]
         handle.agent_type = agent_type or config.name
-        self._ensure_done_event(handle)
-        self._handles[config.name] = handle
+        self._register_handle(config.name, handle)
         return handle
+
+    def _register_handle(self, name: str, handle: SubAgentHandle) -> None:
+        """Track a handle and reconcile completion notifications."""
+        self._ensure_done_event(handle)
+        self._handles[name] = handle
+        if name in self._pending_done or handle.is_done:
+            self._pending_done.discard(name)
+            self._mark_done(handle)
 
     async def spawn_typed(
         self,
@@ -339,7 +347,12 @@ class SubAgentManager:
             except asyncio.CancelledError:
                 pass
             return
-        await event.wait()
+        while not handle.is_done:
+            try:
+                await asyncio.wait_for(event.wait(), timeout=0.25)
+            except TimeoutError:
+                if handle.is_done:
+                    break
 
     def format_status_text(self, *, html: bool = False) -> str:
         """Human-readable list of sub-agents for UI / slash commands."""
@@ -404,3 +417,5 @@ class SubAgentManager:
         handle = self._handles.get(name)
         if handle:
             self._mark_done(handle)
+        else:
+            self._pending_done.add(name)

--- a/core/subagents/process.py
+++ b/core/subagents/process.py
@@ -20,6 +20,7 @@ import json
 import logging
 import multiprocessing
 import os
+import queue
 import threading
 import time
 import uuid
@@ -614,8 +615,8 @@ def _send_result(
     )
     try:
         output_queue.put(msg.serialize(), timeout=5)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.error("Sub-agent '%s' failed to send result: %s", agent_name, exc)
 
 
 def _build_process_system_prompt(
@@ -790,11 +791,30 @@ class SubAgentProcessManager:
         """
         while not handle.is_done:
             try:
-                # Non-blocking check with timeout
-                data = output_queue.get(timeout=1.0)
-                msg = AgentMessage.deserialize(data)
+                data = await asyncio.to_thread(output_queue.get, True, 1.0)
+            except queue.Empty:
+                if handle.task and not handle.task.is_alive():
+                    handle.result = SubAgentResult(
+                        name=agent_name,
+                        success=False,
+                        error="Sub-agent process terminated unexpectedly",
+                        duration_ms=(time.monotonic() - (handle.started_at or time.monotonic())) * 1000,
+                    )
+                    handle.status = SubAgentStatus.FAILED
+                    self._notify_parent_done(agent_name)
+                    return
+                continue
+            except Exception as exc:
+                logger.warning("Sub-agent '%s' IPC read failed: %s", agent_name, exc)
+                continue
 
-                if msg.msg_type == "result":
+            try:
+                msg = AgentMessage.deserialize(data)
+            except Exception as exc:
+                logger.warning("Sub-agent '%s' IPC deserialize failed: %s", agent_name, exc)
+                continue
+
+            if msg.msg_type == "result":
                     # Final result received
                     meta = msg.metadata
                     handle.result = SubAgentResult(
@@ -810,39 +830,25 @@ class SubAgentProcessManager:
                     self._notify_parent_done(agent_name)
                     return
 
-                elif msg.msg_type == "heartbeat":
-                    pass
+            elif msg.msg_type == "heartbeat":
+                pass
 
-                elif msg.msg_type == "confirmation_request":
-                    await self._handle_ipc_confirmation(agent_name, msg)
+            elif msg.msg_type == "confirmation_request":
+                await self._handle_ipc_confirmation(agent_name, msg)
 
-                elif msg.msg_type == "question":
-                    await self._handle_ipc_question(agent_name, msg)
+            elif msg.msg_type == "question":
+                await self._handle_ipc_question(agent_name, msg)
 
-                elif msg.msg_type == "error":
-                    handle.result = SubAgentResult(
-                        name=agent_name,
-                        success=False,
-                        error=msg.content,
-                        duration_ms=(time.monotonic() - (handle.started_at or time.monotonic())) * 1000,
-                    )
-                    handle.status = SubAgentStatus.FAILED
-                    self._notify_parent_done(agent_name)
-                    return
-
-            except Exception:
-                # Queue.get timeout — check if process is still alive
-                if handle.task and not handle.task.is_alive():
-                    # Process died without sending result
-                    handle.result = SubAgentResult(
-                        name=agent_name,
-                        success=False,
-                        error="Sub-agent process terminated unexpectedly",
-                        duration_ms=(time.monotonic() - (handle.started_at or time.monotonic())) * 1000,
-                    )
-                    handle.status = SubAgentStatus.FAILED
-                    self._notify_parent_done(agent_name)
-                    return
+            elif msg.msg_type == "error":
+                handle.result = SubAgentResult(
+                    name=agent_name,
+                    success=False,
+                    error=msg.content,
+                    duration_ms=(time.monotonic() - (handle.started_at or time.monotonic())) * 1000,
+                )
+                handle.status = SubAgentStatus.FAILED
+                self._notify_parent_done(agent_name)
+                return
 
     async def _handle_ipc_confirmation(self, agent_name: str, msg: AgentMessage) -> None:
         bridge = getattr(getattr(self._parent, "subagents", None), "interactions", None)
@@ -924,6 +930,13 @@ class SubAgentProcessManager:
             process.join(timeout=1)
 
         handle.status = SubAgentStatus.CANCELLED
+        handle.result = SubAgentResult(
+            name=name,
+            success=False,
+            error="Cancelled by parent",
+            duration_ms=(time.monotonic() - (handle.started_at or time.monotonic())) * 1000,
+        )
+        self._notify_parent_done(name)
         return True
 
     async def terminate_all(self) -> None:

--- a/tests/test_subagent_wait.py
+++ b/tests/test_subagent_wait.py
@@ -1,0 +1,117 @@
+"""Sub-agent spawn/wait result collection."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from core.subagents.base import (
+    ProcessMode,
+    SubAgentConfig,
+    SubAgentHandle,
+    SubAgentResult,
+    SubAgentStatus,
+)
+from core.subagents.manager import SubAgentManager
+
+
+def _manager() -> SubAgentManager:
+    parent = MagicMock()
+    parent.config = MagicMock(
+        enable_subagents=True,
+        subagent_max_concurrent=4,
+        confirmation_timeout=0,
+    )
+    return SubAgentManager(parent)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_returns_after_early_notify() -> None:
+    """Completion notified before handle registration must not hang wait_for."""
+    mgr = _manager()
+    cfg = SubAgentConfig(name="researcher", process_mode=ProcessMode.PROCESS)
+    handle = SubAgentHandle(
+        name="researcher",
+        config=cfg,
+        status=SubAgentStatus.RUNNING,
+    )
+    handle.result = SubAgentResult(
+        name="researcher",
+        success=True,
+        response="done",
+        duration_ms=10.0,
+    )
+    handle.status = SubAgentStatus.COMPLETED
+
+    mgr.notify_handle_finished("researcher")
+    mgr._register_handle("researcher", handle)
+
+    result = await asyncio.wait_for(mgr.wait_for("researcher", timeout=2.0), timeout=2.0)
+    assert result.success is True
+    assert result.response == "done"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_process_mode_without_event() -> None:
+    """Process-mode wait must observe status even if done_event was never set."""
+    mgr = _manager()
+    cfg = SubAgentConfig(name="coder", process_mode=ProcessMode.PROCESS)
+    handle = SubAgentHandle(
+        name="coder",
+        config=cfg,
+        status=SubAgentStatus.RUNNING,
+    )
+    mgr._register_handle("coder", handle)
+
+    async def finish_later() -> None:
+        await asyncio.sleep(0.05)
+        handle.result = SubAgentResult(
+            name="coder",
+            success=True,
+            response="async finish",
+            duration_ms=50.0,
+        )
+        handle.status = SubAgentStatus.COMPLETED
+
+    asyncio.create_task(finish_later())
+    result = await asyncio.wait_for(mgr.wait_for("coder", timeout=2.0), timeout=2.0)
+    assert result.response == "async finish"
+
+
+@pytest.mark.asyncio
+async def test_async_spawn_wait_returns_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    mgr = _manager()
+    cfg = SubAgentConfig(name="writer", process_mode=ProcessMode.ASYNC)
+
+    async def fake_run(config: SubAgentConfig, task: str) -> SubAgentHandle:
+        handle = SubAgentHandle(
+            name=config.name,
+            config=config,
+            status=SubAgentStatus.RUNNING,
+        )
+
+        async def runner() -> None:
+            await asyncio.sleep(0.01)
+            handle.result = SubAgentResult(
+                name=config.name,
+                success=True,
+                response=f"ok:{task}",
+                duration_ms=10.0,
+            )
+            handle.status = SubAgentStatus.COMPLETED
+            mgr.notify_handle_finished(config.name)
+
+        handle.task = asyncio.create_task(runner())
+        return handle
+
+    async def _noop_register_async(*_a, **_k) -> None:
+        return None
+
+    monkeypatch.setattr(mgr._async_runner, "run", fake_run)
+    monkeypatch.setattr(mgr._comm_bus, "register_async", _noop_register_async)
+
+    handle = await mgr.spawn_sub_agent(cfg, "summarize")
+    result = await mgr.wait_for(handle.name, timeout=2.0)
+    assert result.success is True
+    assert result.response == "ok:summarize"


### PR DESCRIPTION
## Problem
Sub-agents started but results often never reached the parent (hang in `wait_for`, silent drops in plan graph).

## Root causes
1. `notify_handle_finished()` could fire before handle was registered → `done_event` never set
2. `_wait_for_handle()` for process mode only awaited `done_event`, ignoring status updates
3. `_collect_result()` used blocking `queue.get()` inside async task (starved event loop)
4. `collect_subagent_node` swallowed errors without injecting them into messages

## Fixes
- Pending-done buffer + status polling in `wait_for`
- Non-blocking IPC via `asyncio.to_thread`
- Error surfacing in collect node; cancel() now sets result + notifies parent

## Tests
- `tests/test_subagent_wait.py` (3 new cases)
- All `tests/test_subagent_*.py` pass (16)