### PR TITLE
feat(messenger): русский язык по умолчанию для Telegram и MAX

### DIFF
--- a/integrations/max/access_approval.py
+++ b/integrations/max/access_approval.py
@@ -81,6 +81,9 @@ def _prepare_profile_for_user(
                 bot_profile=bot_profile,
                 user_profile=target_profile,
             )
+        from integrations.messenger.locale import apply_messenger_locale
+
+        apply_messenger_locale(target_profile)
         return access_key, key_already_set
 
     if not manager.profile_exists(target_profile):
@@ -93,6 +96,9 @@ def _prepare_profile_for_user(
             bot_profile=bot_profile,
             user_profile=target_profile,
         )
+    from integrations.messenger.locale import ensure_messenger_locale
+
+    ensure_messenger_locale(target_profile)
     return None, profile_has_access_key(target_profile)
 
 

--- a/integrations/max/admin_broadcast.py
+++ b/integrations/max/admin_broadcast.py
@@ -159,26 +159,27 @@ async def deliver_broadcast(
 
 async def handle_admin_message_command(host: Any, command: str) -> None:
     """Parse ``/message`` and start compose mode or show help."""
-    from core.i18n import host_locale, t
+    from core.i18n import t
+    from integrations.messenger.locale import messenger_host_locale
 
     session = host._session
     bot_profile = getattr(session, "bot_profile", "default")
     user_id = int(getattr(session, "user_id", 0))
 
     if not is_max_admin(bot_profile, user_id):
-        await host._send_html(escape_html(t("tg.message_admin_only", host_locale(host))))
+        await host._send_html(escape_html(t("tg.message_admin_only", messenger_host_locale(host))))
         return
 
     parts = command.strip().split()
     sub = parts[1].lower() if len(parts) > 1 else ""
 
     if sub in {"", "help"}:
-        await host._send_html(t("tg.message_help", host_locale(host)))
+        await host._send_html(t("tg.message_help", messenger_host_locale(host)))
         return
 
     if sub == "cancel":
         session.pending_admin_broadcast = None
-        await host._send_html(escape_html(t("tg.message_cancelled", host_locale(host))))
+        await host._send_html(escape_html(t("tg.message_cancelled", messenger_host_locale(host))))
         return
 
     target = parts[1]
@@ -196,7 +197,7 @@ async def handle_admin_message_command(host: Any, command: str) -> None:
             )
             if not recipients:
                 await host._send_html(
-                    escape_html(t("tg.message_unknown_profile", host_locale(host), name=target))
+                    escape_html(t("tg.message_unknown_profile", messenger_host_locale(host), name=target))
                 )
                 return
         draft_target = target
@@ -207,16 +208,16 @@ async def handle_admin_message_command(host: Any, command: str) -> None:
         exclude_user_id=user_id,
     )
     if not recipients:
-        await host._send_html(escape_html(t("tg.message_no_recipients", host_locale(host))))
+        await host._send_html(escape_html(t("tg.message_no_recipients", messenger_host_locale(host))))
         return
 
     session.pending_admin_broadcast = AdminBroadcastDraft(target=draft_target)
     if draft_target.lower() == "all":
-        hint = t("tg.message_compose_all", host_locale(host), count=len(recipients))
+        hint = t("tg.message_compose_all", messenger_host_locale(host), count=len(recipients))
     else:
         hint = t(
             "tg.message_compose_profile",
-            host_locale(host),
+            messenger_host_locale(host),
             profile=escape_html(draft_target),
             count=len(recipients),
         )

--- a/integrations/max/agent_setup.py
+++ b/integrations/max/agent_setup.py
@@ -28,6 +28,9 @@ async def create_agent(
                 bot_profile=bot_profile,
                 user_profile=profile,
             )
+    from integrations.messenger.locale import ensure_messenger_locale
+
+    ensure_messenger_locale(profile)
     config = config or init_profile(profile, profile_key=profile_key, prompt_key=False)
     from core.paths import ensure_profile_memory_dirs
 

--- a/integrations/max/approvals.py
+++ b/integrations/max/approvals.py
@@ -99,10 +99,10 @@ class MaxApprovals:
             attachments=[plan_review_keyboard(token)],
             **reply,
         )
-        from core.i18n.locale import LocaleStore
+        from integrations.messenger.locale import messenger_locale
         from core.i18n.messages import t
 
