### PR TITLE
fix(agent): recover messenger runs after LLM timeout and /init

### DIFF
--- a/cli/core.py
+++ b/cli/core.py
@@ -45,7 +45,7 @@ class ProfileConfig(BaseModel):
     base_url: str = "http://localhost:11434/v1"
     api_key: str = "ollama"
     temperature: float = 0.7
-    max_steps: int = 15
+    max_steps: int = 90
 
     # Profile settings
     profile_name: str = "default"

--- a/cli/shared/commands/project_init.py
+++ b/cli/shared/commands/project_init.py
@@ -9,6 +9,76 @@ from core.project.holix_md import HOLIX_MD_REL_PATH
 from core.project.init_prompt import build_init_user_message
 
 
+def _is_messenger_host(host: Any) -> bool:
+    """Telegram / MAX hosts carry a per-chat session object."""
+    return getattr(host, "_session", None) is not None
+
+
+def _agent_busy(host: Any) -> bool:
+    session = getattr(host, "_session", None)
+    if session is not None:
+        lock = getattr(session, "run_lock", None)
+        if lock is not None and lock.locked():
+            return True
+    return False
+
+
+def prefer_plan_mode(host: Any) -> str | None:
+    """Switch host to plan_and_execute for structured onboarding (TUI)."""
+    modes = getattr(host, "_execution_modes", None)
+    if not modes or "plan_and_execute" not in modes:
+        return None
+    host._execution_mode_index = modes.index("plan_and_execute")
+    refresh = getattr(host, "_refresh_status_bar", None)
+    if refresh:
+        try:
+            refresh()
+        except Exception:
+            pass
+    cycle = getattr(host, "action_cycle_execution_mode", None)
+    if cycle and hasattr(host, "config"):
+        try:
+            from config import settings
+
+            settings.execution_mode = "plan_and_execute"
+        except Exception:
+            pass
+    return "plan_and_execute"
+
+
+def prefer_react_mode(host: Any) -> str | None:
+    """Switch host to react — avoids plan-review blocking in messengers."""
+    modes = getattr(host, "_execution_modes", None)
+    if not modes or "react" not in modes:
+        return None
+    host._execution_mode_index = modes.index("react")
+    refresh = getattr(host, "_refresh_status_bar", None)
+    if refresh:
+        try:
+            refresh()
+        except Exception:
+            pass
+    return "react"
+
+
+def choose_init_execution_mode(host: Any) -> str:
+    """Pick execution mode for /init based on host type."""
+    if _is_messenger_host(host):
+        return prefer_react_mode(host) or "react"
+    return prefer_plan_mode(host) or "plan_and_execute"
+
+
+async def _ack_init_start(host: Any, mode_label: str) -> None:
+    text = (
+        f"▸ /init — анализ проекта → {HOLIX_MD_REL_PATH} (режим: {mode_label})"
+    )
+    send_plain = getattr(host, "_send_plain", None)
+    if send_plain is not None:
+        await send_plain(text)
+        return
+    host.transcript_write(f"[dim]{text}[/dim]")
+
+
 async def dispatch_agent_message(host: Any, message: str) -> None:
     """Send a user message to the host agent loop (TUI / Telegram)."""
     if hasattr(host, "_send_message"):
@@ -29,28 +99,6 @@ async def dispatch_agent_message(host: Any, message: str) -> None:
             await coro
 
 
-def prefer_plan_mode(host: Any) -> None:
-    """Switch host to plan_and_execute for structured onboarding."""
-    modes = getattr(host, "_execution_modes", None)
-    if not modes or "plan_and_execute" not in modes:
-        return
-    host._execution_mode_index = modes.index("plan_and_execute")
-    refresh = getattr(host, "_refresh_status_bar", None)
-    if refresh:
-        try:
-            refresh()
-        except Exception:
-            pass
-    cycle = getattr(host, "action_cycle_execution_mode", None)
-    if cycle and hasattr(host, "config"):
-        try:
-            from config import settings
-
-            settings.execution_mode = "plan_and_execute"
-        except Exception:
-            pass
-
-
 async def run_project_init(host: Any) -> None:
     """Execute /init: analyze repo and write HOLIX.md."""
     if not getattr(host, "agent", None):
