### PR TITLE
feat(launch): external coding CLIs in tmux with Holix profile models

### DIFF
--- a/cli/commands/launch.py
+++ b/cli/commands/launch.py
@@ -1,0 +1,362 @@
+"""holix launch — external coding CLIs in tmux (Linux/macOS)."""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import typer
+from core.external_cli.platform import ensure_launch_platform
+from core.external_cli.registry import EXTERNAL_CLI_REGISTRY, list_cli_specs
+from core.external_cli.store import ExternalCliStore
+from rich.panel import Panel
+from rich.prompt import Prompt
+from rich.table import Table
+
+from cli.core import get_current_config, get_current_profile
+from cli.launch.setup_wizard import run_launch_setup
+from cli.services.tmux_launcher import (
+    TmuxError,
+    attach_session,
+    capture_pane,
+    find_launched_session,
+    kill_session,
+    launch_cli_by_id,
+    list_all_tmux_sessions,
+    prune_dead_sessions,
+    send_text,
+    tmux_session_alive,
+)
+from cli.utils.rich_console import console, print_error, print_info, print_success
+
+app = typer.Typer(
+    help="Launch external coding CLIs in tmux (Linux/macOS). Models from Holix profile.",
+    no_args_is_help=True,
+)
+
+
+def _require_platform() -> None:
+    try:
+        ensure_launch_platform()
+    except RuntimeError as exc:
+        print_error(str(exc))
+        raise typer.Exit(1) from exc
+
+
+def _profile_config(ctx: typer.Context) -> tuple[str, Any]:
+    obj = ctx.obj or {}
+    profile = obj.get("profile") or get_current_profile()
+    config = obj.get("config") or get_current_config()
+    return profile, config
+
+
+@app.command("setup")
+def launch_setup(
+    ctx: typer.Context,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Non-interactive defaults"),
+) -> None:
+    """Interactive install and profile binding for external CLIs."""
+    _require_platform()
+    profile, config = _profile_config(ctx)
+    run_launch_setup(profile, config, yes=yes)
+
+
+@app.command("list")
+def launch_list(ctx: typer.Context) -> None:
+    """List supported external CLIs and profile bindings."""
+    _require_platform()
+    profile, _ = _profile_config(ctx)
+    import shutil
+
+    store = ExternalCliStore(profile)
+    bindings = store.load_bindings()
+
+    table = Table(title="External CLIs", show_header=True)
+    table.add_column("ID", style="cyan")
+    table.add_column("Name")
+    table.add_column("Installed")
+    table.add_column("Enabled")
+    table.add_column("Model slot")
+    table.add_column("Command")
+
+    for spec in list_cli_specs():
+        binding = bindings.get(spec.cli_id)
+        path = None
+        for name in spec.binary_names:
+            path = shutil.which(name)
+            if path:
+                break
+        if binding and binding.command:
+            path = binding.command
+        table.add_row(
+            spec.cli_id,
+            spec.display_name,
+            "yes" if path else "no",
+            "yes" if binding and binding.enabled else "no",
+            binding.model_slot if binding else spec.default_model_slot,
+            path or "—",
+        )
+
+    console.print(table)
+    console.print()
+    print_info("Setup: holix launch setup  |  Launch: holix launch <cli_id>")
+
+
+@app.command("sessions")
+def launch_sessions(ctx: typer.Context) -> None:
+    """List Holix-managed tmux sessions for this profile."""
+    _require_platform()
+    profile, _ = _profile_config(ctx)
+    sessions = prune_dead_sessions(profile)
+
+    if not sessions:
+        print_info("No active Holix launch sessions for this profile.")
+        print_info("Start one: holix launch claude --task \"implement feature X\"")
+        return
+
+    table = Table(title=f"Holix sessions ({profile})", show_header=True)
+    table.add_column("ID", style="cyan")
+    table.add_column("tmux")
+    table.add_column("CLI")
+    table.add_column("Model")
+    table.add_column("CWD")
+    table.add_column("Win")
+
+    for session in sessions:
+        table.add_row(
+            session.session_id,
+            session.tmux_session,
+            session.cli_id,
+            session.model_name or session.model_slot,
+            session.cwd[:48] + ("…" if len(session.cwd) > 48 else ""),
+            str(session.window_index),
+        )
+
+    console.print(table)
+    console.print()
+    print_info("Attach: holix launch attach <tmux_session>")
+    print_info("Send:   holix launch send <id> \"your prompt\"")
+    print_info("Chat:   holix launch chat <id>")
+
+
+@app.command("tmux")
+def launch_tmux() -> None:
+    """List all tmux sessions on this machine."""
+    _require_platform()
+    sessions = list_all_tmux_sessions()
+    if not sessions:
+        print_info("No tmux sessions running.")
+        return
+
+    table = Table(title="tmux sessions", show_header=True)
+    table.add_column("Name", style="cyan")
+    table.add_column("Windows")
+    table.add_column("Attached")
+
+    for session in sessions:
+        table.add_row(
+            session.name,
+            str(session.windows),
+            "yes" if session.attached else "no",
+        )
+    console.print(table)
+
+
+@app.command("attach")
+def launch_attach(
+    session: str = typer.Argument(..., help="tmux session name or Holix session id"),
+    ctx: typer.Context = None,
+) -> None:
+    """Attach to a tmux session (hands control to tmux)."""
+    _require_platform()
+    profile, _ = _profile_config(ctx)
+    target = session
+    found = find_launched_session(profile, session)
+    if found:
+        target = found.tmux_session
+    if not tmux_session_alive(target):
+        print_error(f"tmux session not found: {target}")
+        raise typer.Exit(1)
+    print_info(f"Attaching to {target} (detach: Ctrl+b d)")
+    raise typer.Exit(attach_session(target))
+
+
+@app.command("send")
+def launch_send(
+    session: str = typer.Argument(..., help="Session id or tmux name"),
+    message: str = typer.Argument(..., help="Text to send to the CLI"),
+    ctx: typer.Context = None,
+    no_enter: bool = typer.Option(False, "--no-enter", help="Do not press Enter after text"),
+) -> None:
+    """Send a task/prompt to a running external CLI session."""
+    _require_platform()
+    profile, _ = _profile_config(ctx)
+    found = find_launched_session(profile, session)
+    target = found.tmux_session if found else session
+    if not tmux_session_alive(target):
+        print_error(f"Session not found: {session}")
+        raise typer.Exit(1)
+    window = found.window_index if found else 0
+    send_text(target, message, window_index=window, enter=not no_enter)
+    if found:
+        ExternalCliStore(profile).touch_session_output(found.session_id)
+    print_success(f"Sent to {target}:{window}")
+
+
+@app.command("output")
+def launch_output(
+    session: str = typer.Argument(..., help="Session id or tmux name"),
+    ctx: typer.Context = None,
+    lines: int = typer.Option(40, "--lines", "-n", help="Lines to capture"),
+) -> None:
+    """Show recent output from an external CLI pane."""
+    _require_platform()
+    profile, _ = _profile_config(ctx)
+    found = find_launched_session(profile, session)
+    target = found.tmux_session if found else session
+    if not tmux_session_alive(target):
+        print_error(f"Session not found: {session}")
+        raise typer.Exit(1)
+    window = found.window_index if found else 0
+    text = capture_pane(target, window_index=window, lines=lines)
+    console.print(Panel(text or "(empty)", title=f"{target}:{window}", border_style="dim"))
+    if found:
+        ExternalCliStore(profile).touch_session_output(found.session_id)
+
+
+@app.command("chat")
+def launch_chat(
+    session: str = typer.Argument(..., help="Session id or tmux name"),
+    ctx: typer.Context = None,
+) -> None:
+    """Interactive relay: type prompts, see CLI output (Ctrl+C to exit)."""
+    _require_platform()
+    profile, _ = _profile_config(ctx)
+    found = find_launched_session(profile, session)
+    target = found.tmux_session if found else session
+    if not tmux_session_alive(target):
+        print_error(f"Session not found: {session}")
+        raise typer.Exit(1)
+    window = found.window_index if found else 0
+
+    console.print(Panel.fit(
+        f"[bold]Relay → {target}:{window}[/bold]\n"
+        "Type a prompt and press Enter. Empty line shows output. Ctrl+C to quit.",
+        border_style="cyan",
+    ))
+
+    store = ExternalCliStore(profile)
+    try:
+        while True:
+            try:
+                user_input = Prompt.ask("[bold cyan]holix[/bold cyan]")
+            except (EOFError, KeyboardInterrupt):
+                console.print()
+                break
+            if not user_input.strip():
+                text = capture_pane(target, window_index=window, lines=30)
+                console.print(Panel(text or "(empty)", border_style="dim"))
+                continue
+            send_text(target, user_input.strip(), window_index=window)
+            time.sleep(0.8)
+            text = capture_pane(target, window_index=window, lines=35)
+            console.print(Panel(text, title="CLI output", border_style="green"))
+            if found:
+                store.touch_session_output(found.session_id)
+    except KeyboardInterrupt:
+        console.print()
+    print_info("Relay ended.")
+
+
+@app.command("kill")
+def launch_kill(
+    session: str = typer.Argument(..., help="Session id or tmux name"),
+    ctx: typer.Context = None,
+) -> None:
+    """Stop a tmux session launched by Holix."""
+    _require_platform()
+    profile, _ = _profile_config(ctx)
+    found = find_launched_session(profile, session)
+    target = found.tmux_session if found else session
+    kill_session(target)
+    if found:
+        ExternalCliStore(profile).remove_session(found.session_id)
+    print_success(f"Killed {target}")
+
+
+def _launch_cli(
+    ctx: typer.Context,
+    cli_id: str,
+    *,
+    cwd: Path | None,
+    task: str,
+    model_slot: str | None,
+    detach: bool,
+    new_window: bool,
+    session: str | None,
+) -> None:
+    _require_platform()
+    profile, config = _profile_config(ctx)
+
+    try:
+        launched = launch_cli_by_id(
+            profile=profile,
+            cli_id=cli_id,
+            profile_config=config,
+            cwd=cwd,
+            task=task,
+            model_slot=model_slot,
+            new_window=new_window,
+            target_session=session,
+        )
+    except TmuxError as exc:
+        print_error(str(exc))
+        raise typer.Exit(1) from exc
+
+    print_success(f"Started {cli_id} in tmux [bold]{launched.tmux_session}[/bold]")
+    print_info(f"Model: {launched.model_name} (slot: {launched.model_slot})")
+    print_info(f"CWD:   {launched.cwd}")
+    print_info(f"Attach: holix launch attach {launched.tmux_session}")
+    print_info(f"Relay:  holix launch chat {launched.session_id}")
+
+    if not detach:
+        print_info("Attach now? (y/n)")
+        if sys.stdin.isatty():
+            answer = Prompt.ask("Attach", default="y")
+            if answer.strip().lower() in {"y", "yes", ""}:
+                raise typer.Exit(attach_session(launched.tmux_session))
+
+
+def _register_cli_launch_commands() -> None:
+    for cli_name, spec in EXTERNAL_CLI_REGISTRY.items():
+        def _make_cmd(name: str, label: str):
+            def _cmd(
+                ctx: typer.Context,
+                cwd: Path | None = typer.Option(None, "--cwd", "-C", help="Working directory"),
+                task: str = typer.Option("", "--task", "-t", help="Initial prompt"),
+                model_slot: str | None = typer.Option(None, "--model-slot", "-m", help="Profile model slot"),
+                detach: bool = typer.Option(True, "--detach/--attach", help="Detach after launch"),
+                new_window: bool = typer.Option(False, "--window", "-w", help="New window in session"),
+                session: str | None = typer.Option(None, "--session", "-s", help="Target tmux session"),
+            ) -> None:
+                _launch_cli(
+                    ctx,
+                    name,
+                    cwd=cwd,
+                    task=task,
+                    model_slot=model_slot,
+                    detach=detach,
+                    new_window=new_window,
+                    session=session,
+                )
+            _cmd.__doc__ = f"Launch {label} in tmux with Holix profile models."
+            return _cmd
+
+        app.command(cli_name, help=f"Launch {spec.display_name} in tmux")(
+            _make_cmd(cli_name, spec.display_name)
+        )
+
+
+_register_cli_launch_commands()

