### PR TITLE
feat(subagents): multi-agent orchestration in plan_and_execute

### DIFF
--- a/core/agent_events.py
+++ b/core/agent_events.py
@@ -60,6 +60,10 @@ class EventType(StrEnum):
     PLAN_STEP_COMPLETED = "plan_step_completed"
     PLAN_COMPLETED = "plan_completed"
 
+    # Sub-agent orchestration
+    SUBAGENT_WAVE_STARTED = "subagent_wave_started"
+    SUBAGENT_WAVE_COMPLETED = "subagent_wave_completed"
+
 
 @dataclass
 class EventContext:
@@ -356,6 +360,46 @@ class PlanCompletedEvent(AgentEvent):
 
     def _extra_fields(self) -> dict[str, Any]:
         return {"total_steps": self.total_steps}
+
+
+@dataclass
+class SubAgentWaveStartedEvent(AgentEvent):
+    """Emitted when a sub-agent orchestration wave begins."""
+    wave_id: int = 0
+    total_waves: int = 0
+    job_ids: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.SUBAGENT_WAVE_STARTED)
+
+    def _extra_fields(self) -> dict[str, Any]:
+        return {
+            "wave_id": self.wave_id,
+            "total_waves": self.total_waves,
+            "job_ids": self.job_ids,
+        }
+
+
+@dataclass
+class SubAgentWaveCompletedEvent(AgentEvent):
+    """Emitted when a sub-agent orchestration wave is collected."""
+    wave_id: int = 0
+    total_waves: int = 0
+    completed: int = 0
+    total: int = 0
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.SUBAGENT_WAVE_COMPLETED)
+
+    def _extra_fields(self) -> dict[str, Any]:
+        return {
+            "wave_id": self.wave_id,
+            "total_waves": self.total_waves,
+            "completed": self.completed,
+            "total": self.total,
+        }
 
 
 # ---------------------------------------------------------------------

