### PR TITLE
fix: Hermes-compatible /v1/runs poll and terminal status

### DIFF
--- a/api/routers/hermes_v1.py
+++ b/api/routers/hermes_v1.py
@@ -283,41 +283,93 @@ async def delete_response(
     return {"deleted": True, "id": response_id}
 
 
+def _set_run_status(
+    runs,
+    run_id: str,
+    status: RunStatus,
+    *,
+    last_event: str | None = None,
+    **fields: object,
+) -> None:
+    payload = dict(fields)
+    if last_event is not None:
+        payload["last_event"] = last_event
+    runs.update(run_id, status=status, **payload)
+
+
 async def _execute_run(record, registry, *, is_admin: bool = False) -> None:
     runs = state.runs_store
     if runs is None:
         return
+
+    run_id = record.run_id
     try:
-        runs.update(record.run_id, status=RunStatus.RUNNING)
+        _set_run_status(runs, run_id, RunStatus.RUNNING, last_event="run.running")
         agent = await registry.get_agent(record.profile)
         async with state._agent_request_lock:  # type: ignore[attr-defined]
             if record._cancel.is_set():
-                runs.update(record.run_id, status=RunStatus.CANCELLED)
+                _set_run_status(
+                    runs, run_id, RunStatus.CANCELLED, last_event="run.cancelled"
+                )
                 return
             with gateway_agent_path_visibility_for_admin(agent, is_admin=is_admin):
                 output = await agent.run(
                     user_input=record.input_text,
                     conversation_id=record.session_id or "default",
                 )
-        runs.update(
-            record.run_id,
-            status=RunStatus.COMPLETED,
+        if record._cancel.is_set():
+            _set_run_status(
+                runs, run_id, RunStatus.CANCELLED, last_event="run.cancelled"
+            )
+            return
+        _set_run_status(
+            runs,
+            run_id,
+            RunStatus.COMPLETED,
+            last_event="run.completed",
             output=output,
             usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
         )
-        runs.append_event(record.run_id, {"type": "run.completed", "output": output})
+        runs.append_event(run_id, {"type": "run.completed", "output": output})
     except Exception as exc:
-        runs.update(record.run_id, status=RunStatus.FAILED, error=str(exc))
-        runs.append_event(record.run_id, {"type": "run.failed", "error": str(exc)})
+        if record._cancel.is_set():
+            _set_run_status(
+                runs, run_id, RunStatus.CANCELLED, last_event="run.cancelled"
+            )
+            return
+        _set_run_status(
+            runs,
+            run_id,
+            RunStatus.FAILED,
+            last_event="run.failed",
+            error=str(exc),
+        )
+        runs.append_event(run_id, {"type": "run.failed", "error": str(exc)})
 
 
-@router.post("/runs")
+@router.post("/runs", status_code=202)
 async def create_run(
     body: RunsCreateRequest,
     key_info: dict = Depends(verify_api_key),
     registry=Depends(get_registry),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+    x_holix_session_id: str | None = Header(None),
+    x_hermes_session_id: str | None = Header(None),
 ):
-    ctx = _resolve_ctx(key_info, body.model, None, None, None, None, None, None)
+    if not body.input.strip():
+        raise HTTPException(status_code=400, detail="input is required")
+
+    ctx = _resolve_ctx(
+        key_info,
+        body.model,
+        x_holix_profile,
+        x_hermes_profile,
+        x_holix_session_id,
+        x_hermes_session_id,
+        None,
+        None,
+    )
     checker = PermissionChecker(key_info["permissions"])
     if not checker.can_execute() and not checker.can_read():
         raise HTTPException(status_code=403, detail="Execute permission required")
@@ -333,6 +385,7 @@ async def create_run(
         session_id=body.session_id or ctx.conversation_id,
         instructions=body.instructions,
     )
+    runs.update(record.run_id, last_event="run.started")
     asyncio.create_task(_execute_run(record, registry, is_admin=checker.is_admin()))
     return {"run_id": record.run_id, "status": record.status.value}
 

--- a/core/gateway/run_poll.py
+++ b/core/gateway/run_poll.py
@@ -1,0 +1,65 @@
+"""Hermes-compatible helpers for polling /v1/runs status."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+from core.gateway.runs_store import RunStatus
+
+# Hermes terminal states; "done" is accepted as a legacy alias for "completed".
+TERMINAL_RUN_STATUSES = frozenset({
+    RunStatus.COMPLETED.value,
+    RunStatus.FAILED.value,
+    RunStatus.CANCELLED.value,
+    "done",
+})
+
+
+def is_terminal_run_status(status: str | RunStatus | None) -> bool:
+    """Return True when a run has reached a terminal poll state."""
+    if status is None:
+        return False
+    if isinstance(status, RunStatus):
+        return status in {
+            RunStatus.COMPLETED,
+            RunStatus.FAILED,
+            RunStatus.CANCELLED,
+        }
+    return status.strip().lower() in TERMINAL_RUN_STATUSES
+
+
+def normalize_run_status(status: str | RunStatus | None) -> str | None:
+    """Normalize legacy aliases for external Hermes clients."""
+    if status is None:
+        return None
+    value = status.value if isinstance(status, RunStatus) else str(status).strip().lower()
+    if value == "done":
+        return RunStatus.COMPLETED.value
+    return value
+
+
+def poll_run(
+    fetch: Callable[[str], dict[str, Any]],
+    run_id: str,
+    *,
+    timeout: float = 120.0,
+    interval: float = 0.1,
+) -> dict[str, Any]:
+    """Poll run status until terminal (completed/failed/cancelled/done)."""
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        last = fetch(run_id)
+        status = normalize_run_status(last.get("status"))
+        if status is not None:
+            last = {**last, "status": status}
+        if is_terminal_run_status(status):
+            return last
+        time.sleep(interval)
+    last_status = last.get("status", "unknown")
+    raise TimeoutError(
+        f"Run {run_id} did not reach a terminal status within {timeout}s "
+        f"(last status: {last_status!r})"
+    )

--- a/core/gateway/runs_store.py
+++ b/core/gateway/runs_store.py
@@ -11,6 +11,7 @@ from typing import Any
 
 
 class RunStatus(StrEnum):
+    QUEUED = "queued"
     STARTED = "started"
     RUNNING = "running"
     COMPLETED = "completed"
@@ -31,6 +32,7 @@ class RunRecord:
     output: str | None = None
     error: str | None = None
     usage: dict[str, int] | None = None
+    last_event: str | None = None
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
     events: list[dict[str, Any]] = field(default_factory=list)
@@ -48,6 +50,8 @@ class RunRecord:
             "output": self.output,
             "error": self.error,
             "usage": self.usage,
+            "last_event": self.last_event,
+            "completed": self.status == RunStatus.COMPLETED,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
@@ -56,7 +60,7 @@ class RunRecord:
 class RunsStore:
     def __init__(self) -> None:
         self._runs: dict[str, RunRecord] = {}
-        self._retention_s = 600.0
+        self._retention_s = 3600.0
 
     def create(
         self,
@@ -109,8 +113,14 @@ class RunsStore:
         if run is None:
             return False
         run._cancel.set()
-        if run.status in {RunStatus.STARTED, RunStatus.RUNNING}:
+        if run.status in {
+            RunStatus.QUEUED,
+            RunStatus.STARTED,
+            RunStatus.RUNNING,
+            RunStatus.WAITING_APPROVAL,
+        }:
             run.status = RunStatus.CANCELLED
+            run.last_event = "run.cancelled"
         run.updated_at = time.time()
         return True
 

--- a/tests/test_gateway_hermes_compat.py
+++ b/tests/test_gateway_hermes_compat.py
@@ -92,15 +92,19 @@ def test_runs_lifecycle(gateway_client: TestClient, gateway_auth_headers: dict) 
         headers=gateway_auth_headers,
         json={"input": "ping", "model": "default"},
     )
-    assert created.status_code == 200
+    assert created.status_code == 202
     run_id = created.json()["run_id"]
 
-    import time
+    from core.gateway.run_poll import poll_run
 
-    for _ in range(20):
-        status = gateway_client.get(f"/v1/runs/{run_id}", headers=gateway_auth_headers)
-        if status.json().get("status") == "completed":
-            break
-        time.sleep(0.1)
-    assert status.status_code == 200
-    assert status.json()["status"] == "completed"
+    result = poll_run(
+        lambda rid: gateway_client.get(
+            f"/v1/runs/{rid}",
+            headers=gateway_auth_headers,
+        ).json(),
+        run_id,
+        timeout=5.0,
+        interval=0.05,
+    )
+    assert result["status"] == "completed"
+    assert result["last_event"] == "run.completed"

--- a/tests/test_gateway_run_poll.py
+++ b/tests/test_gateway_run_poll.py
@@ -1,0 +1,54 @@
+"""Hermes-compatible /v1/runs polling and terminal statuses."""
+
+from __future__ import annotations
+
+from core.gateway.run_poll import is_terminal_run_status, poll_run
+from fastapi.testclient import TestClient
+
+
+def test_is_terminal_run_status_accepts_completed_and_done() -> None:
+    assert is_terminal_run_status("completed")
+    assert is_terminal_run_status("done")
+    assert is_terminal_run_status("failed")
+    assert is_terminal_run_status("cancelled")
+    assert not is_terminal_run_status("running")
+    assert not is_terminal_run_status("started")
+
+
+def test_runs_poll_returns_completed_with_last_event(
+    gateway_client: TestClient,
+    gateway_auth_headers: dict,
+) -> None:
+    created = gateway_client.post(
+        "/v1/runs",
+        headers=gateway_auth_headers,
+        json={"input": "ping", "model": "default"},
+    )
+    assert created.status_code == 202
+    run_id = created.json()["run_id"]
+
+    result = poll_run(
+        lambda rid: gateway_client.get(
+            f"/v1/runs/{rid}",
+            headers=gateway_auth_headers,
+        ).json(),
+        run_id,
+        timeout=5.0,
+        interval=0.05,
+    )
+    assert result["status"] == "completed"
+    assert result["last_event"] == "run.completed"
+    assert result["completed"] is True
+    assert result["output"] == "ok"
+
+
+def test_runs_reject_empty_input(
+    gateway_client: TestClient,
+    gateway_auth_headers: dict,
+) -> None:
+    response = gateway_client.post(
+        "/v1/runs",
+        headers=gateway_auth_headers,
+        json={"input": "   ", "model": "default"},
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- `/v1/runs` now sets `last_event` through the lifecycle and returns `completed` with `completed: true` when the agent finishes
- Cancelled runs are no longer overwritten with `completed`
- `POST /v1/runs` returns 202, validates input, accepts `X-Holix-Profile` / session headers
- Adds `core.gateway.run_poll.poll_run()` for Hermes-style polling (`completed`, `failed`, `cancelled`, alias `done`)

## Test plan
- [x] `pytest tests/test_gateway_run_poll.py tests/test_gateway_hermes_compat.py::test_runs_lifecycle`