--- a/cli/doctor/checks.py
+++ b/cli/doctor/checks.py
@@ -237,6 +237,17 @@ def _check_platform() -> list[DoctorFinding]:
                 ),
             )
         )
+    if not IS_WINDOWS:
+        if shutil.which("tmux") is None:
+            out.append(
+                DoctorFinding(
+                    code="platform.missing_tmux",
+                    severity=Severity.INFO.value,
+                    title="tmux not found (holix launch)",
+                    detail="External coding CLIs (Claude Code, OpenCode, …) run in tmux via `holix launch`",
+                    recommendation="Install tmux (brew install tmux / apt install tmux) and run: holix launch setup",
+                )
+            )
     for tool, label in (
         ("node", "Node.js (MCP npx servers)"),
         ("npx", "npx (MCP package runner)"),

--- a/cli/launch/__init__.py
+++ b/cli/launch/__init__.py
@@ -1,0 +1,1 @@
+"""Interactive wizards for holix launch."""

--- a/cli/launch/setup_wizard.py
+++ b/cli/launch/setup_wizard.py
@@ -1,0 +1,168 @@
+"""Interactive setup for external coding CLIs."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Any
+
+from core.external_cli.platform import ensure_launch_platform, tmux_available
+from core.external_cli.registry import EXTERNAL_CLI_REGISTRY, list_cli_specs
+from core.external_cli.store import ExternalCliBinding, ExternalCliStore
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+from rich.table import Table
+
+from cli.utils.rich_console import console, print_error, print_info, print_success, print_warning
+
+
+def _binary_installed(spec_binary_names: tuple[str, ...]) -> str | None:
+    for name in spec_binary_names:
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
+
+def _try_install(spec_id: str) -> bool:
+    spec = EXTERNAL_CLI_REGISTRY[spec_id]
+    if not spec.install_commands:
+        print_info(spec.install_hint or "No automatic install available.")
+        return False
+    for cmd in spec.install_commands:
+        tool = cmd[0]
+        if shutil.which(tool) is None:
+            print_warning(f"Skip install: `{tool}` not found on PATH")
+            return False
+        print_info(f"Running: {' '.join(cmd)}")
+        try:
+            subprocess.run(cmd, check=True, timeout=600)
+            print_success(f"Installed {spec.display_name}")
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            print_error(f"Install failed: {exc}")
+            return False
+    return False
+
+
+def run_launch_setup(profile: str, profile_config: Any, *, yes: bool = False) -> None:
+    ensure_launch_platform()
+    if not tmux_available():
+        print_error("tmux is required. Install: brew install tmux  OR  apt install tmux")
+        raise SystemExit(1)
+
+    console.print()
+    console.print(Panel.fit(
+        "[bold cyan]External CLI Launch Setup[/bold cyan]\n\n"
+        "Configure coding agents (Claude Code, OpenCode, GigaCode, …) in tmux.\n"
+        "Models are taken from your Holix profile (holix models setup).",
+        border_style="cyan",
+    ))
+    console.print()
+
+    store = ExternalCliStore(profile)
+    bindings = store.load_bindings()
+    agent_slots = _agent_slots(profile_config)
+
+    table = Table(title=f"Profile: {profile}", show_header=True)
+    table.add_column("CLI", style="cyan")
+    table.add_column("Status")
+    table.add_column("Binary")
+    table.add_column("Model slot")
+
+    for spec in list_cli_specs():
+        path = _binary_installed(spec.binary_names)
+        binding = bindings.get(spec.cli_id)
+        enabled = binding.enabled if binding else False
+        slot = binding.model_slot if binding else spec.default_model_slot
+        status = "[green]enabled[/green]" if enabled else "[dim]disabled[/dim]"
+        if not path:
+            status = "[yellow]not installed[/yellow]"
+        table.add_row(spec.display_name, status, path or "—", slot)
+
+    console.print(table)
+    console.print()
+
+    if yes:
+        to_configure = [s.cli_id for s in list_cli_specs()]
+    else:
+        raw = Prompt.ask(
+            "Configure which CLI? (comma-separated ids or 'all')",
+            default="all",
+        )
+        if raw.strip().lower() == "all":
+            to_configure = [s.cli_id for s in list_cli_specs()]
+        else:
+            to_configure = [p.strip().lower() for p in raw.split(",") if p.strip()]
+
+    for cli_id in to_configure:
+        spec = EXTERNAL_CLI_REGISTRY.get(cli_id)
+        if spec is None:
+            print_warning(f"Unknown CLI id: {cli_id}")
+            continue
+
+        console.print(f"\n[bold]{spec.display_name}[/bold] — {spec.description}")
+
+        path = _binary_installed(spec.binary_names)
+        if not path:
+            print_warning(f"Binary not found ({', '.join(spec.binary_names)})")
+            if spec.install_hint:
+                print_info(spec.install_hint)
+            if not yes and Confirm.ask("Try automatic install?", default=False):
+                _try_install(cli_id)
+                path = _binary_installed(spec.binary_names)
+
+        binding = bindings.get(cli_id) or ExternalCliBinding(
+            cli_id=cli_id,
+            model_slot=spec.default_model_slot,
+            agent_slot=spec.default_model_slot,
+        )
+
+        if yes:
+            binding.enabled = bool(path)
+        else:
+            binding.enabled = Confirm.ask("Enable for this profile?", default=bool(path))
+
+        if binding.enabled:
+            if path:
+                binding.command = path
+            else:
+                custom = Prompt.ask(
+                    "Path to binary",
+                    default=binding.command or spec.binary_names[0],
+                )
+                binding.command = custom.strip()
+
+            if agent_slots:
+                slot_choices = ", ".join(agent_slots)
+                slot = Prompt.ask(
+                    f"Model slot ({slot_choices})",
+                    default=binding.model_slot or spec.default_model_slot,
+                )
+                binding.model_slot = slot.strip() or spec.default_model_slot
+                binding.agent_slot = binding.model_slot
+
+            cwd = Prompt.ask(
+                "Default working directory (optional)",
+                default=binding.default_cwd or "",
+            )
+            binding.default_cwd = cwd.strip()
+
+        bindings[cli_id] = binding
+        store.upsert_binding(binding)
+        print_success(f"Saved binding for {spec.display_name}")
+
+    console.print()
+    print_info("Launch: holix launch claude --task \"…\"  |  holix launch sessions  |  holix launch attach <name>")
+
+
+def _agent_slots(profile_config: Any) -> list[str]:
+    slots = ["main"]
+    agent_models = getattr(profile_config, "agent_models", None) or {}
+    for name in sorted(agent_models.keys()):
+        if name not in slots:
+            slots.append(name)
+    for spec in list_cli_specs():
+        if spec.default_model_slot not in slots:
+            slots.append(spec.default_model_slot)
+    return slots

--- a/cli/main.py
+++ b/cli/main.py
@@ -58,6 +58,7 @@ def _register_base_commands() -> None:
     from cli.commands.docs import app as docs_app
     from cli.commands.hub import app as hub_app
     from cli.commands.install_cmd import app as install_app
+    from cli.commands.launch import app as launch_app
     from cli.commands.logs import app as logs_app
     from cli.commands.max import register_max_command
     from cli.commands.mcp import app as mcp_app
@@ -81,6 +82,7 @@ def _register_base_commands() -> None:
     app.add_typer(bootstrap_app, name="bootstrap")
     app.add_typer(update_app, name="update")
     app.add_typer(docs_app, name="docs")
+    app.add_typer(launch_app, name="launch")
     _BASE_COMMANDS_REGISTERED = True
 
 

--- a/cli/services/tmux_launcher.py
+++ b/cli/services/tmux_launcher.py
@@ -1,0 +1,298 @@
+"""tmux session management for external coding CLIs."""
+
+from __future__ import annotations
+
+import re
+import secrets
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core.external_cli.env import build_cli_env, env_export_shell, resolve_model_for_slot
+from core.external_cli.platform import ensure_launch_platform
+from core.external_cli.registry import ExternalCliSpec, get_cli_spec
+from core.external_cli.store import ExternalCliBinding, ExternalCliStore, LaunchedSession
+
+
+class TmuxError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class TmuxSessionInfo:
+    name: str
+    windows: int
+    attached: bool
+    created: str = ""
+
+
+def _run_tmux(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    ensure_launch_platform()
+    cmd = ["tmux", *args]
+    try:
+        return subprocess.run(
+            cmd,
+            check=check,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or exc.stdout or "").strip()
+        raise TmuxError(stderr or f"tmux failed: {' '.join(args)}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise TmuxError("tmux command timed out") from exc
+
+
+def list_all_tmux_sessions() -> list[TmuxSessionInfo]:
+    ensure_launch_platform()
+    result = _run_tmux(["list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_attached}"], check=False)
+    if result.returncode != 0:
+        return []
+    sessions: list[TmuxSessionInfo] = []
+    for line in (result.stdout or "").splitlines():
+        parts = line.split("\t")
+        if not parts or not parts[0].strip():
+            continue
+        windows = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 1
+        attached = len(parts) > 2 and parts[2] == "1"
+        sessions.append(TmuxSessionInfo(name=parts[0], windows=windows, attached=attached))
+    return sessions
+
+
+def tmux_session_alive(name: str) -> bool:
+    result = _run_tmux(["has-session", "-t", name], check=False)
+    return result.returncode == 0
+
+
+def _sanitize_session_token(value: str) -> str:
+    token = re.sub(r"[^a-zA-Z0-9_-]", "-", value.strip())[:24]
+    return token or "session"
+
+
+def build_tmux_session_name(profile: str, cli_id: str) -> str:
+    suffix = secrets.token_hex(2)
+    return f"holix-{_sanitize_session_token(profile)}-{_sanitize_session_token(cli_id)}-{suffix}"
+
+
+def resolve_binary(binding: ExternalCliBinding, spec: ExternalCliSpec) -> str:
+    import shutil
+
+    if binding.command.strip():
+        return binding.command.strip()
+    for name in spec.binary_names:
+        path = shutil.which(name)
+        if path:
+            return path
+    return spec.binary_names[0]
+
+
+def _shell_launch_command(env: dict[str, str], binary: str, args: tuple[str, ...]) -> str:
+    exports = env_export_shell(env)
+    quoted = " ".join(shlex.quote(a) for a in (binary, *args))
+    return f"{exports}; exec {quoted}"
+
+
+def create_cli_session(
+    *,
+    profile: str,
+    spec: ExternalCliSpec,
+    binding: ExternalCliBinding,
+    profile_config: Any,
+    cwd: Path,
+    task: str = "",
+    tmux_session: str | None = None,
+    window_name: str | None = None,
+    new_window: bool = False,
+    target_session: str | None = None,
+) -> LaunchedSession:
+    """Create or extend a tmux session running an external CLI with Holix model env."""
+    ensure_launch_platform()
+    model_slot = binding.model_slot or spec.default_model_slot
+    model = resolve_model_for_slot(profile_config, model_slot)
+    if model is None:
+        raise TmuxError(
+            f"No model configured for slot '{model_slot}'. "
+            f"Run: holix models setup -p {profile}"
+        )
+
+    env = build_cli_env(spec, model, extra_env=binding.extra_env)
+    binary = resolve_binary(binding, spec)
+    launch_cmd = _shell_launch_command(env, binary, spec.launch_args)
+    session_name = tmux_session or build_tmux_session_name(profile, spec.cli_id)
+    cwd_str = str(cwd.expanduser().resolve())
+
+    if new_window and target_session:
+        if not tmux_session_alive(target_session):
+            raise TmuxError(f"tmux session not found: {target_session}")
+        win_name = window_name or f"{spec.cli_id}-{secrets.token_hex(1)}"
+        _run_tmux([
+            "new-window",
+            "-t", target_session,
+            "-n", win_name,
+            "-c", cwd_str,
+            launch_cmd,
+        ])
+        target = target_session
+        window_index = _window_count(target) - 1
+    elif tmux_session_alive(session_name):
+        win_name = window_name or f"{spec.cli_id}-{secrets.token_hex(1)}"
+        _run_tmux([
+            "new-window",
+            "-t", session_name,
+            "-n", win_name,
+            "-c", cwd_str,
+            launch_cmd,
+        ])
+        target = session_name
+        window_index = _window_count(target) - 1
+    else:
+        _run_tmux([
+            "new-session",
+            "-d",
+            "-s", session_name,
+            "-n", window_name or spec.cli_id,
+            "-c", cwd_str,
+            launch_cmd,
+        ])
+        target = session_name
+        window_index = 0
+
+    if task.strip():
+        send_text(target, task.strip(), window_index=window_index)
+
+    session_id = secrets.token_hex(4)
+    launched = LaunchedSession(
+        session_id=session_id,
+        tmux_session=target,
+        cli_id=spec.cli_id,
+        profile=profile,
+        cwd=cwd_str,
+        model_slot=model_slot,
+        model_name=model.model,
+        window_index=window_index,
+        task_preview=task.strip()[:200],
+        created_at=_utc_now(),
+    )
+    ExternalCliStore(profile).add_session(launched)
+    return launched
+
+
+def _window_count(session: str) -> int:
+    result = _run_tmux(["list-windows", "-t", session, "-F", "#{window_index}"])
+    lines = [ln for ln in (result.stdout or "").splitlines() if ln.strip()]
+    return max(1, len(lines))
+
+
+def _utc_now() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
+
+
+def send_text(
+    tmux_session: str,
+    text: str,
+    *,
+    window_index: int = 0,
+    enter: bool = True,
+) -> None:
+    target = f"{tmux_session}:{window_index}"
+    literal = text.replace("\n", " ")
+    _run_tmux(["send-keys", "-t", target, "-l", literal])
+    if enter:
+        _run_tmux(["send-keys", "-t", target, "Enter"])
+
+
+def capture_pane(
+    tmux_session: str,
+    *,
+    window_index: int = 0,
+    lines: int = 40,
+) -> str:
+    target = f"{tmux_session}:{window_index}"
+    result = _run_tmux([
+        "capture-pane",
+        "-t", target,
+        "-p",
+        "-S", f"-{max(1, lines)}",
+    ])
+    return (result.stdout or "").rstrip()
+
+
+def attach_session(tmux_session: str) -> int:
+    """Attach to tmux session (replaces current process on success)."""
+    ensure_launch_platform()
+    proc = subprocess.run(["tmux", "attach", "-t", tmux_session])
+    return proc.returncode
+
+
+def kill_session(tmux_session: str) -> None:
+    _run_tmux(["kill-session", "-t", tmux_session], check=False)
+
+
+def find_launched_session(profile: str, ref: str) -> LaunchedSession | None:
+    store = ExternalCliStore(profile)
+    ref = ref.strip()
+    for session in store.load_sessions():
+        if session.session_id == ref or session.tmux_session == ref:
+            return session
+    return None
+
+
+def prune_dead_sessions(profile: str) -> list[LaunchedSession]:
+    store = ExternalCliStore(profile)
+    alive: list[LaunchedSession] = []
+    for session in store.load_sessions():
+        if tmux_session_alive(session.tmux_session):
+            alive.append(session)
+    store.save_sessions(alive)
+    return alive
+
+
+def launch_cli_by_id(
+    *,
+    profile: str,
+    cli_id: str,
+    profile_config: Any,
+    cwd: Path | None = None,
+    task: str = "",
+    model_slot: str | None = None,
+    new_window: bool = False,
+    target_session: str | None = None,
+) -> LaunchedSession:
+    spec = get_cli_spec(cli_id)
+    if spec is None:
+        raise TmuxError(f"Unknown CLI: {cli_id}. Run: holix launch list")
+
+    store = ExternalCliStore(profile)
+    binding = store.get_binding(cli_id)
+    if binding is None:
+        binding = ExternalCliBinding(
+            cli_id=cli_id,
+            command="",
+            model_slot=model_slot or spec.default_model_slot,
+            agent_slot=model_slot or spec.default_model_slot,
+        )
+    elif model_slot:
+        binding.model_slot = model_slot
+        binding.agent_slot = model_slot
+
+    workdir = cwd
+    if workdir is None and binding.default_cwd.strip():
+        workdir = Path(binding.default_cwd)
+    if workdir is None:
+        workdir = Path.cwd()
+
+    return create_cli_session(
+        profile=profile,
+        spec=spec,
+        binding=binding,
+        profile_config=profile_config,
+        cwd=workdir,
+        task=task,
+        new_window=new_window,
+        target_session=target_session,
+    )

--- a/core/external_cli/__init__.py
+++ b/core/external_cli/__init__.py
@@ -1,0 +1,22 @@
+"""External coding CLIs (Claude Code, OpenCode, …) launched via tmux."""
+
+from core.external_cli.platform import ensure_launch_platform, tmux_available
+from core.external_cli.registry import (
+    EXTERNAL_CLI_REGISTRY,
+    ExternalCliSpec,
+    get_cli_spec,
+    list_cli_specs,
+)
+from core.external_cli.store import ExternalCliBinding, ExternalCliStore, LaunchedSession
+
+__all__ = [
+    "EXTERNAL_CLI_REGISTRY",
+    "ExternalCliBinding",
+    "ExternalCliSpec",
+    "ExternalCliStore",
+    "LaunchedSession",
+    "ensure_launch_platform",
+    "get_cli_spec",
+    "list_cli_specs",
+    "tmux_available",
+]

--- a/core/external_cli/env.py
+++ b/core/external_cli/env.py
@@ -1,0 +1,86 @@
+"""Map Holix profile models to external CLI environment variables."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+from core.external_cli.registry import ExternalCliSpec
+from core.models.manager import ModelConfig, ModelManager
+
+_ENV_VAR_RE = re.compile(r"\$\{([A-Z0-9_]+)\}")
+
+
+def _resolve_api_key(raw: str) -> str:
+    value = (raw or "").strip()
+    if not value:
+        return ""
+    match = _ENV_VAR_RE.fullmatch(value)
+    if match:
+        return os.environ.get(match.group(1), "")
+    return value
+
+
+def resolve_model_for_slot(profile_config: Any, model_slot: str) -> ModelConfig | None:
+    manager = ModelManager(profile_config)
+    slot = (model_slot or "main").strip() or "main"
+    if slot == "main":
+        return manager.get_default_model_config()
+    return manager.get_agent_model_config(slot)
+
+
+def build_cli_env(
+    spec: ExternalCliSpec,
+    model: ModelConfig,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build environment variables for an external CLI from a Holix ModelConfig."""
+    api_key = _resolve_api_key(model.api_key)
+    base_url = (model.base_url or "").rstrip("/")
+    model_name = (model.model or "").strip()
+    env: dict[str, str] = {}
+
+    if spec.env_style == "anthropic":
+        env["ANTHROPIC_API_KEY"] = api_key
+        if base_url:
+            env["ANTHROPIC_BASE_URL"] = base_url
+            env["ANTHROPIC_AUTH_TOKEN"] = api_key
+        if model_name:
+            env["ANTHROPIC_MODEL"] = model_name
+            env["CLAUDE_CODE_SUBAGENT_MODEL"] = model_name
+    elif spec.env_style == "gigacode":
+        env["GIGACODE_API_KEY"] = api_key
+        if base_url:
+            env["GIGACODE_BASE_URL"] = base_url
+        if model_name:
+            env["GIGACODE_MODEL"] = model_name
+        env["OPENAI_API_KEY"] = api_key
+        if base_url:
+            env["OPENAI_BASE_URL"] = base_url
+        if model_name:
+            env["OPENAI_MODEL"] = model_name
+    else:
+        env["OPENAI_API_KEY"] = api_key
+        if base_url:
+            env["OPENAI_BASE_URL"] = base_url
+        if model_name:
+            env["OPENAI_MODEL"] = model_name
+            env["LLM_MODEL"] = model_name
+
+    env["HOLIX_LAUNCH_CLI"] = spec.cli_id
+    env["HOLIX_LAUNCH_MODEL"] = model_name
+    env["HOLIX_LAUNCH_PROVIDER"] = model.provider
+    if extra_env:
+        env.update({k: v for k, v in extra_env.items() if v is not None})
+    return {k: v for k, v in env.items() if v}
+
+
+def env_export_shell(env: dict[str, str]) -> str:
+    """Serialize env dict as shell export statements (safe for bash -c)."""
+    parts: list[str] = []
+    for key, value in sorted(env.items()):
+        escaped = value.replace("'", "'\"'\"'")
+        parts.append(f"export {key}='{escaped}'")
+    return "; ".join(parts)

--- a/core/external_cli/platform.py
+++ b/core/external_cli/platform.py
@@ -1,0 +1,32 @@
+"""Platform guards for external CLI + tmux launch."""
+
+from __future__ import annotations
+
+import shutil
+
+from core.platform_compat import IS_LINUX, IS_MACOS, IS_POSIX
+
+
+class LaunchPlatformError(RuntimeError):
+    """Raised when launch is requested on an unsupported platform."""
+
+
+def launch_supported() -> bool:
+    return IS_POSIX and (IS_LINUX or IS_MACOS)
+
+
+def tmux_available() -> bool:
+    return bool(shutil.which("tmux"))
+
+
+def ensure_launch_platform() -> None:
+    if not launch_supported():
+        raise LaunchPlatformError(
+            "holix launch is available only on Linux and macOS. "
+            "Use holix tui or holix gateway on other platforms."
+        )
+    if not tmux_available():
+        raise LaunchPlatformError(
+            "tmux is not installed. Install it (brew install tmux / apt install tmux) "
+            "and run: holix launch setup"
+        )

--- a/core/external_cli/registry.py
+++ b/core/external_cli/registry.py
@@ -1,0 +1,94 @@
+"""Catalog of supported external coding CLIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+EnvStyle = Literal["openai_compat", "anthropic", "gigacode"]
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalCliSpec:
+    cli_id: str
+    display_name: str
+    binary_names: tuple[str, ...]
+    default_model_slot: str
+    env_style: EnvStyle
+    launch_args: tuple[str, ...] = ()
+    install_hint: str = ""
+    install_commands: tuple[tuple[str, ...], ...] = ()
+    docs_url: str = ""
+    description: str = ""
+
+
+EXTERNAL_CLI_REGISTRY: dict[str, ExternalCliSpec] = {
+    "claude": ExternalCliSpec(
+        cli_id="claude",
+        display_name="Claude Code",
+        binary_names=("claude",),
+        default_model_slot="coder",
+        env_style="anthropic",
+        launch_args=(),
+        install_hint="npm install -g @anthropic-ai/claude-code",
+        install_commands=(("npm", "install", "-g", "@anthropic-ai/claude-code"),),
+        docs_url="https://docs.anthropic.com/en/docs/claude-code",
+        description="Anthropic Claude Code terminal agent",
+    ),
+    "opencode": ExternalCliSpec(
+        cli_id="opencode",
+        display_name="OpenCode",
+        binary_names=("opencode",),
+        default_model_slot="coder",
+        env_style="openai_compat",
+        launch_args=(),
+        install_hint="curl -fsSL https://opencode.ai/install | bash",
+        install_commands=(),
+        docs_url="https://opencode.ai",
+        description="Open-source terminal coding agent (OpenAI-compatible providers)",
+    ),
+    "gigacode": ExternalCliSpec(
+        cli_id="gigacode",
+        display_name="GigaCode",
+        binary_names=("gigacode", "giga"),
+        default_model_slot="coder",
+        env_style="gigacode",
+        launch_args=(),
+        install_hint="See vendor docs — install GigaCode CLI and ensure `gigacode` is on PATH",
+        install_commands=(),
+        docs_url="https://gitverse.ru/gigacode",
+        description="GigaCode CLI (maps Holix profile LLM to GigaCode env)",
+    ),
+    "codex": ExternalCliSpec(
+        cli_id="codex",
+        display_name="OpenAI Codex CLI",
+        binary_names=("codex",),
+        default_model_slot="coder",
+        env_style="openai_compat",
+        launch_args=(),
+        install_hint="npm install -g @openai/codex",
+        install_commands=(("npm", "install", "-g", "@openai/codex"),),
+        docs_url="https://github.com/openai/codex",
+        description="OpenAI Codex terminal agent",
+    ),
+    "aider": ExternalCliSpec(
+        cli_id="aider",
+        display_name="Aider",
+        binary_names=("aider",),
+        default_model_slot="coder",
+        env_style="openai_compat",
+        launch_args=("--no-git",),
+        install_hint="uv tool install aider-chat  OR  pip install aider-chat",
+        install_commands=(("uv", "tool", "install", "aider-chat"),),
+        docs_url="https://aider.chat",
+        description="Pair-programming CLI (OpenAI-compatible endpoint from profile)",
+    ),
+}
+
+
+def list_cli_specs() -> list[ExternalCliSpec]:
+    return list(EXTERNAL_CLI_REGISTRY.values())
+
+
+def get_cli_spec(cli_id: str) -> ExternalCliSpec | None:
+    return EXTERNAL_CLI_REGISTRY.get(cli_id.strip().lower())

--- a/core/external_cli/store.py
+++ b/core/external_cli/store.py
@@ -1,0 +1,173 @@
+"""Per-profile persistence for external CLI bindings and tmux sessions."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Self
+
+from core.platform_compat import resolve_holix_home
+
+
+def external_cli_dir(profile: str) -> Path:
+    return (resolve_holix_home() / "profiles" / profile / "external_clis").resolve()
+
+
+def bindings_path(profile: str) -> Path:
+    return external_cli_dir(profile) / "bindings.json"
+
+
+def sessions_path(profile: str) -> Path:
+    return external_cli_dir(profile) / "sessions.json"
+
+
+@dataclass(slots=True)
+class ExternalCliBinding:
+    cli_id: str
+    enabled: bool = True
+    command: str = ""
+    model_slot: str = "coder"
+    agent_slot: str = "coder"
+    default_cwd: str = ""
+    extra_env: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            cli_id=str(data["cli_id"]),
+            enabled=bool(data.get("enabled", True)),
+            command=str(data.get("command") or ""),
+            model_slot=str(data.get("model_slot") or "coder"),
+            agent_slot=str(data.get("agent_slot") or "coder"),
+            default_cwd=str(data.get("default_cwd") or ""),
+            extra_env=dict(data.get("extra_env") or {}),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class LaunchedSession:
+    session_id: str
+    tmux_session: str
+    cli_id: str
+    profile: str
+    cwd: str
+    model_slot: str
+    model_name: str
+    window_index: int = 0
+    pane_index: int = 0
+    task_preview: str = ""
+    created_at: str = ""
+    last_output_at: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            session_id=str(data["session_id"]),
+            tmux_session=str(data["tmux_session"]),
+            cli_id=str(data["cli_id"]),
+            profile=str(data["profile"]),
+            cwd=str(data.get("cwd") or ""),
+            model_slot=str(data.get("model_slot") or "coder"),
+            model_name=str(data.get("model_name") or ""),
+            window_index=int(data.get("window_index", 0)),
+            pane_index=int(data.get("pane_index", 0)),
+            task_preview=str(data.get("task_preview") or ""),
+            created_at=str(data.get("created_at") or ""),
+            last_output_at=str(data.get("last_output_at") or ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class ExternalCliStore:
+    def __init__(self, profile: str) -> None:
+        self.profile = profile
+        external_cli_dir(profile).mkdir(parents=True, exist_ok=True)
+
+    def load_bindings(self) -> dict[str, ExternalCliBinding]:
+        path = bindings_path(self.profile)
+        if not path.is_file():
+            return {}
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+        items = raw.get("bindings") if isinstance(raw, dict) else raw
+        if not isinstance(items, list):
+            return {}
+        out: dict[str, ExternalCliBinding] = {}
+        for item in items:
+            if not isinstance(item, dict) or "cli_id" not in item:
+                continue
+            binding = ExternalCliBinding.from_dict(item)
+            out[binding.cli_id] = binding
+        return out
+
+    def save_bindings(self, bindings: dict[str, ExternalCliBinding]) -> None:
+        data = {"bindings": [b.to_dict() for b in bindings.values()]}
+        bindings_path(self.profile).write_text(
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    def get_binding(self, cli_id: str) -> ExternalCliBinding | None:
+        return self.load_bindings().get(cli_id.strip().lower())
+
+    def upsert_binding(self, binding: ExternalCliBinding) -> None:
+        bindings = self.load_bindings()
+        bindings[binding.cli_id] = binding
+        self.save_bindings(bindings)
+
+    def load_sessions(self) -> list[LaunchedSession]:
+        path = sessions_path(self.profile)
+        if not path.is_file():
+            return []
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return []
+        items = raw.get("sessions") if isinstance(raw, dict) else raw
+        if not isinstance(items, list):
+            return []
+        out: list[LaunchedSession] = []
+        for item in items:
+            if isinstance(item, dict) and item.get("session_id"):
+                out.append(LaunchedSession.from_dict(item))
+        return out
+
+    def save_sessions(self, sessions: list[LaunchedSession]) -> None:
+        data = {"sessions": [s.to_dict() for s in sessions]}
+        sessions_path(self.profile).write_text(
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    def add_session(self, session: LaunchedSession) -> None:
+        sessions = self.load_sessions()
+        sessions = [s for s in sessions if s.session_id != session.session_id]
+        sessions.append(session)
+        self.save_sessions(sessions)
+
+    def remove_session(self, session_id: str) -> None:
+        sessions = [s for s in self.load_sessions() if s.session_id != session_id]
+        self.save_sessions(sessions)
+
+    def touch_session_output(self, session_id: str) -> None:
+        sessions = self.load_sessions()
+        now = datetime.now(UTC).isoformat()
+        changed = False
+        for idx, session in enumerate(sessions):
+            if session.session_id == session_id:
+                sessions[idx] = LaunchedSession(
+                    **{**session.to_dict(), "last_output_at": now}
+                )
+                changed = True
+                break
+        if changed:
+            self.save_sessions(sessions)

--- a/core/tools/external_cli.py
+++ b/core/tools/external_cli.py
@@ -1,0 +1,131 @@
+"""Delegate coding tasks to external CLIs running in tmux (Linux/macOS)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.external_cli.platform import launch_supported
+from core.tools.base import BaseTool
+from core.tools.execution_context import get_profile_name
+
+
+class ExternalCliTool(BaseTool):
+    """Launch or message external coding CLIs (Claude Code, OpenCode, …) via tmux."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "external_cli"
+        self.description = (
+            "Launch or send tasks to external coding CLIs in tmux (claude, opencode, gigacode, …). "
+            "Uses LLM credentials from the active Holix profile. Linux/macOS only."
+        )
+        self.risk_level = "medium"
+        self.parameters = {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["launch", "send", "output", "list_sessions"],
+                    "description": "launch: start CLI in tmux; send: prompt running session; output: read pane; list_sessions",
+                },
+                "cli_id": {
+                    "type": "string",
+                    "description": "CLI id: claude, opencode, gigacode, codex, aider",
+                },
+                "task": {
+                    "type": "string",
+                    "description": "Initial or follow-up prompt for the external CLI",
+                },
+                "session": {
+                    "type": "string",
+                    "description": "Holix session id or tmux session name (for send/output)",
+                },
+                "cwd": {
+                    "type": "string",
+                    "description": "Working directory for launch",
+                },
+                "model_slot": {
+                    "type": "string",
+                    "description": "Profile model slot (main, coder, …)",
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs) -> str:
+        if not launch_supported():
+            return "Error: external_cli is available only on Linux and macOS."
+
+        action = (kwargs.get("action") or "").strip().lower()
+        profile = get_profile_name() or "default"
+
+        try:
+            from cli.core import get_profile_manager
+            from cli.services.tmux_launcher import (
+                capture_pane,
+                find_launched_session,
+                launch_cli_by_id,
+                prune_dead_sessions,
+                send_text,
+                tmux_session_alive,
+            )
+
+            from core.external_cli.registry import get_cli_spec
+        except ImportError as exc:
+            return f"Error: external_cli unavailable ({exc})"
+
+        config = get_profile_manager().load_profile(profile)
+
+        if action == "list_sessions":
+            sessions = prune_dead_sessions(profile)
+            if not sessions:
+                return "No active external CLI sessions. Use action=launch to start one."
+            lines = []
+            for s in sessions:
+                lines.append(
+                    f"- {s.session_id}: {s.cli_id} @ {s.tmux_session}:{s.window_index} "
+                    f"model={s.model_name} cwd={s.cwd}"
+                )
+            return "\n".join(lines)
+
+        if action == "launch":
+            cli_id = (kwargs.get("cli_id") or "").strip().lower()
+            if not cli_id or not get_cli_spec(cli_id):
+                return "Error: cli_id required (claude, opencode, gigacode, codex, aider)."
+            cwd_raw = (kwargs.get("cwd") or "").strip()
+            cwd = Path(cwd_raw) if cwd_raw else None
+            task = (kwargs.get("task") or "").strip()
+            model_slot = (kwargs.get("model_slot") or "").strip() or None
+            launched = launch_cli_by_id(
+                profile=profile,
+                cli_id=cli_id,
+                profile_config=config,
+                cwd=cwd,
+                task=task,
+                model_slot=model_slot,
+            )
+            return (
+                f"Launched {cli_id} in tmux session {launched.tmux_session} "
+                f"(id={launched.session_id}, model={launched.model_name}, cwd={launched.cwd}). "
+                f"Use action=send with session={launched.session_id} for follow-ups."
+            )
+
+        if action in {"send", "output"}:
+            session_ref = (kwargs.get("session") or "").strip()
+            if not session_ref:
+                return "Error: session required for send/output."
+            found = find_launched_session(profile, session_ref)
+            target = found.tmux_session if found else session_ref
+            if not tmux_session_alive(target):
+                return f"Error: tmux session not found: {session_ref}"
+            window = found.window_index if found else 0
+            if action == "send":
+                task = (kwargs.get("task") or "").strip()
+                if not task:
+                    return "Error: task required for send."
+                send_text(target, task, window_index=window)
+                return f"Sent prompt to {target}:{window}"
+            text = capture_pane(target, window_index=window, lines=50)
+            return text or "(empty pane)"
+
+        return f"Error: unknown action '{action}'"

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -64,6 +64,12 @@ class ToolRegistry:
 
         # System
         self.register(TerminalTool())
+        from core.external_cli.platform import launch_supported
+
+        if launch_supported():
+            from core.tools.external_cli import ExternalCliTool
+
+            self.register(ExternalCliTool())
 
         # Web
         self.register(WebSearchTool())

--- a/tests/test_external_cli.py
+++ b/tests/test_external_cli.py
@@ -1,0 +1,116 @@
+"""External CLI launch (tmux) — unit tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from core.external_cli.env import build_cli_env, resolve_model_for_slot
+from core.external_cli.platform import launch_supported
+from core.external_cli.registry import get_cli_spec
+from core.external_cli.store import ExternalCliBinding, ExternalCliStore
+from core.models.manager import ModelConfig
+
+
+@pytest.fixture
+def holix_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "holix"
+    home.mkdir()
+    monkeypatch.setenv("HOLIX_HOME", str(home))
+    return home
+
+
+def test_launch_supported_on_posix() -> None:
+    import sys
+
+    if sys.platform == "win32":
+        assert launch_supported() is False
+    else:
+        assert launch_supported() is True
+
+
+def test_build_cli_env_openai_compat() -> None:
+    spec = get_cli_spec("opencode")
+    assert spec is not None
+    model = ModelConfig(
+        provider="ollama",
+        model="qwen2.5-coder",
+        base_url="http://127.0.0.1:11434/v1",
+        api_key="ollama",
+    )
+    env = build_cli_env(spec, model)
+    assert env["OPENAI_API_KEY"] == "ollama"
+    assert env["OPENAI_BASE_URL"] == "http://127.0.0.1:11434/v1"
+    assert env["OPENAI_MODEL"] == "qwen2.5-coder"
+
+
+def test_build_cli_env_anthropic() -> None:
+    spec = get_cli_spec("claude")
+    assert spec is not None
+    model = ModelConfig(
+        provider="openai",
+        model="claude-sonnet",
+        base_url="http://proxy/v1",
+        api_key="sk-test",
+    )
+    env = build_cli_env(spec, model)
+    assert env["ANTHROPIC_API_KEY"] == "sk-test"
+    assert env["ANTHROPIC_BASE_URL"] == "http://proxy/v1"
+
+
+def test_resolve_model_legacy_profile() -> None:
+    cfg = SimpleNamespace(
+        providers={},
+        default_provider=None,
+        models_via_providers=False,
+        model="local-model",
+        base_url="http://localhost/v1",
+        api_key="key",
+        temperature=0.5,
+        agent_models={},
+    )
+    model = resolve_model_for_slot(cfg, "main")
+    assert model is not None
+    assert model.model == "local-model"
+
+
+def test_external_cli_store_roundtrip(holix_home) -> None:
+    store = ExternalCliStore("default")
+    binding = ExternalCliBinding(
+        cli_id="claude",
+        enabled=True,
+        command="/usr/bin/claude",
+        model_slot="coder",
+        default_cwd="/tmp/proj",
+    )
+    store.upsert_binding(binding)
+    loaded = store.get_binding("claude")
+    assert loaded is not None
+    assert loaded.command == "/usr/bin/claude"
+    assert loaded.model_slot == "coder"
+
+
+@pytest.mark.asyncio
+async def test_external_cli_tool_list_empty(holix_home, monkeypatch) -> None:
+    from core.tools.external_cli import ExternalCliTool
+
+    monkeypatch.setattr("core.tools.external_cli.launch_supported", lambda: True)
+    monkeypatch.setattr("core.tools.external_cli.get_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        "cli.services.tmux_launcher.prune_dead_sessions",
+        lambda _profile: [],
+    )
+    tool = ExternalCliTool()
+    result = await tool.execute(action="list_sessions")
+    assert "No active" in result
+
+
+@pytest.mark.asyncio
+async def test_external_cli_tool_windows_message(monkeypatch) -> None:
+    from core.tools.external_cli import ExternalCliTool
+
+    monkeypatch.setattr("core.tools.external_cli.launch_supported", lambda: False)
+    tool = ExternalCliTool()
+    result = await tool.execute(action="launch", cli_id="claude")
+    assert "Linux and macOS" in result


### PR DESCRIPTION
## Summary

Запуск внешних coding CLI (Claude Code, OpenCode, GigaCode, Codex, Aider) в **tmux** на Linux/macOS с моделями из профиля Holix.

## Команды

```bash
holix launch setup                    # интерактивная установка и привязка к профилю
holix launch list                     # доступные CLI и биндинги
holix launch claude -t "implement X" -C ./project
holix launch opencode --window -s holix-docs-claude-ab12   # новая вкладка
holix launch sessions                 # сессии Holix
holix launch tmux                     # все tmux-сессии
holix launch attach <name>
holix launch send <id> "follow-up prompt"
holix launch chat <id>                # интерактивный relay
holix launch output <id>
```

## Агент

Инструмент `external_cli` (только Linux/macOS) — делегирование задач из графа Holix.

## Test plan

- [x] ruff
- [x] pytest -m "not llm" (1131 passed)
- [x] `holix launch --help`