@@ -59,9 +107,13 @@ async def run_project_init(host: Any) -> None:
         )
         return
 
-    prefer_plan_mode(host)
-    host.transcript_write(
-        f"[dim]▸ /init — analyzing project → {HOLIX_MD_REL_PATH} "
-        f"(mode: plan_and_execute)[/dim]"
-    )
+    if _agent_busy(host):
+        host.transcript_write(
+            "[yellow]Агент занят предыдущим запросом. "
+            "Дождитесь ответа или отправьте /stop.[/yellow]"
+        )
+        return
+
+    mode_label = choose_init_execution_mode(host)
+    await _ack_init_start(host, mode_label)
     await dispatch_agent_message(host, build_init_user_message())

--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     temperature: float = 0.7
 
     # Agent Configuration
-    max_steps: int = 15
+    max_steps: int = 90
     data_dir: str = "data"
     context_window: int = 131072
 

--- a/core/agent_events.py
+++ b/core/agent_events.py
@@ -225,7 +225,7 @@ class ToolCallErrorEvent(AgentEvent):
 @dataclass
 class MaxStepsReachedEvent(AgentEvent):
     """Agent reached the configured max_steps limit."""
-    max_steps: int = 15
+    max_steps: int = 90
 
 
 @dataclass

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -41,7 +41,7 @@ def prepare_initial_state(
 ) -> dict:
     """Prepare initial HolixGraphState for a graph invocation."""
     cfg = getattr(agent, "config", None)
-    max_steps = cfg.max_steps if cfg else 15
+    max_steps = cfg.max_steps if cfg else 90
     max_per_step = cfg.max_steps_per_plan_step if cfg else 5
     max_refinement = cfg.max_refinement_iterations if cfg else 2
 
@@ -162,7 +162,7 @@ async def run_graph_loop(
             )
 
         step_count = final_state.get("step_count", 0)
