### PR TITLE
feat(telegram): production admin profile, menu access, gateway startup

### DIFF
--- a/api/gateway.py
+++ b/api/gateway.py
@@ -80,10 +80,21 @@ async def lifespan(app: FastAPI):
     gateway_deps.api_key_manager = state.api_key_manager
     gateway_deps.rate_limiter = state.rate_limiter
 
-    ensure_profile_memory_dirs(host_profile)
-    await state.registry.get_agent(host_profile)
-    await state.companions.start_cron(host_profile)
-    await state.companions.start_telegram(host_profile)
+    supervised = os.getenv("HOLIX_GATEWAY_SUPERVISOR", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+    async def _warm_gateway() -> None:
+        ensure_profile_memory_dirs(host_profile)
+        await state.registry.get_agent(host_profile)
+        if not supervised:
+            await state.companions.start_cron(host_profile)
+            await state.companions.start_telegram(host_profile)
+
+    asyncio.create_task(_warm_gateway(), name="holix-gateway-warm")
 
     yield
 

--- a/api/services/env_store.py
+++ b/api/services/env_store.py
@@ -73,6 +73,9 @@ def patch_global_env(variables: dict[str, str]) -> Path:
 
     path = ensure_global_env_template()
     patch_env_file(path, variables)
+    from core.profile_admin_seed import maybe_seed_admin_on_env_change
+
+    maybe_seed_admin_on_env_change(variables)
     return path
 
 

--- a/cli/services/gateway_daemon.py
+++ b/cli/services/gateway_daemon.py
@@ -127,8 +127,10 @@ def start_gateway_daemon(
 ) -> None:
     """Start gateway (+ companions) in background or foreground."""
     from core.env_loader import bootstrap_profile_env
+    from core.profile_admin_seed import ensure_admin_profile_from_default
 
     bootstrap_profile_env(profile)
+    ensure_admin_profile_from_default()
     existing = _running_state(profile)
     if existing is not None:
         print_error(

--- a/cli/services/supervisor.py
+++ b/cli/services/supervisor.py
@@ -158,6 +158,8 @@ async def _run_supervisor_async(
         companions.append("telegram (disabled)")
     print_info(f"Companion services: {', '.join(companions)}")
 
+    os.environ["HOLIX_GATEWAY_SUPERVISOR"] = "1"
+
     docs_proc = (
         _docs_subprocess(
             docs_host,

--- a/core/agent.py
+++ b/core/agent.py
@@ -301,7 +301,7 @@ class HolixAgent:
 
         from core.plan_review import init_plan_review_guard
 
-        init_plan_review_guard(
+        self._plan_review_guard = init_plan_review_guard(
             event_bus=self.events,
             interactive=interactive,
             review_timeout=self.config.plan_review_timeout,

--- a/core/gateway/profile_registry.py
+++ b/core/gateway/profile_registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from dishka import AsyncContainer
@@ -88,10 +88,13 @@ class ProfileAgentRegistry:
         from core.env_loader import bootstrap_profile_env
         from core.paths import ensure_profile_memory_dirs
 
-        bootstrap_profile_env(profile)
-        require_gateway_profile_unlock(profile)
-        ensure_profile_memory_dirs(profile)
-        runtime = resolve_runtime_config(init_profile(profile, prompt_key=False))
+        def _prepare_runtime() -> Any:
+            bootstrap_profile_env(profile)
+            require_gateway_profile_unlock(profile)
+            ensure_profile_memory_dirs(profile)
+            return resolve_runtime_config(init_profile(profile, prompt_key=False))
+
+        runtime = await asyncio.to_thread(_prepare_runtime)
         compat = create_compatibility_print_handler()
         agent, container = await create_agent(
             runtime,

--- a/core/i18n/messages.py
+++ b/core/i18n/messages.py
@@ -114,6 +114,9 @@ MESSAGES: dict[str, dict[str, str]] = {
         "tg.cmd.cron": "Cron jobs",
         "tg.cmd.message": "Admin broadcast (all or profile)",
         "tg.message_admin_only": "Only the Telegram bot admin can use /message.",
+        "tg.menu_unavailable": "This menu is not available for your account.",
+        "tg.mcp_read_only": "You can view MCP servers in your profile only. Installing or changing MCP is available to the bot admin.",
+        "tg.mcp_read_only_empty": "No MCP servers in your profile. Ask the bot admin to configure them.",
         "tg.message_help": (
             "<b>Admin broadcast</b>\n\n"
             "<code>/message all</code> — all approved users\n"
@@ -271,6 +274,9 @@ MESSAGES: dict[str, dict[str, str]] = {
         "tg.cmd.cron": "Периодические задачи",
         "tg.cmd.message": "Рассылка админа (всем или профилю)",
         "tg.message_admin_only": "Команда /message доступна только администратору бота.",
+        "tg.menu_unavailable": "Это меню недоступно для вашей учётной записи.",
+        "tg.mcp_read_only": "Доступен только просмотр MCP вашего профиля. Установка и изменение — у администратора бота.",
+        "tg.mcp_read_only_empty": "В вашем профиле нет MCP серверов. Попросите администратора бота настроить их.",
         "tg.message_help": (
             "<b>Рассылка администратора</b>\n\n"
             "<code>/message all</code> — всем одобренным пользователям\n"

--- a/core/presenters/live_buffer.py
+++ b/core/presenters/live_buffer.py
@@ -22,6 +22,9 @@ class LiveTranscriptBuffer:
     tool_lines: list[str] = field(default_factory=list)
     answer: str = ""
     notes: list[str] = field(default_factory=list)
+    # When True (Telegram), the final answer is posted as a separate chat message.
+    publish_answer_separately: bool = False
+    result_posted_separately: bool = False
     max_tool_lines: int = 8
     max_answer_chars: int = 2800
 

--- a/core/profile_admin_seed.py
+++ b/core/profile_admin_seed.py
@@ -1,0 +1,148 @@
+"""Ensure the Telegram admin Holix profile exists in production and mirrors ``default``."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from cli.core import ProfileManager
+
+
+def is_production_env() -> bool:
+    return os.getenv("HOLIX_ENV", "development").strip().lower() == "production"
+
+
+def _copy_profile_env_from_source(source_profile: str, target_profile: str) -> None:
+    from core.env_loader import holix_env_path, profile_env_path
+
+    try:
+        from dotenv import dotenv_values
+
+        from core.crypto.profile_files import dotenv_values_for_path
+    except ImportError:
+        return
+
+    source_env = profile_env_path(source_profile)
+    if not source_env.is_file():
+        return
+
+    source_values = {
+        key: value
+        for key, value in dotenv_values_for_path(source_env, profile=source_profile).items()
+        if value is not None and str(value).strip()
+    }
+    if not source_values:
+        return
+
+    global_values: dict[str, str | None] = {}
+    try:
+        from core.global_config import global_env_path
+
+        gpath = global_env_path()
+        if gpath.is_file():
+            global_values.update(dotenv_values(gpath))
+    except Exception:
+        pass
+    legacy = holix_env_path()
+    if legacy.is_file():
+        global_values.update(dotenv_values(legacy))
+
+    to_copy = {
+        key: value
+        for key, value in source_values.items()
+        if key not in global_values or global_values.get(key) != value
+    }
+    if not to_copy:
+        return
+
+    target_env = profile_env_path(target_profile)
+    target_env.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    if target_env.is_file():
+        lines.append(target_env.read_text(encoding="utf-8").rstrip())
+        lines.append("")
+    else:
+        lines.append(
+            f"# Copied from profile '{source_profile}' for production admin",
+        )
+    for key in sorted(to_copy):
+        lines.append(f"{key}={to_copy[key]}")
+    target_env.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def copy_profile_settings_from_source(
+    manager: ProfileManager,
+    *,
+    source_profile: str,
+    target_profile: str,
+) -> bool:
+    """Copy resolved config and env overrides from *source_profile* into *target_profile*."""
+    source_profile = (source_profile or "").strip()
+    target_profile = (target_profile or "").strip()
+    if not source_profile or not target_profile or source_profile == target_profile:
+        return False
+    if not manager.profile_exists(source_profile):
+        return False
+
+    from cli.core import ProfileConfig, resolve_profile_storage_paths
+
+    from core.global_config import extract_profile_overrides, load_global_config_resolved
+
+    source_cfg = manager.load_profile(source_profile)
+    payload = source_cfg.model_dump()
+    payload["profile_name"] = target_profile
+    target_cfg = ProfileConfig(**payload)
+    target_cfg = resolve_profile_storage_paths(
+        target_profile,
+        target_cfg,
+        profile_dir=manager.get_profile_dir(target_profile),
+    )
+    storage = extract_profile_overrides(
+        target_cfg.model_dump(),
+        load_global_config_resolved(),
+    )
+    manager._write_profile_yaml(target_profile, storage)
+    _copy_profile_env_from_source(source_profile, target_profile)
+    return True
+
+
+def ensure_admin_profile_from_default(
+    *,
+    admin_profile: str | None = None,
+    source_profile: str = "default",
+    manager: ProfileManager | None = None,
+) -> str | None:
+    """In production, create *admin_profile* and copy all settings from *source_profile*."""
+    if not is_production_env():
+        return None
+
+    from cli.core import ProfileManager as PM
+    from integrations.telegram.admin import DEFAULT_ADMIN_PROFILE
+
+    mgr = manager or PM()
+    target = (admin_profile or DEFAULT_ADMIN_PROFILE).strip() or DEFAULT_ADMIN_PROFILE
+    source = (source_profile or "default").strip() or "default"
+
+    if not mgr.profile_exists(source):
+        return target if mgr.profile_exists(target) else None
+
+    if not mgr.profile_exists(target):
+        mgr.create_profile(target, inherit_global=True)
+
+    copy_profile_settings_from_source(
+        mgr,
+        source_profile=source,
+        target_profile=target,
+    )
+    return target
+
+
+def maybe_seed_admin_on_env_change(variables: dict[str, Any]) -> None:
+    """After global env patch, seed admin profile when switching to production."""
+    raw = variables.get("HOLIX_ENV")
+    if raw is None:
+        return
+    if str(raw).strip().lower() != "production":
+        return
+    ensure_admin_profile_from_default()

--- a/integrations/telegram/access_approval.py
+++ b/integrations/telegram/access_approval.py
@@ -143,6 +143,16 @@ def approve_access_request(
     if set_admin and not manager.profile_exists(target_profile):
         manager.create_profile(target_profile, inherit_global=True)
 
+    if set_admin:
+        from core.profile_admin_seed import copy_profile_settings_from_source
+
+        if manager.profile_exists("default"):
+            copy_profile_settings_from_source(
+                manager,
+                source_profile="default",
+                target_profile=target_profile,
+            )
+
     access_key, key_already_set = _prepare_profile_for_user(
         manager,
         target_profile,

--- a/integrations/telegram/approvals.py
+++ b/integrations/telegram/approvals.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import secrets
 from typing import Any
 
 from core.plan_review.review_events import PlanReviewRequestEvent
@@ -10,6 +11,29 @@ from core.security.confirmation import ConfirmationChoice, get_action_guard
 from core.security.confirmation_events import ConfirmationRequestEvent
 
 from integrations.telegram.markdown import escape_html, plain_to_telegram_html
+
+# Telegram Bot API: callback_data must be 1–64 bytes.
+_TELEGRAM_CALLBACK_MAX_BYTES = 64
+
+
+def _register_callback_token(mapping: dict[str, str], full_id: str) -> str:
+    """Map a short opaque token to the full confirmation/review id."""
+    mapping.clear()
+    token = secrets.token_hex(4)
+    mapping[token] = full_id
+    return token
+
+
+def _lookup_callback_token(mapping: dict[str, str], token_or_id: str) -> str:
+    """Resolve short token; pass through when already a full id."""
+    return mapping.get(token_or_id, token_or_id)
+
+
+def _callback_data(*parts: str) -> str:
+    data = ":".join(parts)
+    if len(data.encode("utf-8")) > _TELEGRAM_CALLBACK_MAX_BYTES:
+        raise ValueError(f"Telegram callback_data too long ({len(data.encode('utf-8'))} bytes)")
+    return data
 
 
 class TelegramApprovals:
@@ -22,6 +46,10 @@ class TelegramApprovals:
     async def on_confirmation_request(self, event: ConfirmationRequestEvent) -> None:
         await self.dismiss_confirmation_ui()
         self._pending_confirm_id = event.confirmation_id
+        token = _register_callback_token(
+            self._session.approval_callback_tokens,
+            event.confirmation_id,
+        )
         risk = event.risk_level or "?"
         subagent = getattr(event, "subagent_name", "") or ""
         header = "<b>⚠ Confirmation required</b>"
@@ -46,12 +74,24 @@ class TelegramApprovals:
         kb = InlineKeyboardMarkup(
             inline_keyboard=[
                 [
-                    InlineKeyboardButton(text="✓ Once", callback_data=f"cfm:{event.confirmation_id}:1"),
-                    InlineKeyboardButton(text="✓ Session", callback_data=f"cfm:{event.confirmation_id}:2"),
+                    InlineKeyboardButton(
+                        text="✓ Once",
+                        callback_data=_callback_data("cfm", token, "1"),
+                    ),
+                    InlineKeyboardButton(
+                        text="✓ Session",
+                        callback_data=_callback_data("cfm", token, "2"),
+                    ),
                 ],
                 [
-                    InlineKeyboardButton(text="✓ Always", callback_data=f"cfm:{event.confirmation_id}:3"),
-                    InlineKeyboardButton(text="✗ Deny", callback_data=f"cfm:{event.confirmation_id}:4"),
+                    InlineKeyboardButton(
+                        text="✓ Always",
+                        callback_data=_callback_data("cfm", token, "3"),
+                    ),
+                    InlineKeyboardButton(
+                        text="✗ Deny",
+                        callback_data=_callback_data("cfm", token, "4"),
+                    ),
                 ],
             ]
         )
@@ -67,6 +107,10 @@ class TelegramApprovals:
         await self.dismiss_plan_review_ui()
         self._pending_review_id = event.review_id
         self._session.pending_plan_review_id = event.review_id
+        token = _register_callback_token(
+            self._session.plan_callback_tokens,
+            event.review_id,
+        )
         body = event.rendered_markdown or f"Plan with {event.step_count} steps"
         if len(body) > 3500:
             body = body[:3500] + "…"
@@ -75,12 +119,24 @@ class TelegramApprovals:
         kb = InlineKeyboardMarkup(
             inline_keyboard=[
                 [
-                    InlineKeyboardButton(text="Confirm step", callback_data=f"plan:{event.review_id}:confirm"),
-                    InlineKeyboardButton(text="Auto-run", callback_data=f"plan:{event.review_id}:auto"),
+                    InlineKeyboardButton(
+                        text="Confirm step",
+                        callback_data=_callback_data("plan", token, "confirm"),
+                    ),
+                    InlineKeyboardButton(
+                        text="Auto-run",
+                        callback_data=_callback_data("plan", token, "auto"),
+                    ),
                 ],
                 [
-                    InlineKeyboardButton(text="Refine", callback_data=f"plan:{event.review_id}:refine"),
-                    InlineKeyboardButton(text="Reject", callback_data=f"plan:{event.review_id}:reject"),
+                    InlineKeyboardButton(
+                        text="Refine",
+                        callback_data=_callback_data("plan", token, "refine"),
+                    ),
+                    InlineKeyboardButton(
+                        text="Reject",
+                        callback_data=_callback_data("plan", token, "reject"),
+                    ),
                 ],
             ]
         )
@@ -130,29 +186,85 @@ class TelegramApprovals:
         choice = choice_map.get(code)
         if choice is None:
             return False
+
+        full_id = _lookup_callback_token(
+            self._session.approval_callback_tokens,
+            confirmation_id,
+        )
+        if self._try_resolve_confirmation(full_id, choice):
+            self._pending_confirm_id = None
+            self._session.approval_callback_tokens.clear()
+            return True
+
+        # Fallback: match /yes behaviour (latest pending on this agent).
+        agent = self._session.agent
+        if agent:
+            from core.subagents.interaction import resolve_any_confirmation
+
+            if resolve_any_confirmation(agent, choice):
+                self._pending_confirm_id = None
+                self._session.approval_callback_tokens.clear()
+                return True
+
+        # Idempotent: user double-tapped after the action was already approved.
+        if self._confirmation_already_resolved(full_id):
+            self._pending_confirm_id = None
+            self._session.approval_callback_tokens.clear()
+            return True
+        return False
+
+    def _try_resolve_confirmation(
+        self,
+        confirmation_id: str,
+        choice: ConfirmationChoice,
+    ) -> bool:
         agent = self._session.agent
         if agent:
             from core.subagents.interaction import get_interaction_bridge
 
             bridge = get_interaction_bridge(agent)
             if bridge and bridge.resolve_confirmation(confirmation_id, choice):
-                self._pending_confirm_id = None
                 return True
 
         guard = self._guard()
-        if guard and guard.resolve_confirmation(confirmation_id, choice):
-            self._pending_confirm_id = None
-            return True
-        return False
+        return bool(guard and guard.resolve_confirmation(confirmation_id, choice))
+
+    def _confirmation_already_resolved(self, confirmation_id: str) -> bool:
+        """True when the request id is unknown because it was already settled."""
+        agent = self._session.agent
+        if agent:
+            from core.subagents.interaction import get_interaction_bridge
+
+            bridge = get_interaction_bridge(agent)
+            if bridge and confirmation_id in getattr(bridge, "_pending_confirmations", {}):
+                return False
+
+        guard = self._guard()
+        if guard and confirmation_id in guard._pending_confirmations:
+            return False
+        token = confirmation_id
+        if token in self._session.approval_callback_tokens:
+            return False
+        return self._pending_confirm_id in (None, confirmation_id)
 
     def _guard(self):
-        """Resolve the current ActionGuard (per-agent if present, else global)."""
+        """Resolve ActionGuard for the active Telegram session agent."""
         agent = self._session.agent
         if agent and getattr(agent, "tools", None):
             ag = getattr(agent.tools, "_action_guard", None)
             if ag:
                 return ag
-        return get_action_guard()
+        profile = getattr(self._session, "profile", None)
+        return get_action_guard(profile)
+
+    def _plan_guard(self):
+        """PlanReviewGuard tied to this chat's agent (not a stale global)."""
+        agent = self._session.agent
+        if agent:
+            guard = getattr(agent, "_plan_review_guard", None)
+            if guard:
+                return guard
+        return get_plan_review_guard()
 
     def resolve_plan_callback(self, review_id: str, action: str, *, feedback: str = "") -> bool:
         action_map = {
@@ -164,10 +276,26 @@ class TelegramApprovals:
         choice = action_map.get(action)
         if choice is None:
             return False
-        guard = get_plan_review_guard()
-        if guard.resolve_review(review_id, choice, feedback):
+
+        full_id = _lookup_callback_token(self._session.plan_callback_tokens, review_id)
+        guard = self._plan_guard()
+        if guard and guard.resolve_review(full_id, choice, feedback):
             self._pending_review_id = None
             self._session.pending_plan_review_id = None
+            self._session.plan_callback_tokens.clear()
+            return True
+
+        # Fallback: latest pending review on this agent's guard.
+        if guard and guard._pending_reviews:
+            latest_id = list(guard._pending_reviews.keys())[-1]
+            if guard.resolve_review(latest_id, choice, feedback):
+                self._pending_review_id = None
+                self._session.pending_plan_review_id = None
+                self._session.plan_callback_tokens.clear()
+                return True
+
+        if self._pending_review_id in (None, full_id, review_id):
+            self._session.plan_callback_tokens.clear()
             return True
         return False
 

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -21,6 +21,15 @@ from integrations.telegram.session import ChatSession
 from integrations.telegram.user_profiles import resolve_user_profile
 
 
+def _seed_admin_profile_background() -> None:
+    try:
+        from core.profile_admin_seed import ensure_admin_profile_from_default
+
+        ensure_admin_profile_from_default()
+    except Exception:
+        pass
+
+
 class HolixTelegramBot:
     def __init__(self, settings: TelegramSettings | None = None, *, profile: str = "default") -> None:
         self.settings = settings or load_telegram_settings(profile)
@@ -107,13 +116,19 @@ class HolixTelegramBot:
         except Exception:
             pass
 
-    async def _ensure_authorized_menu(self, bot: Any, chat_id: int) -> None:
+    async def _ensure_authorized_menu(self, bot: Any, chat_id: int, user_id: int) -> None:
         if self.settings.allow_all or chat_id in self._menu_enabled_chats:
             return
         from core.i18n import LocaleStore
 
         locale = LocaleStore(self.settings.profile).get()
-        await enable_chat_menu(bot, chat_id, locale=locale)
+        await enable_chat_menu(
+            bot,
+            chat_id,
+            locale=locale,
+            bot_profile=self.settings.profile,
+            user_id=user_id,
+        )
         self._menu_enabled_chats.add(chat_id)
 
     def _default_profile_for_user(self, user_id: int) -> str:
@@ -134,6 +149,8 @@ class HolixTelegramBot:
         session.pending_plan_review_id = None
         session.pending_confirmation_message_id = None
         session.pending_plan_message_ids.clear()
+        session.approval_callback_tokens.clear()
+        session.plan_callback_tokens.clear()
         session._recent_tool_results.clear()
         session._memory_search_query = ""
         session._memory_search_results.clear()
@@ -383,8 +400,14 @@ class HolixTelegramBot:
 
         @dp.startup()
         async def _on_startup() -> None:
+            import asyncio
+
             from core.i18n import LocaleStore
 
+            asyncio.create_task(
+                asyncio.to_thread(_seed_admin_profile_background),
+                name="tg-admin-profile-seed",
+            )
             locale = LocaleStore(settings.profile).get()
             registered = await register_bot_commands(
                 bot,
@@ -409,8 +432,14 @@ class HolixTelegramBot:
             if not self._allowed(message.from_user.id):
                 await self._handle_unauthorized(bot, message, is_start=True)
                 return
-            await self._ensure_authorized_menu(bot, message.chat.id)
-            await message.answer(help_message_html(), parse_mode="HTML")
+            await self._ensure_authorized_menu(bot, message.chat.id, message.from_user.id)
+            await message.answer(
+                help_message_html(
+                    bot_profile=settings.profile,
+                    user_id=message.from_user.id,
+                ),
+                parse_mode="HTML",
+            )
 
         @dp.message(Command(*menu_commands))
         async def on_menu_command(message: Message) -> None:
@@ -419,7 +448,20 @@ class HolixTelegramBot:
             if not self._allowed(message.from_user.id):
                 await self._handle_unauthorized(bot, message)
                 return
-            await self._ensure_authorized_menu(bot, message.chat.id)
+            from core.i18n import LocaleStore, t
+
+            from integrations.telegram.command_access import is_command_allowed
+            from integrations.telegram.markdown import escape_html
+
+            cmd_token = message.text.strip().split()[0].lstrip("/").lower()
+            if not is_command_allowed(cmd_token, settings.profile, message.from_user.id):
+                lang = LocaleStore(settings.profile).get()
+                await message.answer(
+                    escape_html(t("tg.menu_unavailable", lang)),
+                    parse_mode="HTML",
+                )
+                return
+            await self._ensure_authorized_menu(bot, message.chat.id, message.from_user.id)
             session = await self._get_session(message.chat.id, message.from_user.id)
             host = TelegramHost(bot, session, edit_interval_ms=settings.edit_interval_ms)
             await host.handle_user_text(message.text.strip())
@@ -431,7 +473,7 @@ class HolixTelegramBot:
             if not self._allowed(message.from_user.id):
                 await self._handle_unauthorized(bot, message)
                 return
-            await self._ensure_authorized_menu(bot, message.chat.id)
+            await self._ensure_authorized_menu(bot, message.chat.id, message.from_user.id)
             if message.text.strip().startswith("/"):
                 return
             if await self._flush_pending_files(
@@ -537,7 +579,10 @@ class HolixTelegramBot:
                 await approvals.dismiss_confirmation_ui()
                 await query.answer("Applied.")
             else:
-                await query.answer("Failed or expired.", show_alert=True)
+                await query.answer(
+                    "Could not apply. Tap the latest confirmation message or send /yes.",
+                    show_alert=True,
+                )
 
         @dp.callback_query(F.data.startswith("mcp:"))
         async def on_mcp_cb(query: CallbackQuery) -> None:
@@ -619,7 +664,10 @@ class HolixTelegramBot:
                 await approvals.dismiss_plan_review_ui()
                 await query.answer("Plan updated.")
             else:
-                await query.answer("Failed or expired.", show_alert=True)
+                await query.answer(
+                    "Could not apply. Use the latest plan message or reply in chat.",
+                    show_alert=True,
+                )
 
         self._bot = bot
         self._dp = dp

--- a/integrations/telegram/command_access.py
+++ b/integrations/telegram/command_access.py
@@ -1,0 +1,62 @@
+"""Per-user Telegram command and menu visibility in isolated multi-tenant mode."""
+
+from __future__ import annotations
+
+from integrations.telegram.access_approval import is_telegram_admin
+from integrations.telegram.commands import TelegramCommandSpec, command_specs
+from integrations.telegram.profile_visibility import is_profile_list_hidden
+
+# Hidden from slash menu for non-admins; invocation returns tg.menu_unavailable.
+ADMIN_ONLY_COMMANDS: frozenset[str] = frozenset({
+    "message",
+    "init",
+})
+
+# Hidden from inline status panel for non-admins.
+ADMIN_ONLY_MENU_ACTIONS: frozenset[str] = frozenset({
+    "profile",
+})
+
+
+def commands_restricted_for_user(bot_profile: str, user_id: int) -> bool:
+    return is_profile_list_hidden(bot_profile, user_id)
+
+
+def is_command_allowed(command: str, bot_profile: str, user_id: int) -> bool:
+    token = (command or "").strip().lstrip("/").split()[0].lower()
+    if not token:
+        return True
+    if not commands_restricted_for_user(bot_profile, user_id):
+        return True
+    if token not in ADMIN_ONLY_COMMANDS:
+        return True
+    return is_telegram_admin(bot_profile, user_id)
+
+
+def is_menu_action_allowed(action: str, bot_profile: str, user_id: int) -> bool:
+    if not commands_restricted_for_user(bot_profile, user_id):
+        return True
+    if action not in ADMIN_ONLY_MENU_ACTIONS:
+        return True
+    return is_telegram_admin(bot_profile, user_id)
+
+
+def is_mcp_management_allowed(bot_profile: str, user_id: int) -> bool:
+    """Install, assign, remove, test MCP — admin only in isolated multi-tenant mode."""
+    if not commands_restricted_for_user(bot_profile, user_id):
+        return True
+    return is_telegram_admin(bot_profile, user_id)
+
+
+def commands_for_user(
+    bot_profile: str,
+    user_id: int,
+    *,
+    locale: str | None = None,
+) -> list[TelegramCommandSpec]:
+    specs = command_specs(locale)
+    if not commands_restricted_for_user(bot_profile, user_id):
+        return specs
+    if is_telegram_admin(bot_profile, user_id):
+        return specs
+    return [spec for spec in specs if spec.command not in ADMIN_ONLY_COMMANDS]

--- a/integrations/telegram/commands.py
+++ b/integrations/telegram/commands.py
@@ -119,11 +119,35 @@ async def hide_chat_menu(bot: Any, chat_id: int) -> None:
         pass
 
 
+def _bot_commands_for_user(
+    locale: str | None,
+    *,
+    bot_profile: str | None = None,
+    user_id: int | None = None,
+) -> list[Any]:
+    if bot_profile is not None and user_id is not None:
+        from integrations.telegram.command_access import commands_for_user
+
+        specs = commands_for_user(bot_profile, int(user_id), locale=locale)
+    else:
+        specs = command_specs(locale)
+    try:
+        from aiogram.types import BotCommand
+    except ImportError:
+        return []
+    return [
+        BotCommand(command=spec.command, description=spec.description[:256])
+        for spec in specs
+    ]
+
+
 async def enable_chat_menu(
     bot: Any,
     chat_id: int,
     *,
     locale: str | None = None,
+    bot_profile: str | None = None,
+    user_id: int | None = None,
 ) -> list[str]:
     """Enable slash-command menu for one authorized private chat."""
     try:
@@ -131,7 +155,11 @@ async def enable_chat_menu(
     except ImportError:
         return []
 
-    commands = _bot_commands_for_locale(locale)
+    commands = _bot_commands_for_user(
+        locale,
+        bot_profile=bot_profile,
+        user_id=user_id if user_id is not None else int(chat_id),
+    )
     if not commands:
         return []
 
@@ -142,7 +170,7 @@ async def enable_chat_menu(
         await bot.set_chat_menu_button(chat_id=cid, menu_button=MenuButtonCommands())
     except Exception:
         pass
-    return [spec.command for spec in command_specs(locale)]
+    return [cmd.command for cmd in commands]
 
 
 async def register_global_bot_commands(bot: Any, *, locale: str | None = None) -> list[str]:
@@ -185,7 +213,13 @@ async def register_bot_commands(
     await clear_default_bot_menu(bot)
     names: list[str] = []
     for uid in sorted(authorized_telegram_user_ids(bot_profile)):
-        names = await enable_chat_menu(bot, uid, locale=locale)
+        names = await enable_chat_menu(
+            bot,
+            uid,
+            locale=locale,
+            bot_profile=bot_profile,
+            user_id=uid,
+        )
     return names
 
 
@@ -210,9 +244,20 @@ async def sync_bot_menu(profile: str = "default") -> list[str]:
         await bot.session.close()
 
 
-def help_message_html(locale: str | None = None) -> str:
+def help_message_html(
+    locale: str | None = None,
+    *,
+    bot_profile: str | None = None,
+    user_id: int | None = None,
+) -> str:
     """HTML help for /help and /start."""
     loc = locale or DEFAULT_LOCALE
+    if bot_profile is not None and user_id is not None:
+        from integrations.telegram.command_access import commands_for_user
+
+        specs = commands_for_user(bot_profile, int(user_id), locale=loc)
+    else:
+        specs = command_specs(loc)
     lines = [
         f"<b>{escape_html_simple(t('tg.help.title', loc))}</b>",
         "",
@@ -221,7 +266,7 @@ def help_message_html(locale: str | None = None) -> str:
         "",
         f"<b>{escape_html_simple(t('tg.help.commands', loc))}</b>",
     ]
-    for spec in command_specs(loc):
+    for spec in specs:
         lines.append(
             f"• <code>/{spec.command}</code> — {escape_html_simple(spec.description)}"
         )

--- a/integrations/telegram/event_handler.py
+++ b/integrations/telegram/event_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import TYPE_CHECKING
 
 from core.agent_events import (
@@ -24,6 +25,8 @@ from core.plan_review.review_events import PlanReviewRequestEvent
 from core.security.confirmation_events import ConfirmationRequestEvent
 from core.subagents.interaction_events import SubAgentQuestionEvent
 
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     from integrations.telegram.approvals import TelegramApprovals
     from integrations.telegram.live_presenter import TelegramLivePresenter
@@ -37,6 +40,14 @@ class TelegramEventHandler:
     ) -> None:
         self._presenter = presenter
         self._approvals = approvals
+
+    @staticmethod
+    def _schedule_task(coro) -> None:
+        """Schedule a coroutine; requires a running loop (Telegram polling)."""
+        try:
+            asyncio.get_running_loop().create_task(coro)
+        except RuntimeError:
+            logger.warning("Telegram handler: no event loop; skipped async delivery")
 
     def handle(self, event: AgentEvent) -> None:
         buf = self._presenter.buffer
@@ -80,32 +91,25 @@ class TelegramEventHandler:
                 self._presenter.schedule_edit()
 
             elif isinstance(event, AssistantDeltaEvent):
-                buf.append_answer_delta(event.content)
-                self._presenter.schedule_edit()
+                # Final text is always delivered in a separate chat message.
+                pass
 
             elif isinstance(event, FinalResponseEvent):
                 buf.set_thinking(None)
-                content = event.content or ""
-                if content.strip():
+                content = (event.content or "").strip()
+                if not content:
+                    recent = self._presenter.session._recent_tool_results
+                    if recent:
+                        content = str(recent[-1].get("full_result") or "").strip()
+                if content:
                     self._presenter.session._transcript_store.append(
                         "assistant",
                         content,
                         markdown=content,
                     )
-                # For very long final answers, send the full content split across
-                # multiple Telegram messages (point 3), and keep the live status
-                # message short so it doesn't hit the size limit or duplicate.
-                if len(content) > 2200:
-                    buf.set_answer("📄 Long response follows in chat.")
-                    try:
-                        asyncio.create_task(
-                            self._presenter.send_final_answer_split(content)
-                        )
-                    except Exception:
-                        # fallback to (capped) answer in the status msg
-                        buf.set_answer(content[:2000] + "…")
-                else:
-                    buf.set_answer(content)
+                    buf.result_posted_separately = True
+                    self._schedule_task(self._presenter.deliver_result(content))
+                buf.set_answer("")
                 buf.mark_done()
                 self._presenter.schedule_edit(force=True)
 
@@ -162,7 +166,11 @@ class TelegramEventHandler:
                 self._presenter.schedule_edit()
 
             elif isinstance(event, ErrorEvent):
-                buf.mark_error(str(event.error or "unknown"))
+                err = str(event.error or "unknown")
+                buf.mark_error(err)
+                self._schedule_task(
+                    self._presenter.deliver_result(f"✗ **Ошибка:** {err}")
+                )
                 self._presenter.schedule_edit(force=True)
 
         except Exception as exc:

--- a/integrations/telegram/host.py
+++ b/integrations/telegram/host.py
@@ -339,6 +339,14 @@ class TelegramHost:
             preview = (e["full_result"] or "").split("\n")[0][:60]
             self.transcript_write(f"{i}. {e['name']} — {preview}")
 
+    def _mcp_management_allowed(self) -> bool:
+        from integrations.telegram.command_access import is_mcp_management_allowed
+
+        return is_mcp_management_allowed(
+            self._session.bot_profile,
+            self._session.user_id,
+        )
+
     async def _mcp_list(self) -> None:
         """List MCP servers from current profile config."""
         try:
@@ -362,6 +370,9 @@ class TelegramHost:
 
     async def _mcp_install(self, what: str = "") -> None:
         """Install popular or from git. For interactive use Telegram menus or CLI."""
+        if not self._mcp_management_allowed():
+            await self._send_html(t("tg.mcp_read_only", host_locale(self)))
+            return
         if not what:
             self.transcript_write("Usage: /mcp install <popular-key|git-url>\nPopular: context7, filesystem, github, ... \nOr use the /mcp menu buttons.")
             return
@@ -442,6 +453,9 @@ class TelegramHost:
 
     async def _mcp_assign(self, rest: str = "") -> None:
         """Basic assign: /mcp assign server main,researcher"""
+        if not self._mcp_management_allowed():
+            await self._send_html(t("tg.mcp_read_only", host_locale(self)))
+            return
         if not rest:
             self.transcript_write("Usage: /mcp assign <server-name> <role1,role2>\nExample: /mcp assign context7 main")
             return
@@ -475,6 +489,9 @@ class TelegramHost:
             self.transcript_write(f"Assign error: {e}")
 
     async def _mcp_test(self, name: str = "") -> None:
+        if not self._mcp_management_allowed():
+            await self._send_html(t("tg.mcp_read_only", host_locale(self)))
+            return
         if not name:
             self.transcript_write("Usage: /mcp test <server-name>")
             return
@@ -511,6 +528,9 @@ class TelegramHost:
             self.transcript_write(f"Error listing MCP tools: {e}")
 
     async def _mcp_remove(self, name: str = "") -> None:
+        if not self._mcp_management_allowed():
+            await self._send_html(t("tg.mcp_read_only", host_locale(self)))
+            return
         if not name:
             self.transcript_write("Usage: /mcp remove <server-name>")
             return
@@ -638,6 +658,10 @@ class TelegramHost:
         if not self.agent:
             await self._send_plain("agent not ready")
             return
+        async with self._session.run_lock:
+            await self._run_agent_locked(user_input)
+
+    async def _run_agent_locked(self, user_input: str) -> None:
         from core.session_models import ensure_session_model
 
         ensure_session_model(self)

--- a/integrations/telegram/interactive.py
+++ b/integrations/telegram/interactive.py
@@ -75,6 +75,19 @@ class TelegramInteractive:
     def _session(self) -> Any:
         return self._host._session
 
+    async def _deny_menu_command(self, command_token: str) -> bool:
+        from integrations.telegram.command_access import is_command_allowed
+
+        if is_command_allowed(
+            command_token,
+            self._session.bot_profile,
+            self._session.user_id,
+        ):
+            return False
+        lang = host_locale(self._host)
+        await self._host._send_html(escape_html(t("tg.menu_unavailable", lang)))
+        return True
+
     async def handle_slash(self, command: str) -> bool:
         """Return True if handled (skip AgentCommands)."""
         from cli.shared.slash_input import (
@@ -88,6 +101,9 @@ class TelegramInteractive:
         lower = cmd.lower()
         parts = lower.split()
         cmd_token = slash_command_token(cmd)
+
+        if await self._deny_menu_command(cmd_token.lstrip("/").split()[0]):
+            return True
 
         if is_models_slash(cmd):
             await self.show_models()
@@ -315,23 +331,43 @@ class TelegramInteractive:
                 trans = data.get("transport", "stdio")
                 text_lines.append(f"• <code>{escape_html(name)}</code> ({trans}) [{src}]")
 
-        kb_rows = [
+        from integrations.telegram.command_access import is_mcp_management_allowed
+
+        can_manage_mcp = is_mcp_management_allowed(
+            self._session.bot_profile,
+            self._session.user_id,
+        )
+        kb_rows: list[list[InlineKeyboardButton]] = [
             [
                 InlineKeyboardButton(text="📋 List", callback_data="mcp:list"),
-                InlineKeyboardButton(text="🛠 Install popular", callback_data="mcp:install-popular"),
-            ],
-            [
-                InlineKeyboardButton(text="➕ Install from git", callback_data="mcp:install-git"),
-                InlineKeyboardButton(text="🔗 Assign to agents", callback_data="mcp:assign"),
-            ],
-            [
-                InlineKeyboardButton(text="🧪 Test server", callback_data="mcp:test"),
-                InlineKeyboardButton(text="🗑 Remove server", callback_data="mcp:remove"),
+                InlineKeyboardButton(text="🔧 Tools", callback_data="mcp:tools"),
             ],
             [
                 InlineKeyboardButton(text="🔄 Refresh", callback_data="mcp:refresh"),
             ],
         ]
+        if can_manage_mcp:
+            kb_rows = [
+                [
+                    InlineKeyboardButton(text="📋 List", callback_data="mcp:list"),
+                    InlineKeyboardButton(text="🛠 Install popular", callback_data="mcp:install-popular"),
+                ],
+                [
+                    InlineKeyboardButton(text="➕ Install from git", callback_data="mcp:install-git"),
+                    InlineKeyboardButton(text="🔗 Assign to agents", callback_data="mcp:assign"),
+                ],
+                [
+                    InlineKeyboardButton(text="🧪 Test server", callback_data="mcp:test"),
+                    InlineKeyboardButton(text="🗑 Remove server", callback_data="mcp:remove"),
+                ],
+                [
+                    InlineKeyboardButton(text="🔄 Refresh", callback_data="mcp:refresh"),
+                ],
+            ]
+        elif not servers:
+            text_lines.append(
+                f"\n<i>{escape_html(t('tg.mcp_read_only_empty', host_locale(host)))}</i>"
+            )
 
         # If specific subcommand, handle simply
         if len(parts) > 1:
@@ -345,6 +381,12 @@ class TelegramInteractive:
                 else:
                     await host._mcp_list_tools()
                 return
+            if sub in ("install", "add", "assign", "remove", "rm", "delete", "test"):
+                if not can_manage_mcp:
+                    await self._host._send_html(
+                        escape_html(t("tg.mcp_read_only", host_locale(host)))
+                    )
+                    return
             if sub in ("install", "add"):
                 arg = " ".join(parts[2:]) if len(parts) > 2 else ""
                 host.run_worker(host._mcp_install(arg))
@@ -507,6 +549,17 @@ class TelegramInteractive:
         return t("tg.unknown_action", host_locale(self._host))
 
     async def _refresh(self, kind: str) -> None:
+        from integrations.telegram.command_access import is_menu_action_allowed
+
+        if not is_menu_action_allowed(
+            kind,
+            self._session.bot_profile,
+            self._session.user_id,
+        ):
+            lang = host_locale(self._host)
+            await self._host._send_html(escape_html(t("tg.menu_unavailable", lang)))
+            return
+
         if kind == "compress":
             from cli.shared.commands.context_compress import run_context_compress
 
@@ -574,11 +627,27 @@ class TelegramInteractive:
             profile_picker_keyboard(profiles, current),
         )
 
+    async def _deny_mcp_management(self) -> None:
+        lang = host_locale(self._host)
+        await self._host._send_html(escape_html(t("tg.mcp_read_only", lang)))
+
     async def _handle_mcp_callback(self, value: str) -> None:
         """Handle mcp:* callbacks from the MCP menu."""
+        from integrations.telegram.command_access import is_mcp_management_allowed
+
         host = self._host
+        can_manage = is_mcp_management_allowed(
+            self._session.bot_profile,
+            self._session.user_id,
+        )
         if value == "list" or value == "refresh":
             await host._mcp_list()
+            return
+        if value == "tools":
+            await host._mcp_list_tools()
+            return
+        if not can_manage:
+            await self._deny_mcp_management()
             return
         if value == "install-popular":
             await self._show_mcp_popular_picker()
@@ -872,9 +941,12 @@ class TelegramInteractive:
             f"Субагенты: <code>{subagents}</code>",
             f"Сессия: <code>{escape_html(self._host.conversation_id)}</code>",
         ]
+        from integrations.telegram.access_approval import is_telegram_admin
+
+        is_admin = is_telegram_admin(self._session.bot_profile, self._session.user_id)
         await self._host._send_html_with_keyboard(
             "\n".join(lines),
-            status_menu_keyboard(host_locale(self._host)),
+            status_menu_keyboard(host_locale(self._host), is_admin=is_admin),
         )
 
 

--- a/integrations/telegram/keyboards.py
+++ b/integrations/telegram/keyboards.py
@@ -325,17 +325,22 @@ def models_provider_keyboard(
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
-def status_menu_keyboard(locale: str | None = None) -> Any:
+def status_menu_keyboard(locale: str | None = None, *, is_admin: bool = True) -> Any:
     from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
     from core.i18n.messages import t
 
     loc = locale or "en"
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [
-                InlineKeyboardButton(text=t("tg.menu.mode", loc), callback_data=_cb("r", "mode")),
-                InlineKeyboardButton(text=t("tg.menu.profile", loc), callback_data=_cb("r", "profile")),
-            ],
+    rows: list[list[Any]] = [
+        [
+            InlineKeyboardButton(text=t("tg.menu.mode", loc), callback_data=_cb("r", "mode")),
+        ],
+    ]
+    if is_admin:
+        rows[0].append(
+            InlineKeyboardButton(text=t("tg.menu.profile", loc), callback_data=_cb("r", "profile")),
+        )
+    rows.extend(
+        [
             [
                 InlineKeyboardButton(text=t("tg.menu.sessions", loc), callback_data=_cb("r", "sessions")),
                 InlineKeyboardButton(text=t("tg.menu.streaming", loc), callback_data=_cb("r", "stream")),
@@ -347,11 +352,12 @@ def status_menu_keyboard(locale: str | None = None) -> Any:
             [
                 InlineKeyboardButton(text=t("tg.menu.compress", loc), callback_data=_cb("r", "compress")),
             ],
-            [
-                InlineKeyboardButton(text="Cron", callback_data=_cb("r", "cron")),
-            ],
         ]
     )
+    rows.append(
+        [InlineKeyboardButton(text="Cron", callback_data=_cb("r", "cron"))],
+    )
+    return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
 def access_request_admin_keyboard(user_id: int) -> Any:

--- a/integrations/telegram/live_presenter.py
+++ b/integrations/telegram/live_presenter.py
@@ -34,6 +34,7 @@ class TelegramLivePresenter:
     async def start(self) -> None:
         self.session.bump_live_buffer()
         self._buffer = self.session.live_buffer
+        self._buffer.publish_answer_separately = True
         text = buffer_to_telegram_html(self._buffer)
         msg = await self._bot.send_message(
             self.session.chat_id,
@@ -64,8 +65,13 @@ class TelegramLivePresenter:
         try:
             await self._edit_html(text)
         except Exception:
-            answer = (self._buffer.answer or "").strip()
-            fallback = plain_to_telegram_html(answer or "…")
+            if self._buffer.status == "done":
+                fallback = "<i>✓ Готово</i>"
+            elif self._buffer.status == "error":
+                fallback = "<b>✗ Ошибка</b>"
+            else:
+                answer = (self._buffer.answer or "").strip()
+                fallback = plain_to_telegram_html(answer or "<i>⏳ Working…</i>")
             try:
                 await self._edit_html(truncate_telegram_html(fallback))
             except Exception:
@@ -85,6 +91,10 @@ class TelegramLivePresenter:
             plain_to_telegram_html(text),
             parse_mode="HTML",
         )
+
+    async def deliver_result(self, content: str) -> None:
+        """Post the final agent/work result as one or more new chat messages."""
+        await self.send_final_answer_split(content)
 
     async def send_final_answer_split(self, content: str) -> None:
         """Send a (potentially long) final assistant response as 1+ messages.

--- a/integrations/telegram/render.py
+++ b/integrations/telegram/render.py
@@ -20,7 +20,14 @@ def buffer_to_telegram_html(buf: LiveTranscriptBuffer) -> str:
     done = buf.status == "done"
     show_tools = bool(buf.tool_lines) and not done
 
-    if done and answer and not show_tools and not buf.thinking and not buf.notes:
+    if (
+        done
+        and answer
+        and not buf.publish_answer_separately
+        and not show_tools
+        and not buf.thinking
+        and not buf.notes
+    ):
         body = markdown_to_telegram_html(answer)
         footer = (
             f"<i>🤖 {escape_html(buf.profile)} · {escape_html(buf.mode)} · ✓</i>"
@@ -43,7 +50,7 @@ def buffer_to_telegram_html(buf: LiveTranscriptBuffer) -> str:
             tool_html.append(_format_tool_line(line))
         parts.append("\n".join(tool_html))
 
-    if answer:
+    if answer and not (done and buf.publish_answer_separately):
         rendered = markdown_to_telegram_html(answer)
         parts.append(rendered if rendered else escape_html(answer))
 
@@ -53,10 +60,12 @@ def buffer_to_telegram_html(buf: LiveTranscriptBuffer) -> str:
 
     if running and not answer and not buf.tool_lines:
         parts.append("<i>⏳ Working…</i>")
-    elif done and answer:
+    elif done:
         parts.append(
             f"<i>🤖 {escape_html(buf.profile)} · {escape_html(buf.mode)} · ✓</i>"
         )
+        if buf.publish_answer_separately and buf.result_posted_separately:
+            parts.append("<i>Ответ отправлен отдельным сообщением ↓</i>")
     elif buf.status == "error":
         parts.append("<b>✗ Error</b>")
 

--- a/integrations/telegram/session.py
+++ b/integrations/telegram/session.py
@@ -38,6 +38,9 @@ class ChatSession:
     pending_plan_review_id: str | None = None
     pending_confirmation_message_id: int | None = None
     pending_plan_message_ids: list[int] = field(default_factory=list)
+    # Short tokens for Telegram inline buttons (callback_data max 64 bytes).
+    approval_callback_tokens: dict[str, str] = field(default_factory=dict)
+    plan_callback_tokens: dict[str, str] = field(default_factory=dict)
     agent: Any = None
     profile_manual_override: bool = False
     ui_profiles: list[str] = field(default_factory=list)

--- a/tests/test_profile_admin_seed.py
+++ b/tests/test_profile_admin_seed.py
@@ -1,0 +1,81 @@
+"""Production admin profile seeding from default."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from cli.core import ProfileManager
+from core.profile_admin_seed import (
+    copy_profile_settings_from_source,
+    ensure_admin_profile_from_default,
+    is_production_env,
+)
+
+
+@pytest.fixture
+def holix_home(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import cli.core as cli_core
+
+    root = tmp_path / "holix"
+    profiles = root / "profiles"
+    profiles.mkdir(parents=True)
+    (root / "global").mkdir(parents=True)
+    (root / "global" / "config.yaml").write_text("model: global-model\n", encoding="utf-8")
+    monkeypatch.setenv("HOLIX_HOME", str(root))
+    monkeypatch.setattr(cli_core, "HOLIX_HOME", root)
+    monkeypatch.setattr(cli_core, "PROFILES_DIR", profiles)
+    return root
+
+
+def test_is_production_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOLIX_ENV", "production")
+    assert is_production_env()
+    monkeypatch.setenv("HOLIX_ENV", "development")
+    assert not is_production_env()
+
+
+def test_ensure_admin_creates_and_copies_from_default(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOLIX_ENV", "production")
+    manager = ProfileManager()
+    manager.create_profile("default", inherit_global=True)
+    default_cfg = manager.load_profile("default")
+    default_cfg.model = "copied-model"
+    default_cfg.temperature = 0.42
+    manager.save_profile("default", default_cfg)
+
+    result = ensure_admin_profile_from_default(manager=manager)
+    assert result == "admin"
+    assert manager.profile_exists("admin")
+
+    admin_cfg = manager.load_profile("admin")
+    assert admin_cfg.model == "copied-model"
+    assert admin_cfg.temperature == 0.42
+
+    raw = yaml.safe_load((manager.get_profile_dir("admin") / "config.yaml").read_text(encoding="utf-8"))
+    assert raw.get("model") == "copied-model"
+
+
+def test_no_seed_outside_production(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOLIX_ENV", "development")
+    manager = ProfileManager()
+    manager.create_profile("default", inherit_global=True)
+
+    assert ensure_admin_profile_from_default(manager=manager) is None
+    assert not manager.profile_exists("admin")
+
+
+def test_copy_profile_settings_updates_existing_admin(holix_home) -> None:
+    manager = ProfileManager()
+    manager.create_profile("default", inherit_global=True)
+    manager.create_profile("admin", inherit_global=True)
+
+    default_cfg = manager.load_profile("default")
+    default_cfg.max_steps = 17
+    manager.save_profile("default", default_cfg)
+
+    assert copy_profile_settings_from_source(
+        manager,
+        source_profile="default",
+        target_profile="admin",
+    )
+    assert manager.load_profile("admin").max_steps == 17

--- a/tests/test_telegram_approvals.py
+++ b/tests/test_telegram_approvals.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from integrations.telegram.approvals import TelegramApprovals
+from core.security.confirmation import ConfirmationChoice, init_action_guard
+from integrations.telegram.approvals import (
+    TelegramApprovals,
+    _callback_data,
+    _register_callback_token,
+)
 from integrations.telegram.session import ChatSession
 
 
@@ -55,3 +61,55 @@ async def test_dismiss_confirmation_ignores_delete_errors(
     approvals._bot.delete_message.side_effect = Exception("already gone")
     await approvals.dismiss_confirmation_ui()
     assert session.pending_confirmation_message_id is None
+
+
+def test_callback_data_stays_within_telegram_limit() -> None:
+    token = _register_callback_token({}, "confirm_99_" + "x" * 80)
+    assert len(_callback_data("cfm", token, "1").encode("utf-8")) <= 64
+
+
+def test_resolve_confirmation_via_short_token(
+    approvals: TelegramApprovals, session: ChatSession
+) -> None:
+    agent = MagicMock()
+    agent.tools = MagicMock()
+    agent.subagents = None
+    bus = MagicMock()
+    guard = init_action_guard(event_bus=bus, confirmation_timeout=0)
+    agent.tools._action_guard = guard
+    session.agent = agent
+
+    loop = asyncio.new_event_loop()
+    try:
+        future = loop.create_future()
+        guard._pending_confirmations["confirm_1_tg_default_100"] = future
+        token = _register_callback_token(
+            session.approval_callback_tokens,
+            "confirm_1_tg_default_100",
+        )
+        assert approvals.resolve_confirmation_callback(token, "1") is True
+        assert future.result() == ConfirmationChoice.ALLOW_ONCE
+    finally:
+        loop.close()
+
+
+def test_resolve_confirmation_fallback_to_latest_pending(
+    approvals: TelegramApprovals, session: ChatSession
+) -> None:
+    agent = MagicMock()
+    agent.tools = MagicMock()
+    agent.subagents = None
+    bus = MagicMock()
+    guard = init_action_guard(event_bus=bus, confirmation_timeout=0)
+    agent.tools._action_guard = guard
+    session.agent = agent
+
+    loop = asyncio.new_event_loop()
+    try:
+        future = loop.create_future()
+        guard._pending_confirmations["confirm_2_tg_default_100"] = future
+        # Wrong/stale id from an old inline keyboard — should still resolve latest.
+        assert approvals.resolve_confirmation_callback("stale_token", "2") is True
+        assert future.result() == ConfirmationChoice.ALLOW_SESSION
+    finally:
+        loop.close()

--- a/tests/test_telegram_command_access.py
+++ b/tests/test_telegram_command_access.py
@@ -1,0 +1,162 @@
+"""Telegram command and menu access for non-admin users."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from integrations.telegram.admin import set_admin_user
+from integrations.telegram.command_access import (
+    ADMIN_ONLY_COMMANDS,
+    commands_for_user,
+    is_command_allowed,
+    is_mcp_management_allowed,
+    is_menu_action_allowed,
+)
+from integrations.telegram.commands import help_message_html
+from integrations.telegram.env_store import save_telegram_env
+from integrations.telegram.keyboards import status_menu_keyboard
+from integrations.telegram.session import ChatSession
+
+
+@pytest.fixture
+def holix_home(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import cli.core as cli_core
+
+    root = tmp_path / "holix"
+    profiles = root / "profiles"
+    profiles.mkdir(parents=True)
+    monkeypatch.setenv("HOLIX_HOME", str(root))
+    monkeypatch.setattr(cli_core, "HOLIX_HOME", root)
+    monkeypatch.setattr(cli_core, "PROFILES_DIR", profiles)
+    return root
+
+
+def _isolated_bot(bot_profile: str = "shared") -> None:
+    import os
+
+    os.environ.pop("HOLIX_TELEGRAM_ALLOW_ALL", None)
+    save_telegram_env(
+        {
+            "TELEGRAM_BOT_TOKEN": "1:abc",
+            "HOLIX_TELEGRAM_ACCESS_REQUESTS": "true",
+        },
+        profile=bot_profile,
+    )
+    set_admin_user(bot_profile, 900)
+
+
+def test_non_admin_commands_filtered(holix_home) -> None:
+    _isolated_bot()
+    names = {spec.command for spec in commands_for_user("shared", 77, locale="en")}
+    assert "help" in names
+    assert "status" in names
+    assert "cron" in names
+    assert "mcp" in names
+    assert ADMIN_ONLY_COMMANDS.isdisjoint(names)
+
+
+def test_admin_sees_all_commands(holix_home) -> None:
+    _isolated_bot()
+    names = {spec.command for spec in commands_for_user("shared", 900, locale="en")}
+    assert "message" in names
+    assert "cron" in names
+    assert "mcp" in names
+
+
+def test_is_command_allowed_blocks_message_for_non_admin(holix_home) -> None:
+    _isolated_bot()
+    assert not is_command_allowed("message", "shared", 77)
+    assert is_command_allowed("message", "shared", 900)
+    assert is_command_allowed("help", "shared", 77)
+    assert is_command_allowed("cron", "shared", 77)
+    assert is_command_allowed("mcp", "shared", 77)
+
+
+def test_help_html_hides_admin_commands_for_non_admin(holix_home) -> None:
+    _isolated_bot()
+    html = help_message_html("en", bot_profile="shared", user_id=77)
+    assert "<code>/message</code>" not in html
+    assert "<code>/cron</code>" in html
+    assert "<code>/mcp</code>" in html
+    assert "<code>/help</code>" in html
+
+
+def test_status_menu_hides_profile_but_shows_cron_for_non_admin() -> None:
+    pytest.importorskip("aiogram.types")
+    kb = status_menu_keyboard("en", is_admin=False)
+    labels = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert "Profile" not in labels
+    assert "Cron" in labels
+    assert "Mode" in labels
+
+
+def test_menu_action_allows_cron_for_non_admin(holix_home) -> None:
+    _isolated_bot()
+    assert is_menu_action_allowed("cron", "shared", 77)
+    assert not is_menu_action_allowed("profile", "shared", 77)
+    assert is_menu_action_allowed("profile", "shared", 900)
+
+
+def test_mcp_management_admin_only_in_isolated_mode(holix_home) -> None:
+    _isolated_bot()
+    assert not is_mcp_management_allowed("shared", 77)
+    assert is_mcp_management_allowed("shared", 900)
+
+
+@pytest.mark.asyncio
+async def test_interactive_allows_cron_for_non_admin(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolated_bot()
+    from integrations.telegram.interactive import TelegramInteractive
+
+    host = MagicMock()
+    host._session = ChatSession(
+        chat_id=1,
+        user_id=77,
+        profile="alice",
+        conversation_id="tg_alice_1",
+        bot_profile="shared",
+    )
+    host.profile = "alice"
+    host._send_html_with_keyboard = AsyncMock()
+    host._execution_modes = ["react"]
+    host.streaming_enabled = False
+    host.agent = None
+
+    show_cron = AsyncMock()
+    monkeypatch.setattr(TelegramInteractive, "show_cron_menu", show_cron)
+
+    handled = await TelegramInteractive(host).handle_slash("/cron")
+    assert handled is True
+    show_cron.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mcp_menu_read_only_for_non_admin(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolated_bot()
+    from integrations.telegram.interactive import TelegramInteractive
+
+    host = MagicMock()
+    host._session = ChatSession(
+        chat_id=1,
+        user_id=77,
+        profile="alice",
+        conversation_id="tg_alice_1",
+        bot_profile="shared",
+    )
+    host.profile = "alice"
+    host._send_html_with_keyboard = AsyncMock()
+    host._send_html = AsyncMock()
+
+    monkeypatch.setattr(
+        "cli.core.get_profile_manager",
+        lambda: MagicMock(
+            load_profile=MagicMock(return_value=MagicMock(mcp_servers={}, mcp_assignments={}))
+        ),
+    )
+
+    await TelegramInteractive(host).show_mcp_menu("/mcp")
+    kb = host._send_html_with_keyboard.await_args.args[1]
+    labels = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert "Install popular" not in " ".join(labels)
+    assert "List" in " ".join(labels)

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -136,7 +136,13 @@ async def test_register_bot_commands_per_user_when_not_allow_all(
     names = await register_bot_commands(bot, locale="en", bot_profile="default")
 
     assert names == ["help"]
-    enable_mock.assert_awaited_once_with(bot, 42, locale="en")
+    enable_mock.assert_awaited_once_with(
+        bot,
+        42,
+        locale="en",
+        bot_profile="default",
+        user_id=42,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_event_handler.py
+++ b/tests/test_telegram_event_handler.py
@@ -1,0 +1,63 @@
+"""Telegram agent event → message delivery."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from core.agent_events import FinalResponseEvent
+from core.presenters.live_buffer import LiveTranscriptBuffer
+from integrations.telegram.event_handler import TelegramEventHandler
+from integrations.telegram.session import ChatSession
+
+
+@pytest.fixture
+def handler_setup() -> tuple[TelegramEventHandler, MagicMock, ChatSession]:
+    session = ChatSession(
+        chat_id=1,
+        user_id=2,
+        profile="docs",
+        conversation_id="tg_docs_1",
+    )
+    session.live_buffer = LiveTranscriptBuffer(profile="docs", mode="react")
+    session.live_buffer.publish_answer_separately = True
+
+    presenter = MagicMock()
+    presenter.session = session
+    presenter.buffer = session.live_buffer
+    presenter.deliver_result = AsyncMock()
+
+    approvals = MagicMock()
+    handler = TelegramEventHandler(presenter, approvals)
+    return handler, presenter, session
+
+
+@pytest.mark.asyncio
+async def test_final_response_always_delivered_separately(
+    handler_setup: tuple[TelegramEventHandler, MagicMock, ChatSession],
+) -> None:
+    handler, presenter, session = handler_setup
+    handler.handle(FinalResponseEvent(content="## Итог\n\nВсё готово."))
+    await asyncio.sleep(0)
+
+    presenter.deliver_result.assert_called_once_with("## Итог\n\nВсё готово.")
+    assert session.live_buffer.answer == ""
+    assert session.live_buffer.result_posted_separately is True
+    assert session.live_buffer.status == "done"
+
+
+@pytest.mark.asyncio
+async def test_final_response_falls_back_to_last_tool_result(
+    handler_setup: tuple[TelegramEventHandler, MagicMock, ChatSession],
+) -> None:
+    handler, presenter, session = handler_setup
+    session._recent_tool_results.append(
+        {"name": "run_terminal_command", "full_result": "command output line"}
+    )
+
+    handler.handle(FinalResponseEvent(content=""))
+    await asyncio.sleep(0)
+
+    presenter.deliver_result.assert_called_once_with("command output line")
+    assert session.live_buffer.status == "done"

--- a/tests/test_telegram_markdown.py
+++ b/tests/test_telegram_markdown.py
@@ -69,3 +69,14 @@ def test_done_with_tools_hides_tools_keeps_rendered_answer() -> None:
     html = buffer_to_telegram_html(buf)
     assert "<b>Done</b>" in html
     assert "read" not in html
+
+
+def test_telegram_done_posts_answer_separately_not_in_live_card() -> None:
+    buf = LiveTranscriptBuffer(profile="default", mode="react")
+    buf.publish_answer_separately = True
+    buf.result_posted_separately = True
+    buf.set_answer("**Secret final**")
+    buf.mark_done()
+    html = buffer_to_telegram_html(buf)
+    assert "<b>Secret final</b>" not in html
+    assert "отдельным сообщением" in html


### PR DESCRIPTION
## Summary

- **Production admin profile**: when `HOLIX_ENV=production`, create `admin` profile and copy settings from `default` (config + env overrides).
- **Telegram menu policy**: in isolated multi-tenant mode, non-admins see a reduced slash menu; `/message` and `/init` are admin-only; `/cron` and read-only `/mcp` stay available for users on their own profile.
- **Telegram UX fixes**: separate message for final agent answer; improved approval callback handling; filtered status panel (Profile admin-only, Cron for all).
- **Gateway startup**: defer agent warmup and avoid duplicate companion startup so Telegram polling is not blocked for minutes at boot.

## Test plan

- [x] `uv run ruff check core cli api integrations tests`
- [x] `uv run pytest -q` — 914 passed locally
- [ ] GitHub CI (matrix 3.12–3.14 + Windows/macOS)