### PR TITLE
fix: return LLM models from GET /v1/models

### DIFF
--- a/api/routers/hermes_v1.py
+++ b/api/routers/hermes_v1.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import time
 import uuid
 
 from core.gateway.runs_store import RunStatus
@@ -73,25 +72,20 @@ def _resolve_ctx(
 async def list_models(
     key_info: dict = Depends(verify_api_key),
     registry=Depends(get_registry),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+    refresh: bool = False,
 ):
-    from cli.core import ProfileManager
+    from api.deps import _header_alias
+    from api.services.model_catalog import list_profile_models
 
-    profiles = ProfileManager().list_profiles() or [state.host_profile]
-    data = []
-    for name in profiles:
-        data.append({
-            "id": name,
-            "object": "model",
-            "created": int(time.time()),
-            "owned_by": "holix",
-        })
-    if not data:
-        data.append({
-            "id": state.host_profile,
-            "object": "model",
-            "created": int(time.time()),
-            "owned_by": "holix",
-        })
+    host = state.host_profile or "default"
+    profile = resolve_profile_name(
+        header_profile=_header_alias(x_holix_profile, x_hermes_profile),
+        model=None,
+        host_profile=host,
+    )
+    data = await list_profile_models(profile, refresh=refresh)
     return {"object": "list", "data": data}
 
 

--- a/api/services/model_catalog.py
+++ b/api/services/model_catalog.py
@@ -1,0 +1,115 @@
+"""OpenAI-style model list for GET /v1/models."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from core.models.setup_helpers import probe_provider
+
+
+def _openai_entry(model_id: str, *, owned_by: str, created: int) -> dict[str, Any]:
+    return {
+        "id": model_id,
+        "object": "model",
+        "created": created,
+        "owned_by": owned_by,
+    }
+
+
+def collect_cached_model_entries(profile: str) -> list[dict[str, Any]]:
+    """Return models configured for a profile (providers, agent slots, legacy)."""
+    from cli.core import ProfileManager
+    from core.models.manager import ModelManager
+
+    try:
+        cfg = ProfileManager().load_profile(profile)
+    except Exception:
+        return []
+
+    created = int(time.time())
+    seen: set[str] = set()
+    data: list[dict[str, Any]] = []
+
+    def add(model_id: str, owned_by: str) -> None:
+        mid = (model_id or "").strip()
+        if not mid or mid in seen:
+            return
+        seen.add(mid)
+        data.append(_openai_entry(mid, owned_by=owned_by, created=created))
+
+    for pname, pdata in sorted((cfg.providers or {}).items()):
+        owner = pname or "holix"
+        for mid in pdata.get("available_models") or []:
+            add(str(mid), owner)
+        add(str(pdata.get("default_model") or ""), owner)
+
+    mm = ModelManager(cfg)
+    default = mm.get_default_model_config()
+    if default:
+        add(default.model, default.provider)
+
+    for slot in sorted((cfg.agent_models or {}).keys()):
+        mc = mm.get_agent_model_config(slot)
+        if mc:
+            add(mc.model, mc.provider)
+
+    if not data and cfg.model:
+        add(cfg.model, "legacy")
+
+    return data
+
+
+async def discover_live_model_entries(profile: str) -> list[dict[str, Any]]:
+    """Probe configured providers when cached model lists are empty."""
+    from cli.core import ProfileManager
+
+    try:
+        cfg = ProfileManager().load_profile(profile)
+    except Exception:
+        return []
+
+    providers = cfg.providers or {}
+    if not providers:
+        return []
+
+    created = int(time.time())
+    seen: set[str] = set()
+    data: list[dict[str, Any]] = []
+
+    async def probe_one(name: str, pdata: dict[str, Any]) -> None:
+        base_url = str(pdata.get("base_url") or "").strip()
+        if not base_url:
+            return
+        api_key = str(pdata.get("api_key") or "dummy")
+        metadata = pdata.get("metadata") if isinstance(pdata.get("metadata"), dict) else {}
+        ok, models, _ = await probe_provider(base_url, api_key, metadata)
+        if not ok:
+            return
+        for item in models:
+            mid = str(item.get("id") or "").strip()
+            if not mid or mid in seen:
+                continue
+            seen.add(mid)
+            data.append(
+                _openai_entry(
+                    mid,
+                    owned_by=str(item.get("owned_by") or name or "holix"),
+                    created=int(item.get("created") or created),
+                )
+            )
+
+    await asyncio.gather(*(probe_one(name, pdata) for name, pdata in providers.items()))
+    return data
+
+
+async def list_profile_models(profile: str, *, refresh: bool = False) -> list[dict[str, Any]]:
+    """Models for GET /v1/models: cached config first, optional live provider probe."""
+    data = collect_cached_model_entries(profile)
+    if data and not refresh:
+        return data
+    live = await discover_live_model_entries(profile)
+    if live:
+        return live
+    return data

--- a/tests/test_gateway_v1_models.py
+++ b/tests/test_gateway_v1_models.py
@@ -1,0 +1,110 @@
+"""Tests for GET /v1/models (LLM model list, not profiles)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_v1_models_returns_llm_models_not_profiles(
+    gateway_client: TestClient,
+    gateway_auth_headers: dict,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOLIX_HOME", str(tmp_path))
+    from cli.core import ProfileManager
+
+    manager = ProfileManager()
+    manager.create_profile("docs", inherit_global=False)
+    cfg = manager.load_profile("docs")
+    cfg.providers = {
+        "litellm": {
+            "name": "litellm",
+            "base_url": "http://localhost:4000/v1",
+            "api_key": "sk-test",
+            "default_model": "gpt-4o-mini",
+            "available_models": ["gpt-4o-mini", "claude-3-5-sonnet"],
+        }
+    }
+    manager.save_profile("docs", cfg)
+
+    monkeypatch.setattr("api.state.host_profile", "docs")
+
+    response = gateway_client.get("/v1/models", headers=gateway_auth_headers)
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "list"
+    ids = {item["id"] for item in payload["data"]}
+    assert "gpt-4o-mini" in ids
+    assert "claude-3-5-sonnet" in ids
+    assert "docs" not in ids
+    assert "default" not in ids
+
+
+def test_v1_models_respects_profile_header(
+    gateway_client: TestClient,
+    gateway_auth_headers: dict,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOLIX_HOME", str(tmp_path))
+    from cli.core import ProfileManager
+
+    manager = ProfileManager()
+    manager.create_profile("alpha", inherit_global=False)
+    manager.create_profile("beta", inherit_global=False)
+    for name, model in (("alpha", "model-alpha"), ("beta", "model-beta")):
+        cfg = manager.load_profile(name)
+        cfg.model = model
+        manager.save_profile(name, cfg)
+
+    monkeypatch.setattr("api.state.host_profile", "alpha")
+
+    response = gateway_client.get(
+        "/v1/models",
+        headers={**gateway_auth_headers, "X-Holix-Profile": "beta"},
+    )
+    assert response.status_code == 200
+    ids = {item["id"] for item in response.json()["data"]}
+    assert ids == {"model-beta"}
+
+
+def test_v1_models_live_probe_when_cache_empty(
+    gateway_client: TestClient,
+    gateway_auth_headers: dict,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOLIX_HOME", str(tmp_path))
+    from cli.core import ProfileManager
+
+    manager = ProfileManager()
+    manager.create_profile("probe", inherit_global=False)
+    cfg = manager.load_profile("probe")
+    cfg.providers = {
+        "ollama": {
+            "name": "ollama",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "ollama",
+            "available_models": [],
+        }
+    }
+    manager.save_profile("probe", cfg)
+    monkeypatch.setattr("api.state.host_profile", "probe")
+
+    fake_models = [{"id": "qwen2.5-coder:32b", "owned_by": "ollama", "created": 1}]
+    with patch(
+        "api.services.model_catalog.probe_provider",
+        return_value=(True, fake_models, None),
+    ):
+        response = gateway_client.get(
+            "/v1/models",
+            headers=gateway_auth_headers,
+        )
+
+    assert response.status_code == 200
+    ids = {item["id"] for item in response.json()["data"]}
+    assert ids == {"qwen2.5-coder:32b"}


### PR DESCRIPTION
## Summary
- `GET /v1/models` now returns configured LLM models for the gateway host profile (or `X-Holix-Profile`) instead of Holix profile names
- Uses cached `providers.*.available_models` and falls back to live provider probe when cache is empty
- Adds `?refresh=true` to force re-probe

## Test plan
- [x] `pytest tests/test_gateway_v1_models.py tests/test_gateway_auth_required.py`
- [x] CI green