-        max_steps = final_state.get("max_steps", 15)
+        max_steps = final_state.get("max_steps", 90)
         if step_count >= max_steps and not final_state.get("is_final", False):
             yield MaxStepsReachedEvent(
                 max_steps=max_steps,

--- a/core/graph/nodes/finalize_node.py
+++ b/core/graph/nodes/finalize_node.py
@@ -8,6 +8,7 @@ import logging
 from langchain_core.runnables import RunnableConfig
 
 from core.graph.state import HolixGraphState, get_agent_from_config
+from core.presenters.final_content import is_aborted_final_response
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,13 @@ async def finalize_node(state: HolixGraphState, config: RunnableConfig) -> dict:
     plan_status = state.get("plan_status", "")
 
     if not agent:
+        return {}
+
+    if is_aborted_final_response(final_response):
+        logger.info(
+            "Skipping post-finalize work for aborted run (conversation=%s)",
+            conversation_id,
+        )
         return {}
 
     # Disable plan execution auto-approve since we're finalizing

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -8,6 +8,8 @@ the event bus as side effects.
 
 import asyncio
 import logging
+import time
+from collections.abc import AsyncIterator
 from typing import Any
 
 from langchain_core.runnables import RunnableConfig
@@ -32,6 +34,38 @@ from core.prompt_builder import build_system_prompt, format_tools_description
 logger = logging.getLogger(__name__)
 
 _DEFAULT_LLM_STEP_TIMEOUT_S = 120.0
+
+
+async def _close_async_stream(stream: Any) -> None:
+    """Best-effort close of an OpenAI/httpx streaming response."""
+    for method_name in ("close", "aclose"):
+        method = getattr(stream, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            result = method()
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:
+            logger.debug("Failed to close LLM stream via %s", method_name, exc_info=True)
+        return
+
+
+async def _iter_stream_chunks(stream: Any, timeout_s: float) -> AsyncIterator[Any]:
+    """Iterate stream chunks with a hard deadline and guaranteed stream cleanup."""
+    deadline = time.monotonic() + timeout_s
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError
+            try:
+                chunk = await asyncio.wait_for(anext(stream), timeout=remaining)
+            except StopAsyncIteration:
+                break
+            yield chunk
+    finally:
+        await _close_async_stream(stream)
 
 
 def _llm_step_timeout_s(agent) -> float:
@@ -394,10 +428,8 @@ async def _react_streaming(
     last_finish_reason: str | None = None
     reasoning_status_emitted = False
 
-    async with asyncio.timeout(llm_timeout_s):
-        stream_response = await _open_stream()
-
-        async for chunk in stream_response:
+    stream_response = await _open_stream()
+    async for chunk in _iter_stream_chunks(stream_response, llm_timeout_s):
             delta = chunk.choices[0].delta
             content_delta, reasoning_delta = stream_delta_parts(delta)
 

--- a/core/graph/routers.py
+++ b/core/graph/routers.py
@@ -13,7 +13,7 @@ def route_after_react(state: HolixGraphState) -> str:
     tool_calls = state.get("tool_calls", [])
     is_final = state.get("is_final", False)
     step_count = state.get("step_count", 0)
-    max_steps = state.get("max_steps", 15)
+    max_steps = state.get("max_steps", 90)
 
     if is_final or step_count >= max_steps:
         return "finalize"
@@ -54,7 +54,7 @@ def route_after_react_plan(state: HolixGraphState) -> str:
     is_final = state.get("is_final", False)
     is_step_complete = state.get("is_step_complete", False)
     step_count = state.get("step_count", 0)
-    max_steps = state.get("max_steps", 15)
+    max_steps = state.get("max_steps", 90)
     plan_steps = state.get("plan_steps", [])
     current_step_idx = state.get("current_plan_step", 0)
     current_step_start_count = state.get("current_step_start_count", 0)

--- a/core/memory/episodic.py
+++ b/core/memory/episodic.py
@@ -6,6 +6,7 @@ Each episode captures: what happened, what the outcome was, and what was learned
 Automatically generated when conversations end or are compressed.
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime
@@ -200,18 +201,19 @@ KEY_LEARNING: (one key takeaway, if any)"""
                 logger.warning("Episodic summary skipped: no model provided")
                 return None
 
-            response = await llm_client.chat.completions.create(
-                model=effective_model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": "You are an expert at creating compact episodic memory summaries from conversations. Be concise and factual.",
-                    },
-                    {"role": "user", "content": prompt},
-                ],
-                temperature=0.1,
-                max_tokens=300,
-            )
+            async with asyncio.timeout(60.0):
+                response = await llm_client.chat.completions.create(
+                    model=effective_model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": "You are an expert at creating compact episodic memory summaries from conversations. Be concise and factual.",
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    temperature=0.1,
+                    max_tokens=300,
+                )
 
             result_text = response.choices[0].message.content or ""
 

--- a/core/presenters/final_content.py
+++ b/core/presenters/final_content.py
@@ -13,6 +13,16 @@ _PLACEHOLDER_FINALS = frozenset(
     }
 )
 
+_ABORTED_FINAL_MARKERS = (
+    "не ответила за",
+    "error:",
+    "error during agent step",
+    "no llm model configured",
+    "no llm client available",
+    "agent reached maximum steps",
+    "превышено время выполнения",
+)
+
 MESSENGER_EMPTY_FINAL_RU = (
     "Агент завершил работу без текстового ответа.\n"
     "Проверьте модель (/models) или повторите запрос."
@@ -21,6 +31,14 @@ MESSENGER_EMPTY_FINAL_RU = (
 
 def is_placeholder_final(content: str | None) -> bool:
     return (content or "").strip().lower() in _PLACEHOLDER_FINALS
+
+
+def is_aborted_final_response(content: str | None) -> bool:
+    """True when the run ended with timeout/error rather than a real answer."""
+    text = (content or "").strip().lower()
+    if not text:
+        return False
+    return any(marker in text for marker in _ABORTED_FINAL_MARKERS)
 
 
 def resolve_messenger_final_content(

--- a/core/runtime/run_consumer.py
+++ b/core/runtime/run_consumer.py
@@ -1,0 +1,38 @@
+"""Helpers for consuming agent run event streams in messenger hosts."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+from core.agent_events import AgentEvent
+from core.runtime.timeouts import agent_run_timeout_s
+
+
+async def consume_run_holix(
+    agent: Any,
+    user_input: str,
+    conversation_id: str,
+    *,
+    stream: bool,
+    execution_mode: str | None,
+    emit: Callable[[AgentEvent], None],
+    timeout_s: float | None = None,
+) -> None:
+    """Run Holix and forward events; raises TimeoutError if the run exceeds the cap."""
+    from core.runtime.executor import run_holix
+
+    effective_timeout = timeout_s if timeout_s is not None else agent_run_timeout_s(agent)
+
+    async def _consume() -> None:
+        async for event in run_holix(
+            agent,
+            user_input,
+            conversation_id,
+            stream=stream,
+            execution_mode=execution_mode,
+        ):
+            emit(event)
+
+    await asyncio.wait_for(_consume(), timeout=effective_timeout)

--- a/core/runtime/timeouts.py
+++ b/core/runtime/timeouts.py
@@ -1,0 +1,15 @@
+"""Shared timeout helpers for agent runs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.graph.nodes.react_node import _llm_step_timeout_s
+
+
+def agent_run_timeout_s(agent: Any, *, buffer_s: float = 120.0) -> float:
+    """Upper bound for a full messenger agent run (steps + tools + finalize)."""
+    cfg = getattr(agent, "config", None)
+    max_steps = int(getattr(cfg, "max_steps", 90) or 90)
+    step_timeout = _llm_step_timeout_s(agent)
+    return step_timeout * max(1, max_steps) + buffer_s

--- a/integrations/max/host.py
+++ b/integrations/max/host.py
@@ -583,16 +583,16 @@ class MaxHost:
                 mode = self._session.execution_mode
                 with visibility_ctx:
                     if self._session.streaming_enabled:
-                        from core.runtime.executor import run_holix
+                        from core.runtime.run_consumer import consume_run_holix
 
-                        async for event in run_holix(
+                        await consume_run_holix(
                             self.agent,
                             user_input,
                             self.conversation_id,
                             stream=True,
                             execution_mode=mode,
-                        ):
-                            self.agent.emit(event)
+                            emit=self.agent.emit,
+                        )
                     else:
                         await self.agent.run(
                             user_input=user_input,
@@ -603,6 +603,12 @@ class MaxHost:
                 buf = self._session.live_buffer
                 if buf:
                     buf.add_note("stopped")
+            except TimeoutError:
+                buf = self._session.live_buffer
+                if buf:
+                    buf.mark_error(
+                        "Превышено время выполнения. Попробуйте ещё раз или выберите другую модель (/models)."
+                    )
             except Exception as exc:
                 buf = self._session.live_buffer
                 if buf:

--- a/integrations/telegram/host.py
+++ b/integrations/telegram/host.py
@@ -210,8 +210,9 @@ class TelegramHost:
         await self._interactive.show_mode_picker()
 
     def _action_stop_all(self) -> None:
-        if self._run_task and not self._run_task.done():
-            self._run_task.cancel()
+        for task in list(self._run_tasks):
+            if not task.done():
+                task.cancel()
         self.transcript_write("stopped")
 
     async def _create_new_session(self) -> None:
@@ -706,16 +707,16 @@ class TelegramHost:
             try:
                 with visibility_ctx:
                     if self._session.streaming_enabled:
-                        from core.runtime.executor import run_holix
+                        from core.runtime.run_consumer import consume_run_holix
 
-                        async for event in run_holix(
+                        await consume_run_holix(
                             self.agent,
                             user_input,
                             self.conversation_id,
                             stream=True,
                             execution_mode=mode,
-                        ):
-                            self.agent.emit(event)
+                            emit=self.agent.emit,
+                        )
                     else:
                         await self.agent.run(
                             user_input=user_input,
@@ -726,6 +727,12 @@ class TelegramHost:
                 buf = self._session.live_buffer
                 if buf:
                     buf.add_note("stopped")
+            except TimeoutError:
+                buf = self._session.live_buffer
+                if buf:
+                    buf.mark_error(
+                        "Превышено время выполнения. Попробуйте ещё раз или выберите другую модель (/models)."
+                    )
             except Exception as exc:
                 buf = self._session.live_buffer
                 if buf:

--- a/tests/test_finalize_aborted.py
+++ b/tests/test_finalize_aborted.py
@@ -1,0 +1,45 @@
+"""Post-finalize work must not block messenger runs after LLM timeout/errors."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from core.graph.nodes.finalize_node import finalize_node
+from core.presenters.final_content import is_aborted_final_response
+
+
+def test_is_aborted_final_response_detects_llm_timeout() -> None:
+    assert is_aborted_final_response("Модель не ответила за 120 с. Попробуйте ещё раз.")
+    assert not is_aborted_final_response("Вот готовый ответ на ваш вопрос.")
+
+
+@pytest.mark.asyncio
+async def test_finalize_skips_slow_postprocess_on_timeout() -> None:
+    agent = MagicMock()
+    agent.tools._action_guard = MagicMock()
+    agent.memory.auto_summarize_conversation = AsyncMock(
+        side_effect=lambda *args, **kwargs: asyncio.sleep(60)
+    )
+    agent.skills.should_create_skill = AsyncMock(return_value=True)
+    agent.config = SimpleNamespace(auto_summarize_conversations=True)
+
+    state = {
+        "conversation_id": "test",
+        "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "x"}],
+        "final_response": "Модель не ответила за 120 с. Попробуйте ещё раз.",
+        "plan_status": "",
+        "step_count": 1,
+    }
+    config = {"configurable": {"_agent": agent}}
+
+    started = time.monotonic()
+    await finalize_node(state, config)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    agent.memory.auto_summarize_conversation.assert_not_called()
+    agent.skills.should_create_skill.assert_not_called()

--- a/tests/test_project_init.py
+++ b/tests/test_project_init.py
@@ -1,0 +1,98 @@
+"""`/init` command behaviour across hosts."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cli.shared.commands.project_init import (
+    choose_init_execution_mode,
+    run_project_init,
+)
+from integrations.telegram.session import ChatSession
+
+
+def test_choose_init_execution_mode_react_for_telegram() -> None:
+    session = ChatSession(chat_id=1, user_id=1, profile="default", conversation_id="tg")
+    host = SimpleNamespace(
+        _session=session,
+        _execution_modes=session.execution_modes,
+        _execution_mode_index=0,
+        _refresh_status_bar=lambda: None,
+    )
+    mode = choose_init_execution_mode(host)
+    assert mode == "react"
+    assert host._execution_mode_index == 0
+
+
+def test_choose_init_execution_mode_plan_for_tui() -> None:
+    host = SimpleNamespace(
+        _execution_modes=["react", "plan_and_execute", "hybrid"],
+        _execution_mode_index=0,
+        _refresh_status_bar=lambda: None,
+        config=SimpleNamespace(),
+    )
+    with patch("cli.shared.commands.project_init.settings", create=True):
+        mode = choose_init_execution_mode(host)
+    assert mode == "plan_and_execute"
+    assert host._execution_mode_index == 1
+
+
+@pytest.mark.asyncio
+async def test_run_project_init_warns_when_agent_busy() -> None:
+    session = ChatSession(chat_id=1, user_id=1, profile="default", conversation_id="tg")
+    await session.run_lock.acquire()
+    try:
+        host = MagicMock()
+        host.agent = MagicMock()
+        host._session = session
+        host._send_plain = AsyncMock()
+        host._send_message = AsyncMock()
+
+        await run_project_init(host)
+
+        host.transcript_write.assert_called_once()
+        assert "занят" in str(host.transcript_write.call_args).lower()
+        host._send_message.assert_not_called()
+    finally:
+        session.run_lock.release()
+
+
+@pytest.mark.asyncio
+async def test_run_project_init_starts_agent_on_telegram() -> None:
+    session = ChatSession(chat_id=1, user_id=1, profile="default", conversation_id="tg")
+    host = MagicMock()
+    host.agent = MagicMock()
+    host._session = session
+    host._execution_modes = session.execution_modes
+    host._execution_mode_index = 0
+    host._refresh_status_bar = MagicMock()
+    host._send_plain = AsyncMock()
+    host._send_message = AsyncMock()
+
+    await run_project_init(host)
+
+    host._send_plain.assert_awaited_once()
+    host._send_message.assert_awaited_once()
+    assert session.execution_mode == "react"
+
+
+@pytest.mark.asyncio
+async def test_telegram_stop_cancels_run_tasks() -> None:
+    from integrations.telegram.host import TelegramHost
+
+    bot = MagicMock()
+    session = ChatSession(chat_id=1, user_id=1, profile="default", conversation_id="tg")
+    host = TelegramHost(bot, session)
+
+    async def sleeper() -> None:
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(sleeper())
+    host._run_tasks.add(task)
+
+    host._action_stop_all()
+    await asyncio.sleep(0.05)
+    assert task.cancelled() or task.done()

--- a/tests/test_run_lock_after_timeout.py
+++ b/tests/test_run_lock_after_timeout.py
@@ -1,0 +1,104 @@
+"""Messenger run_lock must be released after an aborted agent run."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from core.agent_events import FinalResponseEvent
+from integrations.telegram.session import ChatSession
+
+
+@pytest.mark.asyncio
+async def test_telegram_run_lock_released_after_timeout_final() -> None:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.edit_message_text = AsyncMock()
+
+    session = ChatSession(chat_id=1, user_id=1, profile="default", conversation_id="tg_default_1")
+    agent = MagicMock()
+    agent.model = "slow"
+    session.agent = agent
+
+    from integrations.telegram.host import TelegramHost
+
+    host = TelegramHost(bot, session)
+
+    async def fake_consume(*_args, emit, **_kwargs):
+        emit(
+            FinalResponseEvent(
+                content="Модель не ответила за 120 с. Попробуйте ещё раз.",
+                steps_taken=1,
+                conversation_id=session.conversation_id,
+            )
+        )
+
+    class _Events:
+        def __init__(self) -> None:
+            self._handlers: list = []
+
+        def subscribe(self, handler) -> None:
+            self._handlers.append(handler)
+
+        def unsubscribe(self, handler) -> None:
+            self._handlers.remove(handler)
+
+    agent.events = _Events()
+
+    with (
+        patch("integrations.telegram.host.TelegramLivePresenter") as presenter_cls,
+        patch("integrations.telegram.event_handler.TelegramEventHandler"),
+        patch("integrations.telegram.approvals.TelegramApprovals"),
+        patch("core.session_models.ensure_session_model"),
+        patch("core.runtime.run_consumer.consume_run_holix", side_effect=fake_consume),
+        patch("core.tools.execution_context.chat_delivery_scope", return_value="token"),
+        patch("core.tools.execution_context.reset_chat_delivery_scope"),
+        patch("core.workspace.agent_path_visibility_context") as vis_ctx,
+        patch("integrations.telegram.access_approval.is_telegram_admin", return_value=False),
+    ):
+        vis_ctx.return_value.__enter__ = MagicMock(return_value=None)
+        vis_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        class FakePresenter:
+            final_delivered = True
+
+            async def start(self) -> None:
+                return None
+
+            async def finish(self) -> None:
+                return None
+
+            def schedule_edit(self, *, force: bool = False) -> None:
+                return None
+
+            def note_final_content(self, content: str) -> None:
+                return None
+
+            def enqueue_outbound(self, coro) -> None:
+                return None
+
+            @property
+            def buffer(self):
+                return session.live_buffer
+
+        presenter_cls.side_effect = lambda *a, **k: FakePresenter()
+
+        session.streaming_enabled = True
+        await host._run_agent("first message")
+        assert not session.run_lock.locked()
+
+        second_started = asyncio.Event()
+
+        async def mark_second() -> None:
+            second_started.set()
+
+        original_locked = host._run_agent_locked
+
+        async def wrapped_locked(user_input: str) -> None:
+            second_started.set()
+            await original_locked(user_input)
+
+        host._run_agent_locked = wrapped_locked  # type: ignore[method-assign]
+        host._start_agent_run("second message")
+        await asyncio.wait_for(second_started.wait(), timeout=1.0)


### PR DESCRIPTION
## Summary

- **LLM timeout hang**: after «Модель не ответила за 120 с» the graph could stay blocked in `finalize_node` (auto-summarize), keeping `run_lock` and silencing Telegram/MAX. Skip post-finalize on aborted finals, close streaming responses on timeout, add messenger run timeout.
- **`/init` silence**: switched messenger `/init` to `react` (no plan-review wait), immediate ack message, busy-agent warning; fixed Telegram `/stop` not cancelling `_run_tasks`.
- **`max_steps`**: default raised from 15 → 90.

## Test plan

- [x] `uv run ruff check core cli api integrations tests`
- [x] `uv run pytest -m "not llm" -q` (1124 passed locally with `--all-extras`)
- [x] New tests: `test_finalize_aborted`, `test_run_lock_after_timeout`, `test_project_init`