-        lang = LocaleStore(self._session.profile).get()
+        lang = messenger_locale(self._session.profile)
         hint_key = (
             "plan.clarify.hint"
             if self._session.pending_plan_phase == "clarification"

--- a/integrations/max/bot.py
+++ b/integrations/max/bot.py
@@ -262,9 +262,21 @@ class HelixMaxBot:
             await self._handle_unauthorized(client, uid, meta=meta, is_start=True)
             return
         try:
-            from core.i18n import LocaleStore
+            from integrations.messenger.locale import (
+                bootstrap_messenger_locales,
+                messenger_locale,
+            )
+            from integrations.messenger.platforms import MAX_PLATFORM
 
-            locale = LocaleStore(self.settings.profile).get()
+            asyncio.create_task(
+                asyncio.to_thread(
+                    bootstrap_messenger_locales,
+                    MAX_PLATFORM,
+                    self.settings.profile,
+                ),
+                name="max-locale-bootstrap",
+            )
+            locale = messenger_locale(self.settings.profile)
             await register_bot_commands(client, locale=locale)
         except Exception:
             logger.exception("Failed to sync MAX command menu on bot_started")

--- a/integrations/max/commands.py
+++ b/integrations/max/commands.py
@@ -46,7 +46,7 @@ async def register_bot_commands(
 
 async def sync_bot_menu(profile: str = "default") -> list[str]:
     """Push command menu to MAX API without starting polling."""
-    from core.i18n import LocaleStore
+    from integrations.messenger.locale import messenger_locale
 
     from integrations.max.config import load_max_settings
 
@@ -55,7 +55,7 @@ async def sync_bot_menu(profile: str = "default") -> list[str]:
     if not token:
         raise RuntimeError("MAX_ACCESS_TOKEN is not set. Run: holix max setup")
 
-    locale = LocaleStore(profile).get()
+    locale = messenger_locale(profile)
     async with MaxClient(token) as client:
         return await register_bot_commands(client, locale=locale)
 

--- a/integrations/max/gateway_routes.py
+++ b/integrations/max/gateway_routes.py
@@ -89,11 +89,11 @@ async def init_max_webhook(profile: str | None = None) -> MaxGatewayState | None
         raise
 
     try:
-        from core.i18n import LocaleStore
+        from integrations.messenger.locale import messenger_locale
 
         from integrations.max.commands import register_bot_commands
 
-        locale = LocaleStore(profile).get()
+        locale = messenger_locale(profile)
         registered = await register_bot_commands(client, locale=locale)
         if registered:
             logger.info("MAX menu: %d commands", len(registered))

--- a/integrations/max/host.py
+++ b/integrations/max/host.py
@@ -9,7 +9,8 @@ from typing import Any
 from cli.shared.commands.agent_commands import AgentCommands
 from cli.shared.rich_text import content_to_plain_text
 from cli.shared.slash_input import is_slash_command, normalize_slash_input
-from core.i18n import host_locale, t
+from core.i18n import t
+from integrations.messenger.locale import messenger_host_locale
 
 from integrations.max.client import MaxClient
 from integrations.max.commands import help_message_markdown
@@ -207,16 +208,16 @@ class MaxHost:
     def action_clear_chat(self) -> None:
         self._session._transcript_store.clear()
         self._session._recent_tool_results.clear()
-        self.transcript_write(t("cleared", host_locale(self)))
+        self.transcript_write(t("cleared", messenger_host_locale(self)))
 
     def action_help(self) -> None:
-        asyncio.create_task(self._send_text(help_message_markdown(host_locale(self))))
+        asyncio.create_task(self._send_text(help_message_markdown(messenger_host_locale(self))))
 
     async def action_status(self) -> None:
         await self._interactive.show_status()
 
     def action_copy_output(self) -> None:
-        lang = host_locale(self)
+        lang = messenger_host_locale(self)
         text = self._session._transcript_store.last_assistant()
         if text:
             self.copy_text(text, label=t("copy_label", lang))
@@ -224,12 +225,12 @@ class MaxHost:
             self.transcript_write(t("copy_nothing", lang))
 
     def action_open_transcript(self) -> None:
-        lang = host_locale(self)
+        lang = messenger_host_locale(self)
         body = self._session._transcript_store.format_all()
         self.copy_text(body or t("transcript_empty", lang), label="transcript")
 
     def copy_text(self, text: str, *, label: str = "copied") -> None:
-        lang = host_locale(self)
+        lang = messenger_host_locale(self)
         if not text or not text.strip():
             self.transcript_write(t("copy_nothing", lang))
             return
@@ -383,7 +384,7 @@ class MaxHost:
 
     async def _mcp_install(self, what: str = "") -> None:
         if not self._mcp_management_allowed():
-            await self._send_text(t("tg.mcp_read_only", host_locale(self)))
+            await self._send_text(t("tg.mcp_read_only", messenger_host_locale(self)))
             return
         self.transcript_write(
             "Установка MCP через MAX пока не поддерживается. Используйте: `helix mcp install` в терминале."

--- a/integrations/max/interactive.py
+++ b/integrations/max/interactive.py
@@ -10,7 +10,8 @@ from cli.shared.slash_input import (
     normalize_slash_input,
     slash_command_token,
 )
-from core.i18n import host_locale, t
+from core.i18n import t
+from integrations.messenger.locale import messenger_host_locale
 
 from integrations.max.keyboards import (
     MODE_LABELS,
@@ -59,7 +60,7 @@ class MaxInteractive:
             self._session.user_id,
         ):
             return False
-        await self._host._send_text(t("tg.menu_unavailable", host_locale(self._host)))
+        await self._host._send_text(t("tg.menu_unavailable", messenger_host_locale(self._host)))
         return True
 
     async def handle_slash(self, command: str) -> bool:
@@ -78,7 +79,7 @@ class MaxInteractive:
         if is_mode_slash(cmd):
             if len(parts) > 1 and parts[1] in self._host._execution_modes:
                 self._host._execution_mode_index = self._host._execution_modes.index(parts[1])
-                await self._host._send_text(t("mode_set", host_locale(self._host), mode=parts[1]))
+                await self._host._send_text(t("mode_set", messenger_host_locale(self._host), mode=parts[1]))
             else:
                 await self.show_mode_picker()
             return True
@@ -87,7 +88,7 @@ class MaxInteractive:
             if len(parts) > 1:
                 self._host.streaming_enabled = parts[1] in ("on", "true", "1")
                 state = "on" if self._host.streaming_enabled else "off"
-                await self._host._send_text(t("streaming", host_locale(self._host), state=state))
+                await self._host._send_text(t("streaming", messenger_host_locale(self._host), state=state))
             else:
                 await self.show_stream_picker()
             return True
@@ -150,16 +151,16 @@ class MaxInteractive:
         if action == "m" and value in self._host._execution_modes:
             self._host._execution_mode_index = self._host._execution_modes.index(value)
             await self.show_mode_picker()
-            return t("tg.mode", host_locale(self._host), mode=value)
+            return t("tg.mode", messenger_host_locale(self._host), mode=value)
 
         if action == "st":
             self._host.streaming_enabled = value == "1"
             await self.show_stream_picker()
             state = "on" if self._host.streaming_enabled else "off"
-            return t("tg.streaming", host_locale(self._host), state=state)
+            return t("tg.streaming", messenger_host_locale(self._host), state=state)
 
         if action == "pi":
-            lang = host_locale(self._host)
+            lang = messenger_host_locale(self._host)
             profiles = self._session.ui_profiles
             idx = int(value)
             if 0 <= idx < len(profiles):
@@ -187,10 +188,10 @@ class MaxInteractive:
 
                 restored = restore_session_model(self._host)
                 title = sessions[idx].get("title") or cid
-                model_line = f"\n{t('tg.model', host_locale(self._host), label=restored)}" if restored else ""
+                model_line = f"\n{t('tg.model', messenger_host_locale(self._host), label=restored)}" if restored else ""
                 await self._host._send_text(f"**Сессия:** `{title}`{model_line}")
-                return t("tg.session_switched", host_locale(self._host))
-            return t("tg.session_invalid", host_locale(self._host))
+                return t("tg.session_switched", messenger_host_locale(self._host))
+            return t("tg.session_invalid", messenger_host_locale(self._host))
 
         if action == "sp":
             await self.show_sessions_picker(page=int(value))
@@ -199,11 +200,11 @@ class MaxInteractive:
         if action == "sn":
             await self._host._create_new_session()
             await self.show_sessions_picker()
-            return t("tg.new_session", host_locale(self._host))
+            return t("tg.new_session", messenger_host_locale(self._host))
 
         if action == "t":
             self._host._show_full_tool_result(int(value))
-            return t("tg.tool_result", host_locale(self._host))
+            return t("tg.tool_result", messenger_host_locale(self._host))
 
         if action == "mp":
             label = await apply_preset_index(self._host, int(value))
@@ -212,7 +213,7 @@ class MaxInteractive:
                 await self.show_provider_models(idx, page=self._session.ui_models_page)
             else:
                 await self.show_models(page=self._session.ui_providers_page)
-            return t("tg.model", host_locale(self._host), label=label)
+            return t("tg.model", messenger_host_locale(self._host), label=label)
 
         if action == "mg":
             await self.show_provider_models(int(value), page=0)
@@ -231,11 +232,11 @@ class MaxInteractive:
         if action == "mm":
             parts = value.split(":", 1)
             if len(parts) != 2:
-                return t("tg.error", host_locale(self._host))
+                return t("tg.error", messenger_host_locale(self._host))
             pi, mi = int(parts[0]), int(parts[1])
             label = await apply_provider_model_index(self._host, pi, mi)
             await self.show_provider_models(pi, page=self._session.ui_models_page)
-            return t("tg.model", host_locale(self._host), label=label)
+            return t("tg.model", messenger_host_locale(self._host), label=label)
 
         if action == "mb":
             await self.show_models()
@@ -253,7 +254,7 @@ class MaxInteractive:
             await self._handle_cron_callback(value)
             return ""
 
-        return t("tg.unknown_action", host_locale(self._host))
+        return t("tg.unknown_action", messenger_host_locale(self._host))
 
     async def _refresh(self, kind: str) -> None:
         from integrations.max.command_access import is_menu_action_allowed
@@ -263,7 +264,7 @@ class MaxInteractive:
             self._session.bot_profile,
             self._session.user_id,
         ):
-            await self._host._send_text(t("tg.menu_unavailable", host_locale(self._host)))
+            await self._host._send_text(t("tg.menu_unavailable", messenger_host_locale(self._host)))
             return
 
         if kind == "compress":
@@ -308,7 +309,7 @@ class MaxInteractive:
 
         profiles = self._host._get_available_profiles()
         self._session.ui_profiles = profiles
-        lang = host_locale(self._host)
+        lang = messenger_host_locale(self._host)
         current = self._host.profile
 
         if is_profile_list_hidden(self._session.bot_profile, self._session.user_id):
@@ -359,7 +360,7 @@ class MaxInteractive:
     async def show_tools_picker(self) -> None:
         tools = self._host._recent_tool_results
         if not tools:
-            await self._host._send_text(t("tg.no_tools", host_locale(self._host)))
+            await self._host._send_text(t("tg.no_tools", messenger_host_locale(self._host)))
             return
         lines = ["**Последние tools**", "_Нажмите, чтобы получить полный вывод_"]
         await self._host._send_text_with_keyboard(
@@ -505,7 +506,7 @@ class MaxInteractive:
                 ],
             ]
             if not servers:
-                text_lines.append(f"\n_{t('tg.mcp_read_only_empty', host_locale(host))}_")
+                text_lines.append(f"\n_{t('tg.mcp_read_only_empty', messenger_host_locale(host))}_")
 
         if len(parts) > 1:
             sub = parts[1]
@@ -518,7 +519,7 @@ class MaxInteractive:
                 return
             if sub in ("install", "add", "assign", "remove", "rm", "delete", "test"):
                 if not can_manage_mcp:
-                    await host._send_text(t("tg.mcp_read_only", host_locale(host)))
+                    await host._send_text(t("tg.mcp_read_only", messenger_host_locale(host)))
                     return
             if sub in ("install", "add"):
                 arg = " ".join(parts[2:]) if len(parts) > 2 else ""
@@ -532,7 +533,7 @@ class MaxInteractive:
         await host._send_text_with_keyboard("\n".join(text_lines), inline_keyboard(rows))
 
     async def _deny_mcp_management(self) -> None:
-        await self._host._send_text(t("tg.mcp_read_only", host_locale(self._host)))
+        await self._host._send_text(t("tg.mcp_read_only", messenger_host_locale(self._host)))
 
     async def _handle_mcp_callback(self, value: str) -> None:
         from integrations.max.command_access import is_mcp_management_allowed
@@ -689,7 +690,7 @@ class MaxInteractive:
         is_admin = is_max_admin(self._session.bot_profile, self._session.user_id)
         await self._host._send_text_with_keyboard(
             "\n".join(lines),
-            status_menu_keyboard(host_locale(self._host), is_admin=is_admin),
+            status_menu_keyboard(messenger_host_locale(self._host), is_admin=is_admin),
         )
 
 

--- a/integrations/max/keyboards.py
+++ b/integrations/max/keyboards.py
@@ -226,7 +226,9 @@ def models_provider_keyboard(
 def status_menu_keyboard(locale: str | None = None, *, is_admin: bool = True) -> dict[str, Any]:
     from core.i18n.messages import t
 
-    loc = locale or "en"
+    from integrations.messenger.locale import MESSENGER_DEFAULT_LOCALE
+
+    loc = locale or MESSENGER_DEFAULT_LOCALE
     row0: list[dict[str, str]] = [
         _callback_btn(t("tg.menu.mode", loc), _cb("r", "mode")),
     ]

--- a/integrations/max/notify.py
+++ b/integrations/max/notify.py
@@ -89,11 +89,11 @@ async def notify_access_approved(
     async with MaxClient(token) as client:
         await send_user_message(client, int(user_id), text)
         try:
-            from core.i18n import LocaleStore
+            from integrations.messenger.locale import messenger_locale
 
             from integrations.max.commands import register_bot_commands
 
-            locale = LocaleStore(bot_profile).get()
+            locale = messenger_locale(bot_profile)
             await register_bot_commands(client, locale=locale)
         except Exception:
             pass

--- a/integrations/max/polling.py
+++ b/integrations/max/polling.py
@@ -40,11 +40,22 @@ async def run_polling(settings: MaxSettings | None = None, *, profile: str = "de
             raise
 
         try:
-            from core.i18n import LocaleStore
+            import asyncio
+
+            from integrations.messenger.locale import (
+                bootstrap_messenger_locales,
+                messenger_locale,
+            )
+            from integrations.messenger.platforms import MAX_PLATFORM
 
             from integrations.max.commands import register_bot_commands
 
-            locale = LocaleStore(settings.profile).get()
+            await asyncio.to_thread(
+                bootstrap_messenger_locales,
+                MAX_PLATFORM,
+                settings.profile,
+            )
+            locale = messenger_locale(settings.profile)
             registered = await register_bot_commands(api_client, locale=locale)
             if registered:
                 logger.info("MAX menu: %d commands", len(registered))

--- a/integrations/messenger/locale.py
+++ b/integrations/messenger/locale.py
@@ -1,0 +1,56 @@
+"""Default UI locale for Telegram and MAX messenger integrations."""
+
+from __future__ import annotations
+
+from core.i18n.locale import LocaleStore, locale_path
+
+MESSENGER_DEFAULT_LOCALE = "ru"
+
+
+def messenger_locale(profile: str) -> str:
+    """Resolve UI language for a messenger session profile."""
+    name = (profile or "default").strip() or "default"
+    store = LocaleStore(name)
+    if not store._path.exists():
+        return MESSENGER_DEFAULT_LOCALE
+    return store.get()
+
+
+def apply_messenger_locale(profile: str, *, locale: str = MESSENGER_DEFAULT_LOCALE) -> str:
+    """Persist messenger default locale for a profile (new user onboarding)."""
+    return LocaleStore((profile or "default").strip() or "default").set(locale)
+
+
+def ensure_messenger_locale(profile: str) -> str:
+    """Set messenger default locale when the profile has no saved locale yet."""
+    name = (profile or "default").strip() or "default"
+    if locale_path(name).is_file():
+        return LocaleStore(name).get()
+    return apply_messenger_locale(name)
+
+
+def messenger_host_locale(host: object) -> str:
+    from core.i18n.locale import host_profile_name
+
+    return messenger_locale(host_profile_name(host))
+
+
+def bootstrap_messenger_locales(platform, bot_profile: str) -> list[str]:
+    """Ensure RU locale for bot host, admin, and mapped users without locale.json."""
+    from integrations.messenger.admin import load_admin_holix_profile
+    from integrations.messenger.user_profiles import load_user_profiles
+
+    bot_profile = (bot_profile or "default").strip() or "default"
+    names: set[str] = {bot_profile}
+    admin_profile = load_admin_holix_profile(platform, bot_profile)
+    if admin_profile:
+        names.add(admin_profile)
+    for holix_profile in load_user_profiles(platform, bot_profile).values():
+        names.add(holix_profile)
+
+    updated: list[str] = []
+    for name in sorted(names):
+        if not locale_path(name).is_file():
+            ensure_messenger_locale(name)
+            updated.append(name)
+    return updated

--- a/integrations/telegram/access_approval.py
+++ b/integrations/telegram/access_approval.py
@@ -86,6 +86,9 @@ def _prepare_profile_for_user(
                 bot_profile=bot_profile,
                 user_profile=target_profile,
             )
+        from integrations.messenger.locale import apply_messenger_locale
+
+        apply_messenger_locale(target_profile)
         return access_key, key_already_set
 
     if not manager.profile_exists(target_profile):
@@ -98,6 +101,9 @@ def _prepare_profile_for_user(
             bot_profile=bot_profile,
             user_profile=target_profile,
         )
+    from integrations.messenger.locale import ensure_messenger_locale
+
+    ensure_messenger_locale(target_profile)
     return None, profile_has_access_key(target_profile)
 
 

--- a/integrations/telegram/admin_broadcast.py
+++ b/integrations/telegram/admin_broadcast.py
@@ -167,26 +167,27 @@ async def deliver_broadcast(
 
 async def handle_admin_message_command(host: Any, command: str) -> None:
     """Parse ``/message`` and start compose mode or show help."""
-    from core.i18n import host_locale, t
+    from core.i18n import t
+    from integrations.messenger.locale import messenger_host_locale
 
     session = host._session
     bot_profile = getattr(session, "bot_profile", "default")
     user_id = int(getattr(session, "user_id", 0))
 
     if not is_telegram_admin(bot_profile, user_id):
-        await host._send_html(escape_html(t("tg.message_admin_only", host_locale(host))))
+        await host._send_html(escape_html(t("tg.message_admin_only", messenger_host_locale(host))))
         return
 
     parts = command.strip().split()
     sub = parts[1].lower() if len(parts) > 1 else ""
 
     if sub in {"", "help"}:
-        await host._send_html(t("tg.message_help", host_locale(host)))
+        await host._send_html(t("tg.message_help", messenger_host_locale(host)))
         return
 
     if sub == "cancel":
         session.pending_admin_broadcast = None
-        await host._send_html(escape_html(t("tg.message_cancelled", host_locale(host))))
+        await host._send_html(escape_html(t("tg.message_cancelled", messenger_host_locale(host))))
         return
 
     target = parts[1]
@@ -204,7 +205,7 @@ async def handle_admin_message_command(host: Any, command: str) -> None:
             )
             if not recipients:
                 await host._send_html(
-                    escape_html(t("tg.message_unknown_profile", host_locale(host), name=target))
+                    escape_html(t("tg.message_unknown_profile", messenger_host_locale(host), name=target))
                 )
                 return
         draft_target = target
@@ -215,16 +216,16 @@ async def handle_admin_message_command(host: Any, command: str) -> None:
         exclude_user_id=user_id,
     )
     if not recipients:
-        await host._send_html(escape_html(t("tg.message_no_recipients", host_locale(host))))
+        await host._send_html(escape_html(t("tg.message_no_recipients", messenger_host_locale(host))))
         return
 
     session.pending_admin_broadcast = AdminBroadcastDraft(target=draft_target)
     if draft_target.lower() == "all":
-        hint = t("tg.message_compose_all", host_locale(host), count=len(recipients))
+        hint = t("tg.message_compose_all", messenger_host_locale(host), count=len(recipients))
     else:
         hint = t(
             "tg.message_compose_profile",
-            host_locale(host),
+            messenger_host_locale(host),
             profile=escape_html(draft_target),
             count=len(recipients),
         )

--- a/integrations/telegram/agent_setup.py
+++ b/integrations/telegram/agent_setup.py
@@ -28,6 +28,9 @@ async def create_agent(
                 bot_profile=bot_profile,
                 user_profile=profile,
             )
+    from integrations.messenger.locale import ensure_messenger_locale
+
+    ensure_messenger_locale(profile)
     config = config or init_profile(profile, profile_key=profile_key, prompt_key=False)
     from core.paths import ensure_profile_memory_dirs
 

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -119,9 +119,9 @@ class HolixTelegramBot:
     async def _ensure_authorized_menu(self, bot: Any, chat_id: int, user_id: int) -> None:
         if self.settings.allow_all or chat_id in self._menu_enabled_chats:
             return
-        from core.i18n import LocaleStore
+        from integrations.messenger.locale import messenger_locale
 
-        locale = LocaleStore(self.settings.profile).get()
+        locale = messenger_locale(self.settings.profile)
         await enable_chat_menu(
             bot,
             chat_id,
@@ -402,13 +402,25 @@ class HolixTelegramBot:
         async def _on_startup() -> None:
             import asyncio
 
-            from core.i18n import LocaleStore
+            from integrations.messenger.locale import (
+                bootstrap_messenger_locales,
+                messenger_locale,
+            )
+            from integrations.messenger.platforms import TELEGRAM_PLATFORM
 
             asyncio.create_task(
                 asyncio.to_thread(_seed_admin_profile_background),
                 name="tg-admin-profile-seed",
             )
-            locale = LocaleStore(settings.profile).get()
+            asyncio.create_task(
+                asyncio.to_thread(
+                    bootstrap_messenger_locales,
+                    TELEGRAM_PLATFORM,
+                    settings.profile,
+                ),
+                name="tg-locale-bootstrap",
+            )
+            locale = messenger_locale(settings.profile)
             registered = await register_bot_commands(
                 bot,
                 locale=locale,
@@ -448,14 +460,15 @@ class HolixTelegramBot:
             if not self._allowed(message.from_user.id):
                 await self._handle_unauthorized(bot, message)
                 return
-            from core.i18n import LocaleStore, t
+            from core.i18n import t
+            from integrations.messenger.locale import messenger_locale
 
             from integrations.telegram.command_access import is_command_allowed
             from integrations.telegram.markdown import escape_html
 
             cmd_token = message.text.strip().split()[0].lstrip("/").lower()
             if not is_command_allowed(cmd_token, settings.profile, message.from_user.id):
-                lang = LocaleStore(settings.profile).get()
+                lang = messenger_locale(settings.profile)
                 await message.answer(
                     escape_html(t("tg.menu_unavailable", lang)),
                     parse_mode="HTML",

--- a/integrations/telegram/commands.py
+++ b/integrations/telegram/commands.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from core.i18n import DEFAULT_LOCALE, LocaleStore, t
+from core.i18n import LocaleStore, t
+from integrations.messenger.locale import MESSENGER_DEFAULT_LOCALE, messenger_locale
 
 # (command without /, description key in messages catalog)
 _TELEGRAM_COMMAND_KEYS: list[tuple[str, str]] = [
@@ -50,7 +51,7 @@ class TelegramCommandSpec:
 
 
 def telegram_menu_commands(locale: str | None = None) -> list[tuple[str, str]]:
-    loc = locale or DEFAULT_LOCALE
+    loc = locale or MESSENGER_DEFAULT_LOCALE
     return [(cmd, t(key, loc)) for cmd, key in _TELEGRAM_COMMAND_KEYS]
 
 
@@ -236,7 +237,7 @@ async def sync_bot_menu(profile: str = "default") -> list[str]:
     except ImportError as e:
         raise ImportError("uv sync --extra telegram") from e
 
-    locale = LocaleStore(profile).get()
+    locale = messenger_locale(profile)
     bot = Bot(token=settings.bot_token)
     try:
         return await register_bot_commands(bot, locale=locale, bot_profile=profile)
@@ -251,7 +252,7 @@ def help_message_html(
     user_id: int | None = None,
 ) -> str:
     """HTML help for /help and /start."""
-    loc = locale or DEFAULT_LOCALE
+    loc = locale or MESSENGER_DEFAULT_LOCALE
     if bot_profile is not None and user_id is not None:
         from integrations.telegram.command_access import commands_for_user
 

--- a/integrations/telegram/host.py
+++ b/integrations/telegram/host.py
@@ -8,7 +8,8 @@ from typing import Any
 from cli.shared.commands.agent_commands import AgentCommands
 from cli.shared.rich_text import content_to_plain_text
 from cli.shared.slash_input import is_slash_command, normalize_slash_input
-from core.i18n import host_locale, t
+from core.i18n import t
+from integrations.messenger.locale import messenger_host_locale
 
 from integrations.telegram.commands import help_message_html, sync_bot_menu
 from integrations.telegram.interactive import TelegramInteractive
@@ -141,10 +142,10 @@ class TelegramHost:
     def action_clear_chat(self) -> None:
         self._session._transcript_store.clear()
         self._session._recent_tool_results.clear()
-        self.transcript_write(t("cleared", host_locale(self)))
+        self.transcript_write(t("cleared", messenger_host_locale(self)))
 
     def action_help(self) -> None:
-        asyncio.create_task(self._send_html(help_message_html(host_locale(self))))
+        asyncio.create_task(self._send_html(help_message_html(messenger_host_locale(self))))
 
     async def _sync_telegram_menu(self) -> None:
         try:
@@ -180,7 +181,7 @@ class TelegramHost:
         )
 
     def action_copy_output(self) -> None:
-        lang = host_locale(self)
+        lang = messenger_host_locale(self)
         text = self._session._transcript_store.last_assistant()
         if text:
             self.copy_text(text, label=t("copy_label", lang))
@@ -188,12 +189,12 @@ class TelegramHost:
             self.transcript_write(t("copy_nothing", lang))
 
     def action_open_transcript(self) -> None:
-        lang = host_locale(self)
+        lang = messenger_host_locale(self)
         body = self._session._transcript_store.format_all()
         self.copy_text(body or t("transcript_empty", lang), label="transcript")
 
     def copy_text(self, text: str, *, label: str = "copied") -> None:
-        lang = host_locale(self)
+        lang = messenger_host_locale(self)
         if not text or not text.strip():
             self.transcript_write(t("copy_nothing", lang))
             return
@@ -372,7 +373,7 @@ class TelegramHost:
     async def _mcp_install(self, what: str = "") -> None:
         """Install popular or from git. For interactive use Telegram menus or CLI."""
         if not self._mcp_management_allowed():
-            await self._send_html(t("tg.mcp_read_only", host_locale(self)))
+            await self._send_html(t("tg.mcp_read_only", messenger_host_locale(self)))
             return
         if not what:
             self.transcript_write("Usage: /mcp install <popular-key|git-url>\nPopular: context7, filesystem, github, ... \nOr use the /mcp menu buttons.")
@@ -455,7 +456,7 @@ class TelegramHost:
     async def _mcp_assign(self, rest: str = "") -> None:
         """Basic assign: /mcp assign server main,researcher"""
         if not self._mcp_management_allowed():
-            await self._send_html(t("tg.mcp_read_only", host_locale(self)))
+            await self._send_html(t("tg.mcp_read_only", messenger_host_locale(self)))
             return
         if not rest:
             self.transcript_write("Usage: /mcp assign <server-name> <role1,role2>\nExample: /mcp assign context7 main")
@@ -491,7 +492,7 @@ class TelegramHost:
 
     async def _mcp_test(self, name: str = "") -> None:
         if not self._mcp_management_allowed():
-            await self._send_html(t("tg.mcp_read_only", host_locale(self)))
+            await self._send_html(t("tg.mcp_read_only", messenger_host_locale(self)))
             return
         if not name:
             self.transcript_write("Usage: /mcp test <server-name>")
@@ -530,7 +531,7 @@ class TelegramHost:
 
     async def _mcp_remove(self, name: str = "") -> None:
         if not self._mcp_management_allowed():
-            await self._send_html(t("tg.mcp_read_only", host_locale(self)))
+            await self._send_html(t("tg.mcp_read_only", messenger_host_locale(self)))
             return
         if not name:
             self.transcript_write("Usage: /mcp remove <server-name>")

--- a/integrations/telegram/interactive.py
+++ b/integrations/telegram/interactive.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from core.i18n import host_locale, t
+from core.i18n import t
+from integrations.messenger.locale import messenger_host_locale
 
 from integrations.telegram.keyboards import (
     MODE_LABELS,
@@ -84,7 +85,7 @@ class TelegramInteractive:
             self._session.user_id,
         ):
             return False
-        lang = host_locale(self._host)
+        lang = messenger_host_locale(self._host)
         await self._host._send_html(escape_html(t("tg.menu_unavailable", lang)))
         return True
 
@@ -112,7 +113,7 @@ class TelegramInteractive:
         if is_mode_slash(cmd):
             if len(parts) > 1 and parts[1] in self._host._execution_modes:
                 self._host._execution_mode_index = self._host._execution_modes.index(parts[1])
-                lang = host_locale(self._host)
+                lang = messenger_host_locale(self._host)
                 await self._host._send_html(
                     f"{escape_html(t('tg.mode', lang, mode=''))}<code>{escape_html(parts[1])}</code>"
                 )
@@ -125,7 +126,7 @@ class TelegramInteractive:
                 self._host.streaming_enabled = parts[1] in ("on", "true", "1")
                 state = "on" if self._host.streaming_enabled else "off"
                 await self._host._send_html(
-                    escape_html(t("tg.streaming", host_locale(self._host), state=state))
+                    escape_html(t("tg.streaming", messenger_host_locale(self._host), state=state))
                 )
             else:
                 await self.show_stream_picker()
@@ -366,7 +367,7 @@ class TelegramInteractive:
             ]
         elif not servers:
             text_lines.append(
-                f"\n<i>{escape_html(t('tg.mcp_read_only_empty', host_locale(host)))}</i>"
+                f"\n<i>{escape_html(t('tg.mcp_read_only_empty', messenger_host_locale(host)))}</i>"
             )
 
         # If specific subcommand, handle simply
@@ -384,7 +385,7 @@ class TelegramInteractive:
             if sub in ("install", "add", "assign", "remove", "rm", "delete", "test"):
                 if not can_manage_mcp:
                     await self._host._send_html(
-                        escape_html(t("tg.mcp_read_only", host_locale(host)))
+                        escape_html(t("tg.mcp_read_only", messenger_host_locale(host)))
                     )
                     return
             if sub in ("install", "add"):
@@ -404,18 +405,18 @@ class TelegramInteractive:
         if action == "m" and value in self._host._execution_modes:
             self._host._execution_mode_index = self._host._execution_modes.index(value)
             await self.show_mode_picker()
-            lang = host_locale(self._host)
+            lang = messenger_host_locale(self._host)
             return t("tg.mode", lang, mode=value)
 
         if action == "st":
             self._host.streaming_enabled = value == "1"
             await self.show_stream_picker()
-            lang = host_locale(self._host)
+            lang = messenger_host_locale(self._host)
             state = "on" if self._host.streaming_enabled else "off"
             return t("tg.streaming", lang, state=state)
 
         if action == "pi":
-            lang = host_locale(self._host)
+            lang = messenger_host_locale(self._host)
             profiles = self._session.ui_profiles
             idx = int(value)
             if 0 <= idx < len(profiles):
@@ -443,7 +444,7 @@ class TelegramInteractive:
 
                 restored = restore_session_model(self._host)
                 title = sessions[idx].get("title") or cid
-                lang = host_locale(self._host)
+                lang = messenger_host_locale(self._host)
                 model_line = (
                     f"\n{escape_html(t('tg.model', lang, label=restored))}"
                     if restored
@@ -454,7 +455,7 @@ class TelegramInteractive:
                     f"<code>{escape_html(title)}</code>{model_line}"
                 )
                 return t("tg.session_switched", lang)
-            return t("tg.session_invalid", host_locale(self._host))
+            return t("tg.session_invalid", messenger_host_locale(self._host))
 
         if action == "sp":
             await self.show_sessions_picker(page=int(value))
@@ -463,11 +464,11 @@ class TelegramInteractive:
         if action == "sn":
             await self._host._create_new_session()
             await self.show_sessions_picker()
-            return t("tg.new_session", host_locale(self._host))
+            return t("tg.new_session", messenger_host_locale(self._host))
 
         if action == "t":
             self._host._show_full_tool_result(int(value))
-            return t("tg.tool_result", host_locale(self._host))
+            return t("tg.tool_result", messenger_host_locale(self._host))
 
         if action == "sk":
             names = self._session.ui_skills
@@ -505,7 +506,7 @@ class TelegramInteractive:
                 await self.show_provider_models(idx, page=self._session.ui_models_page)
             else:
                 await self.show_models(page=self._session.ui_providers_page)
-            return t("tg.model", host_locale(self._host), label=label)
+            return t("tg.model", messenger_host_locale(self._host), label=label)
 
         if action == "mg":
             await self.show_provider_models(int(value), page=0)
@@ -524,11 +525,11 @@ class TelegramInteractive:
         if action == "mm":
             parts = value.split(":", 1)
             if len(parts) != 2:
-                return t("tg.error", host_locale(self._host))
+                return t("tg.error", messenger_host_locale(self._host))
             pi, mi = int(parts[0]), int(parts[1])
             label = await apply_provider_model_index(self._host, pi, mi)
             await self.show_provider_models(pi, page=self._session.ui_models_page)
-            return t("tg.model", host_locale(self._host), label=label)
+            return t("tg.model", messenger_host_locale(self._host), label=label)
 
         if action == "mb":
             await self.show_models()
@@ -546,7 +547,7 @@ class TelegramInteractive:
             await self._handle_cron_callback(value)
             return ""
 
-        return t("tg.unknown_action", host_locale(self._host))
+        return t("tg.unknown_action", messenger_host_locale(self._host))
 
     async def _refresh(self, kind: str) -> None:
         from integrations.telegram.command_access import is_menu_action_allowed
@@ -556,7 +557,7 @@ class TelegramInteractive:
             self._session.bot_profile,
             self._session.user_id,
         ):
-            lang = host_locale(self._host)
+            lang = messenger_host_locale(self._host)
             await self._host._send_html(escape_html(t("tg.menu_unavailable", lang)))
             return
 
@@ -603,7 +604,7 @@ class TelegramInteractive:
 
         profiles = self._host._get_available_profiles()
         self._session.ui_profiles = profiles
-        lang = host_locale(self._host)
+        lang = messenger_host_locale(self._host)
         current = self._host.profile
 
         if is_profile_list_hidden(self._session.bot_profile, self._session.user_id):
@@ -628,7 +629,7 @@ class TelegramInteractive:
         )
 
     async def _deny_mcp_management(self) -> None:
-        lang = host_locale(self._host)
+        lang = messenger_host_locale(self._host)
         await self._host._send_html(escape_html(t("tg.mcp_read_only", lang)))
 
     async def _handle_mcp_callback(self, value: str) -> None:
@@ -789,7 +790,7 @@ class TelegramInteractive:
     async def show_tools_picker(self) -> None:
         tools = self._host._recent_tool_results
         if not tools:
-            await self._host._send_plain(t("tg.no_tools", host_locale(self._host)))
+            await self._host._send_plain(t("tg.no_tools", messenger_host_locale(self._host)))
             return
         lines = ["<b>Последние tools</b>", "<i>Нажмите, чтобы получить полный вывод</i>"]
         await self._host._send_html_with_keyboard(
@@ -948,7 +949,7 @@ class TelegramInteractive:
         is_admin = is_telegram_admin(self._session.bot_profile, self._session.user_id)
         await self._host._send_html_with_keyboard(
             "\n".join(lines),
-            status_menu_keyboard(host_locale(self._host), is_admin=is_admin),
+            status_menu_keyboard(messenger_host_locale(self._host), is_admin=is_admin),
         )
 
 

--- a/integrations/telegram/keyboards.py
+++ b/integrations/telegram/keyboards.py
@@ -329,7 +329,9 @@ def status_menu_keyboard(locale: str | None = None, *, is_admin: bool = True) ->
     from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
     from core.i18n.messages import t
 
-    loc = locale or "en"
+    from integrations.messenger.locale import MESSENGER_DEFAULT_LOCALE
+
+    loc = locale or MESSENGER_DEFAULT_LOCALE
     rows: list[list[Any]] = [
         [
             InlineKeyboardButton(text=t("tg.menu.mode", loc), callback_data=_cb("r", "mode")),

--- a/integrations/telegram/model_switch.py
+++ b/integrations/telegram/model_switch.py
@@ -235,17 +235,19 @@ async def apply_model_choice(host: TelegramHost, choice: ModelChoice) -> str:
     try:
         return apply_model_choice_sync(host, choice)
     except RuntimeError:
-        from core.i18n import host_locale, t
+        from core.i18n import t
+        from integrations.messenger.locale import messenger_host_locale
 
-        return t("tg.agent_not_ready", host_locale(host))
+        return t("tg.agent_not_ready", messenger_host_locale(host))
 
 
 async def apply_preset_index(host: TelegramHost, index: int) -> str:
     presets = host._session.ui_model_presets
     if index < 0 or index >= len(presets):
-        from core.i18n import host_locale, t
+        from core.i18n import t
+        from integrations.messenger.locale import messenger_host_locale
 
-        return t("tg.invalid_preset", host_locale(host))
+        return t("tg.invalid_preset", messenger_host_locale(host))
     return await apply_model_choice(host, presets[index])
 
 
@@ -254,14 +256,16 @@ async def apply_provider_model_index(
 ) -> str:
     providers = host._session.ui_providers
     if provider_idx < 0 or provider_idx >= len(providers):
-        from core.i18n import host_locale, t
+        from core.i18n import t
+        from integrations.messenger.locale import messenger_host_locale
 
-        return t("tg.invalid_provider", host_locale(host))
+        return t("tg.invalid_provider", messenger_host_locale(host))
     prov = providers[provider_idx]
     if model_idx < 0 or model_idx >= len(prov.models):
-        from core.i18n import host_locale, t
+        from core.i18n import t
+        from integrations.messenger.locale import messenger_host_locale
 
-        return t("tg.invalid_model", host_locale(host))
+        return t("tg.invalid_model", messenger_host_locale(host))
     model_id = prov.models[model_idx]
     choice = choice_for_provider_model(prov.name, model_id)
     return await apply_model_choice(host, choice)

--- a/integrations/telegram/notify.py
+++ b/integrations/telegram/notify.py
@@ -94,11 +94,11 @@ async def notify_access_approved(
     await send_user_message(token, int(user_id), text)
     try:
         from aiogram import Bot
-        from core.i18n import LocaleStore
+        from integrations.messenger.locale import messenger_locale
 
         from integrations.telegram.commands import enable_chat_menu
 
-        locale = LocaleStore(bot_profile).get()
+        locale = messenger_locale(bot_profile)
         bot = Bot(token=token)
         try:
             await enable_chat_menu(bot, int(user_id), locale=locale)

--- a/integrations/telegram/profile_seed.py
+++ b/integrations/telegram/profile_seed.py
@@ -168,20 +168,25 @@ def seed_telegram_user_profile_from_bot(
     if not manager.profile_exists(bot_profile) or not manager.profile_exists(user_profile):
         return False
 
+    from integrations.messenger.locale import ensure_messenger_locale
+
     if not _bot_has_meaningful_llm_config(manager, bot_profile):
         return False
 
     user_cfg = manager.load_profile(user_profile)
     if not _is_placeholder_model_config(user_cfg):
         _seed_profile_env_from_bot(bot_profile, user_profile)
+        ensure_messenger_locale(user_profile)
         return False
 
     shared = _collect_bot_shared_overrides(manager, bot_profile)
     if not shared:
+        ensure_messenger_locale(user_profile)
         return False
 
     for key, value in shared.items():
         setattr(user_cfg, key, value)
     manager.save_profile(user_profile, user_cfg, storage_mode="sparse")
     _seed_profile_env_from_bot(bot_profile, user_profile)
+    ensure_messenger_locale(user_profile)
     return True

--- a/tests/test_messenger_locale.py
+++ b/tests/test_messenger_locale.py
@@ -1,0 +1,88 @@
+"""Messenger (Telegram/MAX) default locale tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cli.core as cli_core
+import pytest
+from core.i18n import LocaleStore
+from integrations.messenger.locale import (
+    MESSENGER_DEFAULT_LOCALE,
+    apply_messenger_locale,
+    bootstrap_messenger_locales,
+    ensure_messenger_locale,
+    messenger_host_locale,
+    messenger_locale,
+)
+from integrations.messenger.platforms import TELEGRAM_PLATFORM
+
+
+@pytest.fixture
+def holix_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    root = tmp_path / "holix"
+    profiles = root / "profiles"
+    profiles.mkdir(parents=True)
+    monkeypatch.setenv("HOLIX_HOME", str(root))
+    monkeypatch.setattr(cli_core, "HOLIX_HOME", root)
+    monkeypatch.setattr(cli_core, "PROFILES_DIR", profiles)
+    cli_core._unlocked_profiles.clear()
+    yield root
+    cli_core._unlocked_profiles.clear()
+
+
+class _FakeHost:
+    def __init__(self, profile: str = "tg_user") -> None:
+        self.profile = profile
+
+
+def test_messenger_default_locale_is_ru() -> None:
+    assert MESSENGER_DEFAULT_LOCALE == "ru"
+
+
+def test_messenger_locale_without_file_defaults_to_ru(
+    holix_home: Path,
+) -> None:
+    assert messenger_locale("fresh_user") == "ru"
+
+
+def test_ensure_messenger_locale_persists_ru(holix_home: Path) -> None:
+    assert ensure_messenger_locale("fresh_user") == "ru"
+    assert LocaleStore("fresh_user").get() == "ru"
+
+
+def test_apply_messenger_locale_overwrites_existing(holix_home: Path) -> None:
+    LocaleStore("worker").set("en")
+    assert apply_messenger_locale("worker") == "ru"
+    assert LocaleStore("worker").get() == "ru"
+
+
+def test_messenger_host_locale_uses_profile(holix_home: Path) -> None:
+    apply_messenger_locale("host_profile")
+    assert messenger_host_locale(_FakeHost("host_profile")) == "ru"
+
+
+def test_bootstrap_messenger_locales_for_bot_and_users(
+    holix_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cli.core import ProfileManager
+    from integrations.telegram.env_store import save_telegram_env
+
+    manager = ProfileManager()
+    manager.create_profile("shared", inherit_global=True)
+    manager.create_profile("alice", inherit_global=True)
+
+    from integrations.telegram.admin import set_admin_user
+    from integrations.telegram.user_profiles import set_user_profile
+
+    save_telegram_env({"TELEGRAM_BOT_TOKEN": "1:abc"}, profile="shared")
+    set_user_profile("shared", 42, "alice")
+    manager.create_profile("admin", inherit_global=True)
+    set_admin_user("shared", 99, holix_profile="admin")
+
+    updated = bootstrap_messenger_locales(TELEGRAM_PLATFORM, "shared")
+    assert "shared" in updated
+    assert "alice" in updated
+    assert "admin" in updated
+    assert LocaleStore("alice").get() == "ru"


### PR DESCRIPTION
## Summary

- Добавлен `integrations/messenger/locale.py` с дефолтом `ru` для Telegram и MAX
- Новые профили получают `locale.json` с `ru` при approve, seed и `create_agent`
- При старте бота выполняется bootstrap: bot-профиль, admin и все mapped user-профили без `locale.json` переключаются на `ru`
- Все UI-строки в Telegram/MAX (меню, help, клавиатуры, host) читают locale через `messenger_locale` / `messenger_host_locale`
- TUI и CLI по-прежнему используют `en` по умолчанию; явный `/lang en` сохраняется

## Tests

- `tests/test_messenger_locale.py` — 6 тестов
- Существующие тесты Telegram/MAX: 27 passed

## Deploy note

После мержа достаточно перезапустить gateway — bootstrap проставит `ru` существующим профилям без `locale.json` при старте бота.