--- a/core/graph/modes/plan_execute.py
+++ b/core/graph/modes/plan_execute.py
@@ -51,7 +51,11 @@ def build_plan_and_execute_graph(
     graph.add_conditional_edges(
         "step_orchestrate",
         route_after_step_orchestrate,
-        {"react": "delegate_subagent", "finalize": "finalize"},
+        {
+            "react": "react",
+            "delegate_subagent": "delegate_subagent",
+            "finalize": "finalize",
+        },
     )
     graph.add_edge("delegate_subagent", "collect_subagent")
     graph.add_edge("collect_subagent", "react")

--- a/core/graph/nodes/collect_subagent_node.py
+++ b/core/graph/nodes/collect_subagent_node.py
@@ -1,81 +1,152 @@
-"""Wait for a pending sub-agent and inject its result into the conversation."""
+"""Wait for pending sub-agents and inject aggregated results for react synthesis."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 from langchain_core.runnables import RunnableConfig
 
 from core.graph.state import HolixGraphState, get_agent_from_config
+from core.logging.events import log_subagent_event
+from core.subagents.orchestrator import (
+    OrchestrationPlan,
+    SubagentTask,
+    format_wave_aggregate,
+)
 
 logger = logging.getLogger(__name__)
+
+
+async def _wait_job(manager, job_id: str, timeout: float) -> dict[str, Any]:
+    try:
+        result = await manager.wait_for(job_id, timeout=timeout)
+        return {
+            "success": result.success if result else False,
+            "response": result.response if result else "",
+            "error": result.error if result else None,
+        }
+    except Exception as exc:
+        return {"success": False, "response": "", "error": str(exc)}
 
 
 async def collect_subagent_node(
     state: HolixGraphState,
     config: RunnableConfig,
 ) -> dict[str, Any]:
-    """Wait for ``pending_subagent`` (spawned earlier) and append result to messages."""
-    pending = state.get("pending_subagent")
+    """Wait for active sub-agent wave and append synthesis context to messages."""
+    pending = list(state.get("pending_subagents") or [])
+    legacy = state.get("pending_subagent")
+    if legacy and legacy not in pending:
+        pending.append(legacy)
     if not pending:
         return {}
 
     agent = get_agent_from_config(config)
     if not agent:
-        return {"pending_subagent": None}
+        return {"pending_subagents": [], "pending_subagent": None}
 
     manager = agent.subagents
-    handle = manager.get_handle(pending)
-    if not handle:
-        return {"pending_subagent": None}
+    wave_idx = int(state.get("current_subagent_wave", 0))
+    task_meta_raw = dict(state.get("subagent_task_meta") or {})
+
+    timeouts = []
+    for job_id in pending:
+        handle = manager.get_handle(job_id)
+        timeouts.append(handle.config.timeout if handle else 120.0)
+    timeout = max(timeouts) if timeouts else 120.0
 
     try:
-        result = await manager.wait_for(pending, timeout=handle.config.timeout)
-        results = dict(state.get("sub_agent_results", {}))
-        results[pending] = {
-            "response": result.response if result else "",
-            "success": result.success if result else False,
-            "error": result.error if result else None,
-        }
-        messages = list(state.get("messages", []))
-        snippet = (result.response or result.error or "")[:4000] if result else ""
-        messages.append(
-            {
-                "role": "user",
-                "content": (
-                    f"[Sub-agent '{pending}' completed]\n"
-                    f"success={result.success if result else False}\n\n{snippet}"
-                ),
-            }
+        payloads = await asyncio.gather(
+            *[_wait_job(manager, job_id, timeout) for job_id in pending]
         )
+        results = {job_id: payload for job_id, payload in zip(pending, payloads, strict=True)}
+
+        task_meta: dict[str, SubagentTask] = {}
+        step_indices: list[int] = []
+        for job_id, meta in task_meta_raw.items():
+            if job_id not in results:
+                continue
+            task_meta[job_id] = SubagentTask(
+                agent_type=str(meta.get("agent_type", "")),
+                task=str(meta.get("task", "")),
+                step_ref=int(meta.get("step_ref", 0)),
+                step_index=int(meta.get("step_index", 0)),
+            )
+            step_indices.append(int(meta.get("step_index", 0)))
+
+        orch_raw = state.get("subagent_orchestration")
+        total_waves = 1
+        if orch_raw:
+            total_waves = len(OrchestrationPlan.from_dict(orch_raw).waves) or 1
+
+        aggregate = format_wave_aggregate(
+            wave_id=wave_idx,
+            total_waves=total_waves,
+            results=results,
+            task_meta=task_meta,
+        )
+
+        sub_results = dict(state.get("sub_agent_results", {}))
+        for job_id, payload in results.items():
+            sub_results[job_id] = payload
+
+        wave_results = dict(state.get("subagent_wave_results", {}))
+        wave_results[str(wave_idx)] = results
+
+        messages = list(state.get("messages", []))
+        messages.append({"role": "user", "content": aggregate})
+
+        completed = sum(1 for p in results.values() if p.get("success"))
+        log_subagent_event(
+            "INFO",
+            f"wave {wave_idx + 1}/{total_waves} collected {completed}/{len(results)}",
+            subagent=",".join(pending),
+        )
+        if agent and hasattr(agent, "emit"):
+            from core.agent_events import SubAgentWaveCompletedEvent
+
+            agent.emit(
+                SubAgentWaveCompletedEvent(
+                    wave_id=wave_idx,
+                    total_waves=total_waves,
+                    completed=completed,
+                    total=len(results),
+                    conversation_id=state.get("conversation_id", "default"),
+                )
+            )
+
         return {
+            "pending_subagents": [],
             "pending_subagent": None,
-            "sub_agent_results": results,
+            "current_subagent_wave": wave_idx + 1,
+            "sub_agent_results": sub_results,
+            "subagent_wave_results": wave_results,
             "messages": messages,
-            "is_step_complete": True,
+            "is_step_complete": False,
+            "subagent_wave_step_indices": sorted(set(step_indices)),
+            "subagent_awaiting_synthesis": True,
         }
     except Exception as exc:
-        logger.warning("collect_subagent failed for %s: %s", pending, exc)
+        logger.warning("collect_subagent failed: %s", exc)
         messages = list(state.get("messages", []))
         messages.append(
             {
                 "role": "user",
                 "content": (
-                    f"[Sub-agent '{pending}' failed]\n"
-                    f"success=false\n\n{exc}"
+                    f"[Sub-agents wave {wave_idx + 1} failed]\n"
+                    f"success=false\n\n{exc}\n\n"
+                    "Explain the failure to the user and suggest next steps."
                 ),
             }
         )
-        results = dict(state.get("sub_agent_results", {}))
-        results[pending] = {
-            "response": "",
-            "success": False,
-            "error": str(exc),
-        }
         return {
+            "pending_subagents": [],
             "pending_subagent": None,
-            "sub_agent_results": results,
+            "current_subagent_wave": wave_idx + 1,
             "messages": messages,
-            "is_step_complete": True,
+            "is_step_complete": False,
+            "subagent_awaiting_synthesis": True,
+            "subagent_wave_step_indices": [],
         }

--- a/core/graph/nodes/delegate_subagent_node.py
+++ b/core/graph/nodes/delegate_subagent_node.py
@@ -1,4 +1,4 @@
-"""Delegate plan steps to sub-agents when configured."""
+"""Delegate plan steps to sub-agents (single or orchestrated waves)."""
 
 from __future__ import annotations
 
@@ -8,62 +8,128 @@ from typing import Any
 from langchain_core.runnables import RunnableConfig
 
 from core.graph.state import HolixGraphState, get_agent_from_config
+from core.logging.events import log_subagent_event
+from core.subagents.orchestrator import (
+    OrchestrationPlan,
+    build_orchestration_plan,
+    current_wave,
+)
+from core.subagents.spawn import prepare_subagent_config
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_orchestration(
+    state: HolixGraphState,
+    *,
+    enable_subagents: bool,
+    max_concurrent: int,
+) -> OrchestrationPlan | None:
+    raw = state.get("subagent_orchestration")
+    if raw:
+        return OrchestrationPlan.from_dict(raw)
+
+    plan = build_orchestration_plan(
+        plan_analysis=state.get("plan_analysis"),
+        plan_steps=state.get("plan_steps", []),
+        current_step_index=state.get("current_plan_step", 0),
+        enable_subagents=enable_subagents,
+        max_concurrent=max_concurrent,
+    )
+    if not plan.enabled:
+        return None
+    return plan
 
 
 async def delegate_subagent_node(
     state: HolixGraphState,
     config: RunnableConfig,
 ) -> dict[str, Any]:
-    """Spawn a sub-agent for the current plan step when ``subagent_type`` is set.
-
-    When sub-agents are disabled or no type is specified, passes through to react.
-    """
+    """Spawn sub-agent(s) for the current orchestration wave."""
     agent = get_agent_from_config(config)
     if not agent:
         return {}
 
     cfg = getattr(agent, "config", None)
-    if not cfg or not cfg.enable_subagents:
+    if not cfg or not getattr(cfg, "enable_subagents", False):
         return {}
 
-    plan_steps = state.get("plan_steps", [])
-    current_step_idx = state.get("current_plan_step", 0)
-    if current_step_idx >= len(plan_steps):
-        return {}
+    orchestration = _resolve_orchestration(
+        state,
+        enable_subagents=True,
+        max_concurrent=int(getattr(cfg, "subagent_max_concurrent", 4) or 4),
+    )
+    if orchestration is None:
+        return {"subagent_delegate_next": False}
 
-    step = plan_steps[current_step_idx]
-    subagent_type = step.get("subagent_type")
-    if not subagent_type:
-        return {}
+    wave_idx = int(state.get("current_subagent_wave", 0))
+    wave = current_wave(orchestration, wave_idx)
+    if wave is None:
+        return {"subagent_delegate_next": False}
 
-    task = step.get("description", "")
-    if not task:
-        return {}
+    manager = agent.subagents
+    pending: list[str] = []
+    task_meta: dict[str, dict[str, Any]] = {}
+    tasks_log = list(state.get("sub_agent_tasks", []))
 
     try:
-        manager = agent.subagents
-        handle, _ = await manager.spawn_typed(subagent_type, task, wait=False)
-
-        tasks = list(state.get("sub_agent_tasks", []))
-        tasks.append(
-            {
-                "type": subagent_type,
-                "task": task,
-                "handle": handle.name,
-                "process_mode": handle.config.process_mode.value,
+        for task in wave.tasks:
+            instance = manager.allocate_name(task.agent_type)
+            sub_cfg = prepare_subagent_config(
+                task.agent_type,
+                cfg,
+                instance_name=instance,
+            )
+            handle = await manager.spawn_sub_agent(
+                sub_cfg,
+                task.task,
+                agent_type=task.agent_type,
+            )
+            pending.append(handle.name)
+            task_meta[handle.name] = {
+                "agent_type": task.agent_type,
+                "task": task.task,
+                "step_ref": task.step_ref,
+                "step_index": task.step_index,
             }
+            tasks_log.append(
+                {
+                    "type": task.agent_type,
+                    "task": task.task,
+                    "handle": handle.name,
+                    "process_mode": handle.config.process_mode.value,
+                    "wave_id": wave.wave_id,
+                }
+            )
+
+        log_subagent_event(
+            "INFO",
+            f"wave {wave.wave_id + 1}/{len(orchestration.waves)} started",
+            subagent=",".join(pending),
+            task_count=len(pending),
         )
+        if agent and hasattr(agent, "emit"):
+            from core.agent_events import SubAgentWaveStartedEvent
+
+            agent.emit(
+                SubAgentWaveStartedEvent(
+                    wave_id=wave.wave_id,
+                    total_waves=len(orchestration.waves),
+                    job_ids=pending,
+                    conversation_id=state.get("conversation_id", "default"),
+                )
+            )
 
         return {
-            "sub_agent_tasks": tasks,
-            "pending_subagent": handle.name,
+            "subagent_orchestration": orchestration.to_dict(),
+            "current_subagent_wave": wave_idx,
+            "pending_subagents": pending,
+            "pending_subagent": pending[0] if len(pending) == 1 else None,
+            "subagent_task_meta": task_meta,
+            "sub_agent_tasks": tasks_log,
+            "subagent_delegate_next": False,
             "is_step_complete": False,
         }
-    except KeyError:
-        logger.warning("Unknown subagent_type: %s", subagent_type)
-        return {}
     except Exception as exc:
-        logger.warning("Sub-agent delegation failed: %s", exc)
-        return {}
+        logger.warning("Sub-agent wave delegation failed: %s", exc)
+        return {"subagent_delegate_next": False}

--- a/core/graph/nodes/plan_node.py
+++ b/core/graph/nodes/plan_node.py
@@ -138,6 +138,19 @@ Now create a plan for the task above. Respond with ONLY valid JSON:
     "reasoning": "..."
 }}"""
 
+SUBAGENT_PLAN_APPENDIX = """
+## Sub-agent delegation (enabled)
+When complexity is medium or complex, assign `subagent_type` on steps that specialists should run:
+- research / web search → `web_researcher` or `researcher`
+- coding / implementation → `coder`
+- data / SQL analysis → `analyst`
+- code review → `reviewer`
+- documentation → `writer`
+For complex tasks, use `parallel_group` (same integer) for independent steps that can run in parallel.
+Use `depends_on` so downstream steps wait for prerequisites.
+Leave `subagent_type` null only for steps the main agent must handle directly.
+"""
+
 FALLBACK_PLAN_PROMPT = """You are a task planner. Break down the following task into clear, ordered sub-tasks.
 
 Task: {task}
@@ -278,6 +291,9 @@ async def plan_node(state: HolixGraphState, config: RunnableConfig) -> dict:
         prompt = FALLBACK_PLAN_PROMPT.format(task=user_input)
         if project_handbook:
             prompt += f"\n\n## PROJECT HANDBOOK\n{project_handbook}\n"
+
+    if getattr(agent.config, "enable_subagents", False):
+        prompt += SUBAGENT_PLAN_APPENDIX
 
     # Append refinement feedback if the user requested changes to a previous plan
     if refinement_feedback:

--- a/core/graph/nodes/step_orchestrate_node.py
+++ b/core/graph/nodes/step_orchestrate_node.py
@@ -75,8 +75,11 @@ async def step_orchestrate_node(state: HolixGraphState, config: RunnableConfig) 
 
     # Check if current step has been completed by react
     if is_step_complete:
-        # Current step is done, advance to next
-        new_step_idx = current_step_idx + 1
+        wave_indices = state.get("subagent_wave_step_indices") or []
+        if wave_indices:
+            new_step_idx = max(wave_indices) + 1
+        else:
+            new_step_idx = current_step_idx + 1
 
         # Check for per-step step limit
         try:
@@ -110,11 +113,18 @@ async def step_orchestrate_node(state: HolixGraphState, config: RunnableConfig) 
                     conversation_id=conversation_id,
                 ))
 
+            clear_orch: dict = {
+                "subagent_orchestration": None,
+                "subagent_delegate_next": False,
+                "subagent_awaiting_synthesis": False,
+                "subagent_wave_step_indices": None,
+            }
             return {
                 "current_plan_step": new_step_idx,
                 "is_step_complete": False,
                 "is_final": True,
                 "final_response": state.get("final_response", f"Plan completed: all {len(plan_steps)} steps executed."),
+                **clear_orch,
             }
 
         # Inject next step description as a user message
@@ -145,15 +155,53 @@ async def step_orchestrate_node(state: HolixGraphState, config: RunnableConfig) 
             except Exception as e:
                 logger.warning(f"Failed to save plan step message: {e}")
 
+        orch_updates: dict = {
+            "subagent_awaiting_synthesis": False,
+            "subagent_wave_step_indices": None,
+        }
+        raw_orch = state.get("subagent_orchestration")
+        if raw_orch:
+            from core.subagents.orchestrator import OrchestrationPlan
+
+            orch_plan = OrchestrationPlan.from_dict(raw_orch)
+            if int(state.get("current_subagent_wave", 0)) >= len(orch_plan.waves):
+                orch_updates["subagent_orchestration"] = None
+                orch_updates["subagent_delegate_next"] = False
+
         return {
             "current_plan_step": new_step_idx,
             "is_step_complete": False,
             "current_step_start_count": step_count,
             "messages": messages,
+            **orch_updates,
         }
 
+    cfg = getattr(agent, "config", None) if agent else None
+    if (
+        cfg
+        and getattr(cfg, "enable_subagents", False)
+        and not state.get("subagent_orchestration")
+        and not state.get("subagent_awaiting_synthesis")
+    ):
+        from core.subagents.orchestrator import build_orchestration_plan
+
+        orch_plan = build_orchestration_plan(
+            plan_analysis=state.get("plan_analysis"),
+            plan_steps=plan_steps,
+            current_step_index=current_step_idx,
+            enable_subagents=True,
+            max_concurrent=int(getattr(cfg, "subagent_max_concurrent", 4) or 4),
+        )
+        if orch_plan.enabled:
+            return {
+                "subagent_orchestration": orch_plan.to_dict(),
+                "current_subagent_wave": 0,
+                "subagent_delegate_next": True,
+                "is_step_complete": False,
+                "current_step_start_count": step_count,
+            }
+
     # First entry for this step — inject step context
-    # Check if this is the very first step (current_step_idx == 0 and no step messages yet)
     step_context_msg = (
         f"[Plan Step {step_num}/{len(plan_steps)}] {step_description}\n"
         f"Tools: {', '.join(current_step.get('tools_needed', [])) or 'all available tools'}\n"

--- a/core/graph/routers.py
+++ b/core/graph/routers.py
@@ -87,6 +87,17 @@ def route_after_step_orchestrate(state: HolixGraphState) -> str:
     current_step_idx = state.get("current_plan_step", 0)
     if state.get("is_final", False):
         return "finalize"
+    if state.get("subagent_delegate_next"):
+        return "delegate_subagent"
+    if not state.get("subagent_awaiting_synthesis"):
+        orch = state.get("subagent_orchestration")
+        if orch:
+            from core.subagents.orchestrator import OrchestrationPlan
+
+            plan = OrchestrationPlan.from_dict(orch)
+            wave_idx = int(state.get("current_subagent_wave", 0))
+            if wave_idx < len(plan.waves):
+                return "delegate_subagent"
     if current_step_idx < len(plan_steps):
         return "react"
     return "finalize"

--- a/core/graph/state.py
+++ b/core/graph/state.py
@@ -57,7 +57,15 @@ class HolixGraphState(TypedDict, total=False):
     # Sub-agent state (Phase 4b)
     sub_agent_tasks: list[dict[str, Any]]    # Sub-tasks for sub-agents
     sub_agent_results: dict[str, Any]        # {agent_name: result}
-    pending_subagent: str | None          # Job id awaiting collect_subagent_node
+    pending_subagent: str | None          # Legacy single job id (use pending_subagents)
+    pending_subagents: list[str]          # Active wave job ids
+    subagent_orchestration: dict[str, Any] | None  # Serialized OrchestrationPlan
+    current_subagent_wave: int            # Next wave index to run
+    subagent_wave_results: dict[str, Any]  # {wave_id: {job_id: result}}
+    subagent_task_meta: dict[str, Any]     # {job_id: task metadata}
+    subagent_wave_step_indices: list[int] | None  # Plan indices finished in last wave
+    subagent_awaiting_synthesis: bool     # True after collect, before react synthesis
+    subagent_delegate_next: bool           # Router hint to spawn the next wave
 
     # Plan state (for plan_and_execute and hybrid modes)
     plan_steps: list[dict[str, Any]]         # Ordered list of plan steps

--- a/core/subagents/orchestrator.py
+++ b/core/subagents/orchestrator.py
@@ -1,0 +1,313 @@
+"""Build sub-agent orchestration waves from plan_and_execute state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.subagents.registry import PREDEFINED_SUBAGENTS
+
+_VALID_TYPES = frozenset(PREDEFINED_SUBAGENTS.keys())
+
+
+@dataclass(slots=True)
+class SubagentTask:
+    agent_type: str
+    task: str
+    step_ref: int
+    step_index: int
+
+
+@dataclass(slots=True)
+class OrchestrationWave:
+    wave_id: int
+    tasks: list[SubagentTask] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class OrchestrationPlan:
+    complexity: str
+    enabled: bool
+    waves: list[OrchestrationWave] = field(default_factory=list)
+    reasoning: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "complexity": self.complexity,
+            "enabled": self.enabled,
+            "reasoning": self.reasoning,
+            "waves": [
+                {
+                    "wave_id": wave.wave_id,
+                    "tasks": [
+                        {
+                            "agent_type": t.agent_type,
+                            "task": t.task,
+                            "step_ref": t.step_ref,
+                            "step_index": t.step_index,
+                        }
+                        for t in wave.tasks
+                    ],
+                }
+                for wave in self.waves
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OrchestrationPlan:
+        waves = []
+        for wave_data in data.get("waves", []):
+            tasks = [
+                SubagentTask(
+                    agent_type=t["agent_type"],
+                    task=t["task"],
+                    step_ref=int(t["step_ref"]),
+                    step_index=int(t["step_index"]),
+                )
+                for t in wave_data.get("tasks", [])
+            ]
+            waves.append(OrchestrationWave(wave_id=int(wave_data["wave_id"]), tasks=tasks))
+        return cls(
+            complexity=str(data.get("complexity", "medium")),
+            enabled=bool(data.get("enabled", False)),
+            waves=waves,
+            reasoning=str(data.get("reasoning", "")),
+        )
+
+
+def infer_subagent_type(step: dict[str, Any]) -> str | None:
+    """Resolve sub-agent type from plan step metadata or heuristics."""
+    explicit = (step.get("subagent_type") or "").strip()
+    if explicit in _VALID_TYPES:
+        return explicit
+
+    description = (step.get("description") or "").lower()
+    tools = [str(t).lower() for t in (step.get("tools_needed") or [])]
+
+    if (
+        any(t in tools for t in ("web_search", "web_fetch"))
+        or any(kw in description for kw in ("research", "search", "investigate", "look up"))
+    ):
+        return "web_researcher"
+    if (
+        any(t in tools for t in ("write_file", "terminal", "code_executor"))
+        or any(kw in description for kw in ("implement", "code", "build", "debug", "fix", "refactor"))
+    ):
+        return "coder"
+    if any(t in tools for t in ("sql_query", "sql_schema", "database")) or "analy" in description:
+        return "analyst"
+    if "review" in description:
+        return "reviewer"
+    if any(kw in description for kw in ("document", "readme", "documentation", "write doc")):
+        return "writer"
+    return None
+
+
+def _completed_step_numbers(plan_steps: list[dict[str, Any]], current_step_index: int) -> set[int]:
+    done: set[int] = set()
+    for idx in range(max(0, current_step_index)):
+        if idx < len(plan_steps):
+            done.add(int(plan_steps[idx].get("step", idx + 1)))
+    return done
+
+
+def _deps_satisfied(step: dict[str, Any], completed: set[int]) -> bool:
+    depends_on = step.get("depends_on") or []
+    if not depends_on:
+        return True
+    return all(int(dep) in completed for dep in depends_on)
+
+
+def _eligible_steps(
+    plan_steps: list[dict[str, Any]],
+    *,
+    current_step_index: int,
+) -> list[tuple[int, dict[str, Any], str]]:
+    """Return (index, step, agent_type) for steps ready to delegate."""
+    completed = _completed_step_numbers(plan_steps, current_step_index)
+    eligible: list[tuple[int, dict[str, Any], str]] = []
+    for idx in range(current_step_index, len(plan_steps)):
+        step = plan_steps[idx]
+        if not _deps_satisfied(step, completed):
+            continue
+        agent_type = infer_subagent_type(step)
+        if not agent_type:
+            continue
+        task = (step.get("description") or "").strip()
+        if not task:
+            continue
+        eligible.append((idx, step, agent_type))
+    return eligible
+
+
+def _cap_tasks(
+    items: list[SubagentTask],
+    max_concurrent: int,
+) -> list[SubagentTask]:
+    limit = max(1, int(max_concurrent or 4))
+    return items[:limit]
+
+
+def _build_medium_waves(eligible: list[tuple[int, dict[str, Any], str]]) -> list[OrchestrationWave]:
+    tasks = [
+        SubagentTask(
+            agent_type=agent_type,
+            task=(step.get("description") or "").strip(),
+            step_ref=int(step.get("step", idx + 1)),
+            step_index=idx,
+        )
+        for idx, step, agent_type in eligible
+    ]
+    if not tasks:
+        return []
+    return [OrchestrationWave(wave_id=0, tasks=tasks)]
+
+
+def _build_complex_waves(
+    plan_steps: list[dict[str, Any]],
+    *,
+    current_step_index: int,
+) -> list[OrchestrationWave]:
+    """Build multiple waves respecting depends_on and parallel_group."""
+    completed = _completed_step_numbers(plan_steps, current_step_index)
+    scheduled_indices: set[int] = set(range(current_step_index))
+    waves: list[OrchestrationWave] = []
+    wave_id = 0
+
+    while True:
+        eligible: list[tuple[int, dict[str, Any], str]] = []
+        for idx in range(len(plan_steps)):
+            if idx in scheduled_indices:
+                continue
+            step = plan_steps[idx]
+            if not _deps_satisfied(step, completed):
+                continue
+            agent_type = infer_subagent_type(step)
+            if not agent_type:
+                continue
+            task = (step.get("description") or "").strip()
+            if not task:
+                continue
+            eligible.append((idx, step, agent_type))
+
+        if not eligible:
+            break
+
+        buckets: dict[str, list[tuple[int, dict[str, Any], str]]] = {}
+        for idx, step, agent_type in eligible:
+            pg = step.get("parallel_group")
+            key = f"pg:{pg}" if pg is not None else f"solo:{idx}"
+            buckets.setdefault(key, []).append((idx, step, agent_type))
+
+        next_key = min(
+            buckets.keys(),
+            key=lambda k: min(item[0] for item in buckets[k]),
+        )
+        batch = buckets.pop(next_key)
+        tasks = [
+            SubagentTask(
+                agent_type=agent_type,
+                task=(step.get("description") or "").strip(),
+                step_ref=int(step.get("step", idx + 1)),
+                step_index=idx,
+            )
+            for idx, step, agent_type in batch
+        ]
+        waves.append(OrchestrationWave(wave_id=wave_id, tasks=tasks))
+        wave_id += 1
+
+        for idx, step, _ in batch:
+            scheduled_indices.add(idx)
+            completed.add(int(step.get("step", idx + 1)))
+
+    return waves
+
+
+def build_orchestration_plan(
+    *,
+    plan_analysis: dict[str, Any] | None,
+    plan_steps: list[dict[str, Any]],
+    current_step_index: int = 0,
+    enable_subagents: bool = False,
+    max_concurrent: int = 4,
+) -> OrchestrationPlan:
+    """Decide whether and how to run sub-agents for the remaining plan."""
+    analysis = plan_analysis or {}
+    complexity = str(analysis.get("complexity", "medium")).strip().lower()
+
+    if not enable_subagents or complexity == "simple":
+        return OrchestrationPlan(
+            complexity=complexity,
+            enabled=False,
+            reasoning="sub-agents disabled or task complexity is simple",
+        )
+
+    eligible = _eligible_steps(plan_steps, current_step_index=current_step_index)
+    if not eligible:
+        return OrchestrationPlan(
+            complexity=complexity,
+            enabled=False,
+            reasoning="no plan steps match sub-agent delegation",
+        )
+
+    if complexity == "medium":
+        waves = _build_medium_waves(eligible)
+        reasoning = "medium: single parallel wave for eligible steps"
+    else:
+        waves = _build_complex_waves(
+            plan_steps,
+            current_step_index=current_step_index,
+        )
+        reasoning = "complex: waves by parallel_group and dependencies"
+
+    for wave in waves:
+        wave.tasks = _cap_tasks(wave.tasks, max_concurrent)
+
+    waves = [w for w in waves if w.tasks]
+    if not waves:
+        return OrchestrationPlan(
+            complexity=complexity,
+            enabled=False,
+            reasoning="no tasks after concurrency limits",
+        )
+
+    return OrchestrationPlan(
+        complexity=complexity,
+        enabled=True,
+        waves=waves,
+        reasoning=reasoning,
+    )
+
+
+def current_wave(plan: OrchestrationPlan, wave_index: int) -> OrchestrationWave | None:
+    if not plan.enabled or wave_index < 0 or wave_index >= len(plan.waves):
+        return None
+    return plan.waves[wave_index]
+
+
+def format_wave_aggregate(
+    *,
+    wave_id: int,
+    total_waves: int,
+    results: dict[str, dict[str, Any]],
+    task_meta: dict[str, SubagentTask],
+) -> str:
+    """Build markdown context for main-agent synthesis in react."""
+    completed = sum(1 for r in results.values() if r.get("success"))
+    total = len(results)
+    lines = [
+        f"[Sub-agents wave {wave_id + 1}/{total_waves} — {completed}/{total} completed]",
+        "",
+        "Synthesize the sub-agent outputs below into a coherent progress update for the user.",
+        "Highlight successes, failures, and concrete deliverables.",
+        "",
+    ]
+    for job_id, payload in results.items():
+        meta = task_meta.get(job_id)
+        step_label = f"step {meta.step_ref}" if meta else "step ?"
+        status = "✓" if payload.get("success") else "✗"
+        lines.append(f"### {job_id} ({step_label}) {status}")
+        body = payload.get("response") or payload.get("error") or ""
+        lines.append(str(body)[:4000])
+        lines.append("")
+    return "\n".join(lines).strip()

--- a/tests/test_collect_subagent_batch.py
+++ b/tests/test_collect_subagent_batch.py
@@ -1,0 +1,121 @@
+"""Batch collect_subagent_node behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from core.graph.nodes.collect_subagent_node import collect_subagent_node
+from core.subagents.base import (
+    ProcessMode,
+    SubAgentConfig,
+    SubAgentHandle,
+    SubAgentResult,
+    SubAgentStatus,
+)
+from core.subagents.orchestrator import build_orchestration_plan
+
+
+def _orch_state() -> dict:
+    steps = [
+        {
+            "step": 1,
+            "description": "Research",
+            "tools_needed": ["web_search"],
+            "depends_on": [],
+            "parallel_group": None,
+            "subagent_type": None,
+        },
+        {
+            "step": 2,
+            "description": "Implement module",
+            "tools_needed": ["write_file"],
+            "depends_on": [],
+            "parallel_group": None,
+            "subagent_type": None,
+        },
+    ]
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "medium"},
+        plan_steps=steps,
+        enable_subagents=True,
+    )
+    return {
+        "pending_subagents": ["web_researcher", "coder"],
+        "current_subagent_wave": 0,
+        "subagent_orchestration": plan.to_dict(),
+        "subagent_task_meta": {
+            "web_researcher": {
+                "agent_type": "web_researcher",
+                "task": "Research",
+                "step_ref": 1,
+                "step_index": 0,
+            },
+            "coder": {
+                "agent_type": "coder",
+                "task": "Implement module",
+                "step_ref": 2,
+                "step_index": 1,
+            },
+        },
+        "messages": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_collect_batch_aggregates_for_synthesis() -> None:
+    agent = MagicMock()
+    manager = MagicMock()
+
+    def _handle(name: str) -> SubAgentHandle:
+        return SubAgentHandle(
+            name=name,
+            config=SubAgentConfig(name=name, process_mode=ProcessMode.ASYNC),
+            status=SubAgentStatus.COMPLETED,
+        )
+
+    async def _wait_for(name: str, timeout: float | None = None) -> SubAgentResult:
+        return SubAgentResult(name=name, success=True, response=f"done:{name}")
+
+    manager.get_handle = _handle
+    manager.wait_for = AsyncMock(side_effect=_wait_for)
+    agent.subagents = manager
+
+    state = _orch_state()
+    config = {"configurable": {"_agent": agent}}
+    result = await collect_subagent_node(state, config)
+
+    assert result.get("pending_subagents") == []
+    assert result.get("is_step_complete") is False
+    assert result.get("subagent_awaiting_synthesis") is True
+    assert result.get("subagent_wave_step_indices") == [0, 1]
+    assert result.get("current_subagent_wave") == 1
+    content = result["messages"][-1]["content"]
+    assert "Synthesize" in content
+    assert "web_researcher" in content
+    assert "coder" in content
+
+
+def test_route_delegate_when_orchestration_pending() -> None:
+    from core.graph.routers import route_after_step_orchestrate
+
+    steps = [
+        {
+            "step": 1,
+            "description": "Research",
+            "tools_needed": ["web_search"],
+            "depends_on": [],
+        }
+    ]
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "medium"},
+        plan_steps=steps,
+        enable_subagents=True,
+    )
+    state = {
+        "plan_steps": steps,
+        "current_plan_step": 0,
+        "subagent_orchestration": plan.to_dict(),
+        "current_subagent_wave": 0,
+    }
+    assert route_after_step_orchestrate(state) == "delegate_subagent"

--- a/tests/test_subagent_orchestrator.py
+++ b/tests/test_subagent_orchestrator.py
@@ -1,0 +1,155 @@
+"""Tests for sub-agent orchestration plan builder."""
+
+from __future__ import annotations
+
+from core.subagents.orchestrator import (
+    build_orchestration_plan,
+    current_wave,
+    format_wave_aggregate,
+    infer_subagent_type,
+)
+
+
+def _step(
+    num: int,
+    desc: str,
+    *,
+    subagent_type=None,
+    tools=None,
+    depends_on=None,
+    parallel_group=None,
+) -> dict:
+    return {
+        "step": num,
+        "description": desc,
+        "tools_needed": tools or [],
+        "depends_on": depends_on or [],
+        "parallel_group": parallel_group,
+        "subagent_type": subagent_type,
+    }
+
+
+def test_simple_complexity_disabled() -> None:
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "simple"},
+        plan_steps=[_step(1, "Research API options", tools=["web_search"])],
+        enable_subagents=True,
+    )
+    assert plan.enabled is False
+
+
+def test_medium_no_eligible_steps_disabled() -> None:
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "medium"},
+        plan_steps=[_step(1, "Reply with the number 42")],
+        enable_subagents=True,
+    )
+    assert plan.enabled is False
+
+
+def test_medium_single_wave_two_tasks() -> None:
+    steps = [
+        _step(1, "Research competitors", tools=["web_search"]),
+        _step(2, "Implement API module", tools=["write_file", "terminal"]),
+    ]
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "medium"},
+        plan_steps=steps,
+        enable_subagents=True,
+        max_concurrent=4,
+    )
+    assert plan.enabled is True
+    assert len(plan.waves) == 1
+    assert len(plan.waves[0].tasks) == 2
+    types = {t.agent_type for t in plan.waves[0].tasks}
+    assert types == {"web_researcher", "coder"}
+
+
+def test_respects_max_concurrent() -> None:
+    steps = [
+        _step(i, f"Research topic {i}", tools=["web_search"])
+        for i in range(1, 6)
+    ]
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "medium"},
+        plan_steps=steps,
+        enable_subagents=True,
+        max_concurrent=2,
+    )
+    assert plan.enabled is True
+    assert len(plan.waves[0].tasks) == 2
+
+
+def test_complex_parallel_groups_create_multiple_waves() -> None:
+    steps = [
+        _step(1, "Research A", tools=["web_search"], parallel_group=1),
+        _step(2, "Research B", tools=["web_search"], parallel_group=1),
+        _step(3, "Write docs", tools=["write_file"], depends_on=[1, 2]),
+    ]
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "complex"},
+        plan_steps=steps,
+        enable_subagents=True,
+    )
+    assert plan.enabled is True
+    assert len(plan.waves) == 2
+    assert len(plan.waves[0].tasks) == 2
+    assert plan.waves[1].tasks[0].agent_type == "coder"
+
+
+def test_deps_block_until_completed_index() -> None:
+    steps = [
+        _step(1, "Build core", tools=["write_file"]),
+        _step(2, "Research add-ons", tools=["web_search"], depends_on=[1]),
+    ]
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "medium"},
+        plan_steps=steps,
+        current_step_index=0,
+        enable_subagents=True,
+    )
+    assert len(plan.waves[0].tasks) == 1
+    assert plan.waves[0].tasks[0].agent_type == "coder"
+
+    plan2 = build_orchestration_plan(
+        plan_analysis={"complexity": "medium"},
+        plan_steps=steps,
+        current_step_index=1,
+        enable_subagents=True,
+    )
+    assert len(plan2.waves[0].tasks) == 1
+    assert plan2.waves[0].tasks[0].agent_type == "web_researcher"
+
+
+def test_explicit_subagent_type() -> None:
+    step = _step(1, "Do something", subagent_type="reviewer")
+    assert infer_subagent_type(step) == "reviewer"
+
+
+def test_format_wave_aggregate() -> None:
+    from core.subagents.orchestrator import SubagentTask
+
+    meta = {
+        "reviewer-1": SubagentTask("reviewer", "review code", 1, 0),
+    }
+    text = format_wave_aggregate(
+        wave_id=0,
+        total_waves=1,
+        results={"reviewer-1": {"success": True, "response": "LGTM"}},
+        task_meta=meta,
+    )
+    assert "wave 1/1" in text
+    assert "reviewer-1" in text
+    assert "LGTM" in text
+    assert "Synthesize" in text
+
+
+def test_current_wave_accessor() -> None:
+    plan = build_orchestration_plan(
+        plan_analysis={"complexity": "medium"},
+        plan_steps=[_step(1, "Research", tools=["web_search"])],
+        enable_subagents=True,
+    )
+    wave = current_wave(plan, 0)
+    assert wave is not None
+    assert len(wave.tasks) == 1


### PR DESCRIPTION
## Summary
Orchestrates sub-agents in `plan_and_execute` based on plan complexity and eligible steps.

- **simple** → no sub-agents (main agent only)
- **medium** → one parallel wave for all suitable steps (deps satisfied)
- **complex** → multiple waves via `parallel_group` + `depends_on`

Flow: `step_orchestrate` → `delegate` (batch spawn) → `collect` (aggregate) → `react` (main agent synthesis) → advance plan.

## Requirements met
- plan_and_execute only
- medium: only when plan has suitable steps; single parallel wave
- main agent synthesizes wave results in react

## Tests
- `tests/test_subagent_orchestrator.py`
- `tests/test_collect_subagent_batch.py`
- existing step/subagent tests pass