### PR TITLE
fix(telegram): store attachments under named profile, not shared data_dir

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -7,6 +7,7 @@ import logging
 from collections.abc import AsyncIterator
 
 from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
 
 from config import settings
 
@@ -43,8 +44,6 @@ async def safe_sse_wrap(stream: AsyncIterator[str]) -> AsyncIterator[str]:
 
 def sse_streaming_response(stream: AsyncIterator[str]) -> StreamingResponse:
     """Return an SSE response that never leaks stack traces to clients."""
-    from fastapi.responses import StreamingResponse
-
     return StreamingResponse(
         safe_sse_wrap(stream),
         media_type="text/event-stream",

--- a/api/routers/hermes_sessions.py
+++ b/api/routers/hermes_sessions.py
@@ -6,14 +6,15 @@ import json
 
 from core.security.permissions import PermissionChecker
 from fastapi import APIRouter, Depends, Header, HTTPException
+
 from api import state
-from api.errors import _SSE_ERROR_CHUNK, sse_streaming_response
 from api.deps import (
     ensure_resource_profile,
     get_registry,
     resolve_profile_name,
     verify_api_key,
 )
+from api.errors import _SSE_ERROR_CHUNK, sse_streaming_response
 from api.schemas.hermes import SessionChatRequest, SessionCreateRequest, SessionPatchRequest
 from api.services.content_parts import (
     UnsupportedContentTypeError,

--- a/api/routers/holix_models.py
+++ b/api/routers/holix_models.py
@@ -9,7 +9,6 @@ from core.models.setup_helpers import add_preset_to_config, apply_ssl_override, 
 from fastapi import APIRouter, Depends, Header, HTTPException
 
 from api.deps import verify_api_key
-from api.errors import client_safe_message
 from api.schemas.holix import AgentModelsPatchRequest, FallbacksPatchRequest, ProviderAddRequest
 from api.services.config_mask import mask_config_dict
 from api.services.holix_deps import profile_access

--- a/api/routers/holix_profiles.py
+++ b/api/routers/holix_profiles.py
@@ -14,7 +14,6 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 
 from api import state
 from api.deps import verify_api_key
-
 from api.schemas.holix import (
     JailEnableRequest,
     ProfileCreateRequest,

--- a/api/routers/legacy_v1.py
+++ b/api/routers/legacy_v1.py
@@ -7,6 +7,7 @@ import time
 from core.loop_streaming import StreamingAgentLoop
 from core.security.permissions import PermissionChecker
 from fastapi import APIRouter, Depends, Header, HTTPException
+
 from api import state
 from api.deps import get_registry, resolve_profile_name, verify_api_key
 from api.errors import _SSE_ERROR_CHUNK, sse_streaming_response

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"

--- a/cli/core.py
+++ b/cli/core.py
@@ -546,9 +546,11 @@ def unlock_profile(profile: str, profile_key: str) -> bool:
 
 def unlock_profile_encryption(profile: str, unlock_key: str) -> None:
     """Derive DEK from user encryption key and cache it for this process."""
-    from core.crypto.profile_crypto import unlock_profile_dek
+    from core.crypto.profile_crypto import profile_has_crypto_metadata, unlock_profile_dek
     from core.crypto.unlock_context import set_profile_session_unlock
 
+    if not profile_has_crypto_metadata(profile):
+        return
     dek = unlock_profile_dek(profile, unlock_key)
     set_profile_session_unlock(profile, dek)
 
@@ -589,12 +591,22 @@ def init_profile(
     _current_profile = profile
     _current_config = _profile_manager.load_profile(profile)
 
-    if unlock_key and unlock_key.strip():
-        from core.crypto.profile_crypto import is_profile_encryption_enabled
+    from core.crypto.profile_crypto import (
+        is_profile_encryption_enabled,
+        profile_has_crypto_metadata,
+    )
 
+    if getattr(_current_config, "encryption_enabled", False) and not profile_has_crypto_metadata(profile):
+        _current_config.encryption_enabled = False
+        try:
+            _profile_manager.save_profile(profile, _current_config)
+        except OSError:
+            pass
+
+    if unlock_key and unlock_key.strip():
         key = unlock_key.strip()
         os.environ["HOLIX_UNLOCK_KEY"] = key
-        if is_profile_encryption_enabled(profile) or getattr(_current_config, "encryption_enabled", False):
+        if is_profile_encryption_enabled(profile) or profile_has_crypto_metadata(profile):
             unlock_profile_encryption(profile, key)
 
     created_key = _profile_manager.pop_last_created_access_key()

--- a/cli/services/cron_worker.py
+++ b/cli/services/cron_worker.py
@@ -4,20 +4,25 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import os
 import sys
 
-from core.cron.scheduler import CronScheduler
+from core.cron.scheduler import CronScheduler, GlobalCronScheduler
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Holix cron scheduler worker")
-    parser.add_argument("--profile", default=os.environ.get("HOLIX_PROFILE", "default"))
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="Legacy: run scheduler for one profile only (default: all profiles)",
+    )
     args = parser.parse_args(argv)
-    os.environ["HOLIX_PROFILE"] = args.profile
 
     async def _run() -> None:
-        await CronScheduler(args.profile).run_forever()
+        if args.profile:
+            await CronScheduler(args.profile).run_forever()
+        else:
+            await GlobalCronScheduler().run_forever()
 
     try:
         asyncio.run(_run())

--- a/cli/services/supervisor.py
+++ b/cli/services/supervisor.py
@@ -82,10 +82,10 @@ async def _run_gateway_uvicorn(host: str, port: int) -> None:
     await server.serve()
 
 
-async def _run_cron_scheduler(profile: str) -> None:
-    from core.cron.scheduler import CronScheduler
+async def _run_cron_scheduler(_profile: str) -> None:
+    from core.cron.scheduler import GlobalCronScheduler
 
-    await CronScheduler(profile).run_forever()
+    await GlobalCronScheduler().run_forever()
 
 
 async def _run_max(profile: str) -> None:
@@ -227,9 +227,9 @@ async def _run_supervisor_async(
 def _cron_subprocess(profile: str) -> subprocess.Popen[bytes] | None:
     env = os.environ.copy()
     env["HOLIX_PROFILE"] = profile
-    print_success(f"Cron scheduler starting in subprocess (profile={profile})")
+    print_success("Cron scheduler starting in subprocess (all profiles)")
     return popen_background(
-        [sys.executable, "-m", "cli.services.cron_worker", "--profile", profile],
+        [sys.executable, "-m", "cli.services.cron_worker"],
         env=env,
     )
 

--- a/config.py
+++ b/config.py
@@ -213,6 +213,11 @@ class Settings(BaseSettings):
         validation_alias="HOLIX_TELEGRAM_VISION_MODEL",
         description="Vision model for Telegram images; empty = main agent model",
     )
+    telegram_image_router_enabled: bool = Field(
+        default=False,
+        validation_alias="HOLIX_TELEGRAM_IMAGE_ROUTER_ENABLED",
+        description="Helix-side image routing (off when LiteLLM vision-auto handles routing)",
+    )
     telegram_media_group_delay_ms: int = Field(
         default=800,
         validation_alias="HOLIX_TELEGRAM_MEDIA_GROUP_DELAY_MS",

--- a/core/cron/discovery.py
+++ b/core/cron/discovery.py
@@ -1,0 +1,139 @@
+"""Discover profiles with cron jobs and cache job lists for the global scheduler."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Iterator
+
+from core.cron.models import CronJob
+from core.cron.store import CronStore, jobs_path
+
+logger = logging.getLogger(__name__)
+
+DISCOVERY_INTERVAL_S = 300.0
+_SKIP_PROFILE_DIRS = frozenset({"global"})
+
+
+class CronProfileIndex:
+    """Lazy index of per-profile cron jobs, keyed by jobs.json mtime."""
+
+    def __init__(self, *, discovery_interval_s: float = DISCOVERY_INTERVAL_S) -> None:
+        self._discovery_interval_s = discovery_interval_s
+        self._last_full_scan = 0.0
+        self._cache: dict[str, tuple[float, list[CronJob]]] = {}
+
+    def invalidate(self, profile: str) -> None:
+        self._cache.pop(profile, None)
+
+    def warm_profile(self, profile: str) -> None:
+        if _profile_has_jobs(profile):
+            self._load_profile(profile, force=True)
+        else:
+            self.invalidate(profile)
+
+    def scan_profiles_with_jobs(self) -> list[str]:
+        from cli.core import profiles_dir
+
+        root = profiles_dir()
+        if not root.exists():
+            return []
+
+        found: list[str] = []
+        for item in root.iterdir():
+            if not item.is_dir() or item.name in _SKIP_PROFILE_DIRS:
+                continue
+            if _profile_has_jobs(item.name):
+                found.append(item.name)
+        return sorted(found)
+
+    def refresh_known_profiles(self) -> None:
+        now = time.monotonic()
+        if now - self._last_full_scan < self._discovery_interval_s:
+            return
+        for profile in self.scan_profiles_with_jobs():
+            self._load_profile(profile, force=True)
+        stale = [p for p in self._cache if not jobs_path(p).exists()]
+        for profile in stale:
+            self._cache.pop(profile, None)
+        self._last_full_scan = now
+
+    def iter_enabled_jobs(self) -> Iterator[tuple[str, list[CronJob]]]:
+        self.refresh_known_profiles()
+        for profile in sorted(self._cache):
+            jobs = self._get_jobs(profile)
+            if jobs:
+                yield profile, jobs
+
+    def refresh_all_next_runs(self) -> None:
+        for profile in self.scan_profiles_with_jobs():
+            try:
+                CronStore(profile).refresh_all_next_runs()
+                self._load_profile(profile, force=True)
+            except Exception:
+                logger.exception("Failed to refresh cron next_run for profile=%s", profile)
+
+    def _get_jobs(self, profile: str) -> list[CronJob]:
+        path = jobs_path(profile)
+        if not path.exists():
+            self._cache.pop(profile, None)
+            return []
+        mtime = path.stat().st_mtime
+        cached = self._cache.get(profile)
+        if cached and cached[0] == mtime:
+            return cached[1]
+        return self._load_profile(profile)
+
+    def _load_profile(self, profile: str, *, force: bool = False) -> list[CronJob]:
+        path = jobs_path(profile)
+        if not path.exists():
+            self._cache.pop(profile, None)
+            return []
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            self._cache.pop(profile, None)
+            return []
+
+        if not force:
+            cached = self._cache.get(profile)
+            if cached and cached[0] == mtime:
+                return cached[1]
+
+        if not _profile_has_jobs(profile):
+            self._cache.pop(profile, None)
+            return []
+
+        jobs = CronStore(profile).list_jobs(enabled_only=True)
+        self._cache[profile] = (mtime, jobs)
+        return jobs
+
+
+_index: CronProfileIndex | None = None
+
+
+def get_profile_index() -> CronProfileIndex:
+    global _index
+    if _index is None:
+        interval = float(
+            __import__("os").environ.get("HOLIX_CRON_DISCOVERY_INTERVAL", DISCOVERY_INTERVAL_S)
+        )
+        _index = CronProfileIndex(discovery_interval_s=interval)
+    return _index
+
+
+def invalidate_profile(profile: str) -> None:
+    get_profile_index().warm_profile(profile)
+
+
+def _profile_has_jobs(profile: str) -> bool:
+    path = jobs_path(profile)
+    if not path.exists():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    jobs = data.get("jobs")
+    return isinstance(jobs, list) and bool(jobs)

--- a/core/cron/discovery.py
+++ b/core/cron/discovery.py
@@ -40,9 +40,15 @@ class CronProfileIndex:
         if not root.exists():
             return []
 
+        from core.profile.names import ProfileNameError, validate_profile_name
+
         found: list[str] = []
         for item in root.iterdir():
             if not item.is_dir() or item.name in _SKIP_PROFILE_DIRS:
+                continue
+            try:
+                validate_profile_name(item.name)
+            except ProfileNameError:
                 continue
             if _profile_has_jobs(item.name):
                 found.append(item.name)
@@ -50,7 +56,10 @@ class CronProfileIndex:
 
     def refresh_known_profiles(self) -> None:
         now = time.monotonic()
-        if now - self._last_full_scan < self._discovery_interval_s:
+        if (
+            self._last_full_scan > 0
+            and now - self._last_full_scan < self._discovery_interval_s
+        ):
             return
         for profile in self.scan_profiles_with_jobs():
             self._load_profile(profile, force=True)

--- a/core/cron/scheduler.py
+++ b/core/cron/scheduler.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from datetime import UTC, datetime
 
 from core.cron import active_runs
+from core.cron.discovery import get_profile_index
 from core.cron.runner import run_cron_job
 from core.cron.store import CronStore
 
 logger = logging.getLogger(__name__)
 
-TICK_SECONDS = 30
+TICK_SECONDS = int(os.environ.get("HOLIX_CRON_TICK_SECONDS", "30"))
+MAX_CONCURRENT_RUNS = int(os.environ.get("HOLIX_CRON_MAX_CONCURRENT", "4"))
 
 
 def _parse_utc_iso(value: str) -> datetime:
@@ -31,8 +34,67 @@ def _job_is_due(job, *, now: datetime) -> bool:
         return False
 
 
+class GlobalCronScheduler:
+    """Single scheduler tick loop for cron jobs across all Holix profiles."""
+
+    def __init__(
+        self,
+        *,
+        tick_seconds: int = TICK_SECONDS,
+        max_concurrent: int = MAX_CONCURRENT_RUNS,
+    ) -> None:
+        self._tick_seconds = tick_seconds
+        self._max_concurrent = max(1, max_concurrent)
+        self._index = get_profile_index()
+        self._semaphore = asyncio.Semaphore(self._max_concurrent)
+        self._dispatch_lock = asyncio.Lock()
+
+    async def run_forever(self) -> None:
+        logger.info(
+            "Cron scheduler started (global, all profiles, max_concurrent=%s)",
+            self._max_concurrent,
+        )
+        self._index.refresh_all_next_runs()
+        while True:
+            try:
+                await self.tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Cron tick failed")
+            await asyncio.sleep(self._tick_seconds)
+
+    async def tick(self) -> None:
+        now = datetime.now(UTC)
+        for profile, jobs in self._index.iter_enabled_jobs():
+            for job in jobs:
+                if active_runs.is_active(job.id):
+                    continue
+                if job.last_status == "running":
+                    continue
+                if not _job_is_due(job, now=now):
+                    continue
+                async with self._dispatch_lock:
+                    if active_runs.is_active(job.id):
+                        continue
+                    task = asyncio.create_task(
+                        self._run_wrapped(profile, job.id),
+                        name=f"cron-{profile}-{job.id}",
+                    )
+                    active_runs.register_task(job.id, task)
+
+    async def _run_wrapped(self, profile: str, job_id: str) -> None:
+        async with self._semaphore:
+            try:
+                job = CronStore(profile).get(job_id)
+                if job and job.enabled:
+                    await run_cron_job(job)
+            finally:
+                self._index.invalidate(profile)
+
+
 class CronScheduler:
-    """Poll due jobs and dispatch agent runs."""
+    """Legacy single-profile scheduler; kept for tests and narrow tooling."""
 
     def __init__(self, profile: str = "default") -> None:
         self.profile = profile

--- a/core/cron/store.py
+++ b/core/cron/store.py
@@ -50,6 +50,9 @@ class CronStore:
             store.model_dump_json(indent=2),
             encoding="utf-8",
         )
+        from core.cron.discovery import invalidate_profile
+
+        invalidate_profile(self.profile)
 
     def list_jobs(self, *, enabled_only: bool = False) -> list[CronJob]:
         jobs = self.load().jobs

--- a/core/gateway/companions.py
+++ b/core/gateway/companions.py
@@ -10,7 +10,6 @@ from typing import Any
 @dataclass(slots=True)
 class CompanionState:
     profile: str
-    cron_task: asyncio.Task[Any] | None = None
     telegram_task: asyncio.Task[Any] | None = None
     max_task: asyncio.Task[Any] | None = None
 
@@ -20,12 +19,16 @@ class CompanionManager:
 
     def __init__(self) -> None:
         self._states: dict[str, CompanionState] = {}
+        self._global_cron_task: asyncio.Task[Any] | None = None
+
+    def _cron_running(self) -> bool:
+        return bool(self._global_cron_task and not self._global_cron_task.done())
 
     def status(self, profile: str) -> dict[str, Any]:
         state = self._states.get(profile)
         return {
             "profile": profile,
-            "cron_running": bool(state and state.cron_task and not state.cron_task.done()),
+            "cron_running": self._cron_running(),
             "telegram_running": bool(
                 state and state.telegram_task and not state.telegram_task.done()
             ),
@@ -35,26 +38,32 @@ class CompanionManager:
         }
 
     async def start_cron(self, profile: str) -> None:
-        await self.stop_cron(profile)
-        from core.cron.scheduler import CronScheduler
+        await self.ensure_global_cron()
 
-        state = self._states.setdefault(profile, CompanionState(profile=profile))
+    async def ensure_global_cron(self) -> None:
+        if self._cron_running():
+            return
+        from core.cron.scheduler import GlobalCronScheduler
 
         async def _run() -> None:
-            await CronScheduler(profile).run_forever()
+            await GlobalCronScheduler().run_forever()
 
-        state.cron_task = asyncio.create_task(_run(), name=f"holix-cron-{profile}")
+        self._global_cron_task = asyncio.create_task(_run(), name="holix-cron-global")
 
     async def stop_cron(self, profile: str) -> None:
-        state = self._states.get(profile)
-        if state is None or state.cron_task is None:
+        from core.cron.discovery import invalidate_profile
+
+        invalidate_profile(profile)
+
+    async def stop_global_cron(self) -> None:
+        if self._global_cron_task is None:
             return
-        state.cron_task.cancel()
+        self._global_cron_task.cancel()
         try:
-            await state.cron_task
+            await self._global_cron_task
         except asyncio.CancelledError:
             pass
-        state.cron_task = None
+        self._global_cron_task = None
 
     async def start_telegram(self, profile: str) -> None:
         await self.stop_telegram(profile)
@@ -123,7 +132,7 @@ class CompanionManager:
         return self.status(profile)
 
     async def shutdown_all(self) -> None:
+        await self.stop_global_cron()
         for profile in list(self._states):
-            await self.stop_cron(profile)
             await self.stop_telegram(profile)
             await self.stop_max(profile)

--- a/core/plan_review/plan_storage.py
+++ b/core/plan_review/plan_storage.py
@@ -15,8 +15,8 @@ from pathlib import Path
 from typing import Any
 
 from core.config_utils import get_local_plan_dir
-from core.paths import realpath_under
 from core.di.runtime_config import HolixRuntimeConfig
+from core.paths import realpath_under
 
 logger = logging.getLogger(__name__)
 

--- a/core/profile_admin_seed.py
+++ b/core/profile_admin_seed.py
@@ -87,10 +87,16 @@ def copy_profile_settings_from_source(
 
     from cli.core import ProfileConfig, resolve_profile_storage_paths
 
-    from core.global_config import extract_profile_overrides, load_global_config_resolved
+    from core.global_config import (
+        PROFILE_ONLY_KEYS,
+        extract_profile_overrides,
+        load_global_config_resolved,
+    )
 
     source_cfg = manager.load_profile(source_profile)
     payload = source_cfg.model_dump()
+    for key in PROFILE_ONLY_KEYS:
+        payload.pop(key, None)
     payload["profile_name"] = target_profile
     target_cfg = ProfileConfig(**payload)
     target_cfg = resolve_profile_storage_paths(

--- a/core/tools/file_ops.py
+++ b/core/tools/file_ops.py
@@ -13,7 +13,9 @@ from core.workspace.storage import (
     write_profile_file_text,
 )
 
-_IMAGE_SUFFIXES = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic", ".heif", ".tif", ".tiff"})
+_IMAGE_SUFFIXES = frozenset(
+    {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic", ".heif", ".tif", ".tiff"}
+)
 
 
 def _is_binary_image_path(path: Path) -> bool:

--- a/core/tools/file_ops.py
+++ b/core/tools/file_ops.py
@@ -1,3 +1,6 @@
+import mimetypes
+from pathlib import Path
+
 from core.crypto.profile_crypto import ProfileCryptoLockedError
 from core.tools.base import BaseTool
 from core.tools.execution_context import get_profile_name
@@ -9,6 +12,16 @@ from core.workspace.storage import (
     read_profile_file_text,
     write_profile_file_text,
 )
+
+_IMAGE_SUFFIXES = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic", ".heif", ".tif", ".tiff"})
+
+
+def _is_binary_image_path(path: Path) -> bool:
+    suffix = path.suffix.lower()
+    if suffix in _IMAGE_SUFFIXES:
+        return True
+    mime, _ = mimetypes.guess_type(str(path))
+    return bool(mime and mime.startswith("image/"))
 
 
 class ReadFileTool(BaseTool):
@@ -47,6 +60,14 @@ class ReadFileTool(BaseTool):
 
             if not file_path.is_file():
                 return f"Error: '{path}' is not a file"
+
+            if _is_binary_image_path(file_path):
+                display_path = display_path_for_user(file_path, input_path=path)
+                return (
+                    f"{display_path} is a binary image file; read_file cannot decode it as text. "
+                    "If the user attached this image in Telegram, use the vision description "
+                    "already included in their message. Do not ask the user to re-upload the image."
+                )
 
             profile = get_profile_name()
             content = read_profile_file_text(file_path, profile=profile)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## 0.1.17 — 2026-06-21
+
+### Added
+- **Global cron scheduler** — one gateway tick loop runs due jobs across all Holix profiles; per-profile job storage and visibility unchanged
+- **Cron profile index** — mtime-cached `jobs.json` discovery, periodic full scan, `HOLIX_CRON_MAX_CONCURRENT` run limit
+- **Telegram image router** (optional) — classify image overviews and route to specialist vision models (`HOLIX_TELEGRAM_IMAGE_ROUTER_ENABLED`)
+
+### Fixed
+- **Cron not running for user profiles** — jobs created under `admin` (or any mapped profile) execute when gateway runs on `docs`
+- **Telegram attachments** — store files under the named Holix profile, not shared `data_dir`
+- **Telegram gateway startup** — start polling before per-user menu registration; skip eager `set_my_commands` on boot; typing during agent init
+- **Telegram vision** — prefer vision-capable LiteLLM aliases (`vision-auto`, `gemini-flash`, `auto`) over text-only models
+
+### Changed
+- **Version** — package `Holix` 0.1.17
+- **Cron worker** — standalone worker schedules all profiles by default (`--profile` kept for legacy single-profile mode)
+
 ### Documentation
 - **Information architecture** — one canonical page per topic; merged multi-profile and launch-subagents docs into TELEGRAM, MAX, SUBAGENTS
 - **INSTALLATION** (EN/RU) — unified Path A (uv/pipx) and Path B (Docker); QUICKSTART → START_HERE cheat sheet

--- a/integrations/telegram/agent_setup.py
+++ b/integrations/telegram/agent_setup.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from cli.core import ProfileConfig, init_profile
 from core.agent import HolixAgent
 
-from integrations.telegram.profile_auth import authorize_telegram_profile_access
+from integrations.telegram.profile_auth import (
+    init_profile_for_telegram,
+    telegram_user_may_access_profile,
+)
 
 
 async def create_agent(
@@ -17,7 +20,11 @@ async def create_agent(
     profile_key: str | None = None,
 ) -> HolixAgent:
     if bot_profile is not None and telegram_user_id is not None:
-        authorize_telegram_profile_access(bot_profile, telegram_user_id, profile)
+        if not telegram_user_may_access_profile(bot_profile, telegram_user_id, profile):
+            msg = (
+                f"Telegram user {telegram_user_id} is not authorized for profile '{profile}'"
+            )
+            raise PermissionError(msg)
         if config is None:
             from cli.core import ProfileManager
 
@@ -31,7 +38,16 @@ async def create_agent(
     from integrations.messenger.locale import ensure_messenger_locale
 
     ensure_messenger_locale(profile)
-    config = config or init_profile(profile, profile_key=profile_key, prompt_key=False)
+    if config is None:
+        if bot_profile is not None and telegram_user_id is not None:
+            config = init_profile_for_telegram(
+                profile,
+                bot_profile=bot_profile,
+                telegram_user_id=telegram_user_id,
+                profile_key=profile_key,
+            )
+        else:
+            config = init_profile(profile, profile_key=profile_key, prompt_key=False)
     from core.paths import ensure_profile_memory_dirs
 
     ensure_profile_memory_dirs(profile)

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -160,17 +160,32 @@ class HolixTelegramBot:
         mapped = resolve_user_profile(self.settings.profile, user_id)
         return mapped or self.settings.profile
 
-    async def _switch_session_profile(self, session: ChatSession, profile: str) -> None:
+    async def _switch_session_profile(
+        self,
+        session: ChatSession,
+        profile: str,
+        *,
+        bot: Any | None = None,
+    ) -> None:
         from integrations.telegram.agent_setup import create_agent
+        from integrations.telegram.typing_indicator import TypingIndicator
 
         previous_profile = session.profile
         session.profile = profile
         session.conversation_id = f"tg_{profile}_{session.chat_id}"
-        session.agent = await create_agent(
-            profile,
-            bot_profile=self.settings.profile,
-            telegram_user_id=session.user_id,
-        )
+
+        async def _create() -> None:
+            session.agent = await create_agent(
+                profile,
+                bot_profile=self.settings.profile,
+                telegram_user_id=session.user_id,
+            )
+
+        if bot is not None:
+            async with TypingIndicator(bot, session.chat_id):
+                await _create()
+        else:
+            await _create()
         if previous_profile != profile:
             session.pending_files.clear()
         session.pending_plan_review_id = None
@@ -182,24 +197,55 @@ class HolixTelegramBot:
         session._memory_search_query = ""
         session._memory_search_results.clear()
 
-    async def _get_session(self, chat_id: int, user_id: int) -> ChatSession:
-        if chat_id not in self._sessions:
-            profile = self._default_profile_for_user(user_id)
-            self._sessions[chat_id] = ChatSession(
-                chat_id=chat_id,
-                user_id=user_id,
-                profile=profile,
-                conversation_id=f"tg_{profile}_{chat_id}",
-                bot_profile=self.settings.profile,
+    async def _send_session_error(self, bot: Any, chat_id: int, exc: Exception) -> None:
+        from integrations.telegram.markdown import escape_html
+
+        name = type(exc).__name__
+        if name == "InvalidTag":
+            text = (
+                "❌ Не удалось открыть память профиля (ошибка шифрования).\n"
+                "Обратитесь к администратору."
             )
-        session = self._sessions[chat_id]
-        if not session.profile_manual_override:
-            target = self._default_profile_for_user(user_id)
-            if target != session.profile:
-                await self._switch_session_profile(session, target)
-        if session.agent is None:
-            await self._switch_session_profile(session, session.profile)
-        return session
+        elif name == "ProfileKeyError":
+            text = "❌ Профиль защищён ключом доступа. Обратитесь к администратору."
+        elif name == "PermissionError":
+            text = f"❌ Нет доступа к этому профилю.\n{escape_html(str(exc))}"
+        else:
+            text = f"❌ Ошибка инициализации агента: {escape_html(str(exc) or name)}"
+        try:
+            await bot.send_message(chat_id, text, parse_mode="HTML")
+        except Exception:
+            pass
+
+    async def _get_session(
+        self,
+        chat_id: int,
+        user_id: int,
+        *,
+        bot: Any | None = None,
+    ) -> ChatSession:
+        try:
+            if chat_id not in self._sessions:
+                profile = self._default_profile_for_user(user_id)
+                self._sessions[chat_id] = ChatSession(
+                    chat_id=chat_id,
+                    user_id=user_id,
+                    profile=profile,
+                    conversation_id=f"tg_{profile}_{chat_id}",
+                    bot_profile=self.settings.profile,
+                )
+            session = self._sessions[chat_id]
+            if not session.profile_manual_override:
+                target = self._default_profile_for_user(user_id)
+                if target != session.profile:
+                    await self._switch_session_profile(session, target, bot=bot)
+            if session.agent is None:
+                await self._switch_session_profile(session, session.profile, bot=bot)
+            return session
+        except Exception as exc:
+            if bot is not None:
+                await self._send_session_error(bot, chat_id, exc)
+            raise
 
     async def _handle_transcribed_audio(
         self,
@@ -228,7 +274,9 @@ class HolixTelegramBot:
 
         await bot.send_chat_action(message.chat.id, action=ChatAction.TYPING)
 
-        session = await self._get_session(message.chat.id, message.from_user.id)
+        session = await self._get_session(
+            message.chat.id, message.from_user.id, bot=bot
+        )
         try:
             transcribed = await process_voice_message(
                 bot,
@@ -339,7 +387,7 @@ class HolixTelegramBot:
 
         await bot.send_chat_action(chat_id, action=ChatAction.TYPING)
 
-        session = await self._get_session(chat_id, user_id)
+        session = await self._get_session(chat_id, user_id, bot=bot)
         saved_files: list[SavedTelegramFile] = []
         errors: list[str] = []
 
@@ -402,7 +450,9 @@ class HolixTelegramBot:
         user_text: str,
         settings: TelegramSettings,
     ) -> bool:
-        session = await self._get_session(message.chat.id, message.from_user.id)
+        session = await self._get_session(
+            message.chat.id, message.from_user.id, bot=bot
+        )
         if not session.pending_files:
             return False
 
@@ -509,7 +559,9 @@ class HolixTelegramBot:
                 )
                 return
             await self._ensure_authorized_menu(bot, message.chat.id, message.from_user.id)
-            session = await self._get_session(message.chat.id, message.from_user.id)
+            session = await self._get_session(
+                message.chat.id, message.from_user.id, bot=bot
+            )
             host = TelegramHost(bot, session, edit_interval_ms=settings.edit_interval_ms)
             await host.handle_user_text(message.text.strip())
 
@@ -538,7 +590,12 @@ class HolixTelegramBot:
                 settings=settings,
             ):
                 return
-            session = await self._get_session(message.chat.id, message.from_user.id)
+            try:
+                session = await self._get_session(
+                    message.chat.id, message.from_user.id, bot=bot
+                )
+            except Exception:
+                return
             host = TelegramHost(bot, session, edit_interval_ms=settings.edit_interval_ms)
             await host.handle_user_text(message.text)
 
@@ -628,7 +685,9 @@ class HolixTelegramBot:
                 await query.answer("Invalid.", show_alert=True)
                 return
             _, cid, code = parts
-            session = await self._get_session(query.message.chat.id, query.from_user.id)
+            session = await self._get_session(
+                query.message.chat.id, query.from_user.id, bot=bot
+            )
             approvals = TelegramApprovals(bot, session)
             if approvals.resolve_confirmation_callback(cid, code):
                 await approvals.dismiss_confirmation_ui()
@@ -646,7 +705,9 @@ class HolixTelegramBot:
             if not self._allowed(query.from_user.id):
                 await query.answer("Access denied.", show_alert=True)
                 return
-            session = await self._get_session(query.message.chat.id, query.from_user.id)
+            session = await self._get_session(
+                query.message.chat.id, query.from_user.id, bot=bot
+            )
             host = TelegramHost(bot, session, edit_interval_ms=settings.edit_interval_ms)
             value = query.data.split(":", 1)[1] if ":" in query.data else ""
             try:
@@ -693,7 +754,9 @@ class HolixTelegramBot:
             if not self._allowed(query.from_user.id):
                 await query.answer("Access denied.", show_alert=True)
                 return
-            session = await self._get_session(query.message.chat.id, query.from_user.id)
+            session = await self._get_session(
+                query.message.chat.id, query.from_user.id, bot=bot
+            )
             host = TelegramHost(bot, session, edit_interval_ms=settings.edit_interval_ms)
             try:
                 msg = await dispatch_callback(host, query.data)
@@ -713,7 +776,9 @@ class HolixTelegramBot:
                 await query.answer("Invalid.", show_alert=True)
                 return
             _, rid, action = parts
-            session = await self._get_session(query.message.chat.id, query.from_user.id)
+            session = await self._get_session(
+                query.message.chat.id, query.from_user.id, bot=bot
+            )
             approvals = TelegramApprovals(bot, session)
             if approvals.resolve_plan_callback(rid, action):
                 await approvals.dismiss_plan_review_ui()

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -119,16 +119,26 @@ class HolixTelegramBot:
     async def _ensure_authorized_menu(self, bot: Any, chat_id: int, user_id: int) -> None:
         if self.settings.allow_all or chat_id in self._menu_enabled_chats:
             return
+        import logging
+
         from integrations.messenger.locale import messenger_locale
 
         locale = messenger_locale(self.settings.profile)
-        await enable_chat_menu(
-            bot,
-            chat_id,
-            locale=locale,
-            bot_profile=self.settings.profile,
-            user_id=user_id,
-        )
+        try:
+            await enable_chat_menu(
+                bot,
+                chat_id,
+                locale=locale,
+                bot_profile=self.settings.profile,
+                user_id=user_id,
+            )
+        except Exception as exc:
+            logging.getLogger(__name__).warning(
+                "Telegram menu setup failed for chat %s (continuing): %s",
+                chat_id,
+                exc,
+            )
+        # Mark attempted so a slow/failed menu API does not block every message.
         self._menu_enabled_chats.add(chat_id)
 
     def _default_profile_for_user(self, user_id: int) -> str:
@@ -138,6 +148,7 @@ class HolixTelegramBot:
     async def _switch_session_profile(self, session: ChatSession, profile: str) -> None:
         from integrations.telegram.agent_setup import create_agent
 
+        previous_profile = session.profile
         session.profile = profile
         session.conversation_id = f"tg_{profile}_{session.chat_id}"
         session.agent = await create_agent(
@@ -145,7 +156,8 @@ class HolixTelegramBot:
             bot_profile=self.settings.profile,
             telegram_user_id=session.user_id,
         )
-        session.pending_files.clear()
+        if previous_profile != profile:
+            session.pending_files.clear()
         session.pending_plan_review_id = None
         session.pending_confirmation_message_id = None
         session.pending_plan_message_ids.clear()
@@ -331,6 +343,13 @@ class HolixTelegramBot:
                 )
                 saved_files.append(saved)
             except Exception as exc:
+                import logging
+
+                logging.getLogger(__name__).exception(
+                    "Telegram attachment save failed for profile=%s file=%s",
+                    session.profile,
+                    item.file_name,
+                )
                 errors.append(f"{item.file_name}: {exc}")
 
         if not saved_files and errors:

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -116,30 +116,45 @@ class HolixTelegramBot:
         except Exception:
             pass
 
-    async def _ensure_authorized_menu(self, bot: Any, chat_id: int, user_id: int) -> None:
+    async def _ensure_authorized_menu(
+        self,
+        bot: Any,
+        chat_id: int,
+        user_id: int,
+        *,
+        blocking: bool = True,
+    ) -> None:
         if self.settings.allow_all or chat_id in self._menu_enabled_chats:
             return
+        import asyncio
         import logging
 
         from integrations.messenger.locale import messenger_locale
 
         locale = messenger_locale(self.settings.profile)
-        try:
-            await enable_chat_menu(
-                bot,
-                chat_id,
-                locale=locale,
-                bot_profile=self.settings.profile,
-                user_id=user_id,
-            )
-        except Exception as exc:
-            logging.getLogger(__name__).warning(
-                "Telegram menu setup failed for chat %s (continuing): %s",
-                chat_id,
-                exc,
-            )
+
+        async def _setup() -> None:
+            try:
+                await enable_chat_menu(
+                    bot,
+                    chat_id,
+                    locale=locale,
+                    bot_profile=self.settings.profile,
+                    user_id=user_id,
+                )
+            except Exception as exc:
+                logging.getLogger(__name__).warning(
+                    "Telegram menu setup failed for chat %s (continuing): %s",
+                    chat_id,
+                    exc,
+                )
+
         # Mark attempted so a slow/failed menu API does not block every message.
         self._menu_enabled_chats.add(chat_id)
+        if blocking:
+            await _setup()
+        else:
+            asyncio.create_task(_setup(), name=f"tg-menu-{chat_id}")
 
     def _default_profile_for_user(self, user_id: int) -> str:
         mapped = resolve_user_profile(self.settings.profile, user_id)
@@ -505,7 +520,15 @@ class HolixTelegramBot:
             if not self._allowed(message.from_user.id):
                 await self._handle_unauthorized(bot, message)
                 return
-            await self._ensure_authorized_menu(bot, message.chat.id, message.from_user.id)
+            from aiogram.enums import ChatAction
+
+            await bot.send_chat_action(message.chat.id, action=ChatAction.TYPING)
+            await self._ensure_authorized_menu(
+                bot,
+                message.chat.id,
+                message.from_user.id,
+                blocking=False,
+            )
             if message.text.strip().startswith("/"):
                 return
             if await self._flush_pending_files(

--- a/integrations/telegram/commands.py
+++ b/integrations/telegram/commands.py
@@ -179,7 +179,7 @@ async def enable_chat_menu(
         logging.getLogger(__name__).warning(
             "set_my_commands failed for chat %s: %s", cid, exc
         )
-        raise
+        return []
     try:
         await asyncio.wait_for(
             bot.set_chat_menu_button(chat_id=cid, menu_button=MenuButtonCommands()),
@@ -227,17 +227,26 @@ async def register_bot_commands(
     if settings.allow_all:
         return await register_global_bot_commands(bot, locale=locale)
 
+    import asyncio
+
     await clear_default_bot_menu(bot)
-    names: list[str] = []
+
+    async def _register_for_user(uid: int) -> None:
+        try:
+            await enable_chat_menu(
+                bot,
+                uid,
+                locale=locale,
+                bot_profile=bot_profile,
+                user_id=uid,
+            )
+        except Exception:
+            pass
+
+    # Do not block polling startup on per-chat Telegram API calls (can take minutes).
     for uid in sorted(authorized_telegram_user_ids(bot_profile)):
-        names = await enable_chat_menu(
-            bot,
-            uid,
-            locale=locale,
-            bot_profile=bot_profile,
-            user_id=uid,
-        )
-    return names
+        asyncio.create_task(_register_for_user(uid), name=f"tg-menu-register-{uid}")
+    return []
 
 
 async def sync_bot_menu(profile: str = "default") -> list[str]:

--- a/integrations/telegram/commands.py
+++ b/integrations/telegram/commands.py
@@ -227,25 +227,10 @@ async def register_bot_commands(
     if settings.allow_all:
         return await register_global_bot_commands(bot, locale=locale)
 
-    import asyncio
-
     await clear_default_bot_menu(bot)
-
-    async def _register_for_user(uid: int) -> None:
-        try:
-            await enable_chat_menu(
-                bot,
-                uid,
-                locale=locale,
-                bot_profile=bot_profile,
-                user_id=uid,
-            )
-        except Exception:
-            pass
-
-    # Do not block polling startup on per-chat Telegram API calls (can take minutes).
-    for uid in sorted(authorized_telegram_user_ids(bot_profile)):
-        asyncio.create_task(_register_for_user(uid), name=f"tg-menu-register-{uid}")
+    # Per-chat menus are registered lazily on the first authorized message
+    # (see HolixTelegramBot._ensure_authorized_menu). Eager registration here
+    # hammers the Telegram API on every gateway restart and often times out.
     return []
 
 

--- a/integrations/telegram/commands.py
+++ b/integrations/telegram/commands.py
@@ -165,11 +165,26 @@ async def enable_chat_menu(
     if not commands:
         return []
 
+    import asyncio
+    import logging
+
     cid = int(chat_id)
     scope = BotCommandScopeChat(chat_id=cid)
-    await bot.set_my_commands(commands, scope=scope)
     try:
-        await bot.set_chat_menu_button(chat_id=cid, menu_button=MenuButtonCommands())
+        await asyncio.wait_for(
+            bot.set_my_commands(commands, scope=scope),
+            timeout=15.0,
+        )
+    except Exception as exc:
+        logging.getLogger(__name__).warning(
+            "set_my_commands failed for chat %s: %s", cid, exc
+        )
+        raise
+    try:
+        await asyncio.wait_for(
+            bot.set_chat_menu_button(chat_id=cid, menu_button=MenuButtonCommands()),
+            timeout=10.0,
+        )
     except Exception:
         pass
     return [cmd.command for cmd in commands]

--- a/integrations/telegram/file_handler.py
+++ b/integrations/telegram/file_handler.py
@@ -218,14 +218,12 @@ def profile_files_dir(
     bot_profile: str | None = None,
     telegram_user_id: int | None = None,
 ) -> Path:
-    from cli.core import ProfileManager, resolve_profile_storage_paths
+    from core.env_loader import profile_dir_path
 
     from integrations.telegram.profile_auth import init_profile_for_telegram
 
-    mgr = ProfileManager()
-    pdir = mgr.get_profile_dir(profile)
     if bot_profile is not None and telegram_user_id is not None:
-        cfg_source = init_profile_for_telegram(
+        init_profile_for_telegram(
             profile,
             bot_profile=bot_profile,
             telegram_user_id=telegram_user_id,
@@ -233,9 +231,9 @@ def profile_files_dir(
     else:
         from cli.core import init_profile
 
-        cfg_source = init_profile(profile, prompt_key=False)
-    cfg = resolve_profile_storage_paths(profile, cfg_source, profile_dir=pdir)
-    dest = Path(cfg.data_dir) / "files" / "telegram" / str(chat_id)
+        init_profile(profile, prompt_key=False)
+    # Always store Telegram attachments under the named profile dir (never a shared data_dir).
+    dest = profile_dir_path(profile) / "data" / "files" / "telegram" / str(chat_id)
     dest.mkdir(parents=True, exist_ok=True)
     return dest
 
@@ -510,25 +508,49 @@ def format_files_preview(
 def build_agent_prompt(user_text: str, files: list[SavedTelegramFile]) -> str:
     lines = []
     task = (user_text or "").strip()
+    images = [f for f in files if f.kind == "image" or _is_image(f.mime_type, f.original_name)]
     if task:
         lines.append(task)
+    elif images:
+        lines.append(
+            "Проанализируй прикреплённое изображение на основе распознавания ниже "
+            "и ответь по запросу пользователя."
+        )
     else:
         lines.append("Обработай прикреплённые файлы.")
 
     lines.append("")
-    lines.append("## Вложения (сохранены в профиле)")
+    lines.append("## Вложения из Telegram (уже загружены и сохранены)")
+    lines.append(
+        "Файлы уже приняты из чата и лежат на диске. "
+        "НЕ проси пользователя загрузить их повторно."
+    )
     for item in files:
+        is_image = item.kind == "image" or _is_image(item.mime_type, item.original_name)
         lines.append(f"- **{item.original_name}** ({item.kind})")
         lines.append(f"  Путь: `{item.path}`")
         lines.append(f"  MIME: {item.mime_type or 'unknown'} · {item.size_bytes} bytes")
+        if is_image:
+            lines.append(
+                "  Тип: изображение — read_file для JPEG/PNG не подходит; "
+                "используй блок «Содержимое / распознавание» ниже."
+            )
         if item.description:
-            lines.append("  Содержимое / распознавание:")
+            lines.append("  Содержимое / распознавание (vision, уже выполнено):")
             lines.append("  ```")
             lines.append(item.description.strip())
             lines.append("  ```")
+        elif is_image:
+            lines.append("  (Распознавание недоступно — опиши ограничение пользователю.)")
     lines.append("")
+    if images:
+        lines.append(
+            "Для изображений опирайся на vision-описание выше — это основной источник. "
+            "Не вызывай read_file для бинарных фото."
+        )
+        lines.append("")
     lines.append(
-        "Используй пути к файлам для read_file, write_file и других инструментов. "
+        "Для текстовых файлов используй read_file/write_file. "
         "Чтобы отправить сформированные файлы пользователю в Telegram, вызови "
         "send_chat_files с путями (2–10 файлов отправятся альбомом). "
         "Не удаляй оригиналы без явного запроса пользователя."

--- a/integrations/telegram/file_handler.py
+++ b/integrations/telegram/file_handler.py
@@ -54,6 +54,31 @@ _TEXT_SUFFIXES = frozenset(
     }
 )
 _PLACEHOLDER_KEYS = frozenset({"", "ollama", "dummy", "sk-...", "your-api-key"})
+# LiteLLM aliases known to handle image input (ordered preference).
+_VISION_MODEL_PREFERENCES: tuple[str, ...] = (
+    "gemini-flash",
+    "auto",
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+    "claude-haiku-4-5-20251001",
+    "medgemma:27b",
+    "balanced",
+    "smart",
+    "heavy",
+    "research",
+)
+# Substrings that indicate a text-only / code model (unsuitable for vision).
+_TEXT_ONLY_MODEL_MARKERS: tuple[str, ...] = (
+    "coder",
+    "qwen3-coder",
+    "kimi-k2.7-code",
+    "deepseek-v4",
+    "llama-3.3",
+    "ollama-glm",
+    "openrouter-free",
+    "free",
+    "fast",
+)
 
 
 @dataclass(slots=True)
@@ -117,6 +142,60 @@ def _pick_model(*candidates: str) -> str:
         if model and model not in _PLACEHOLDER_KEYS:
             return model
     return ""
+
+
+def _is_text_only_model(name: str) -> bool:
+    lowered = str(name or "").strip().lower()
+    if not lowered:
+        return True
+    return any(marker in lowered for marker in _TEXT_ONLY_MODEL_MARKERS)
+
+
+def _collect_available_models(providers: dict[str, Any]) -> list[str]:
+    models: list[str] = []
+    for raw in providers.values():
+        if not isinstance(raw, dict):
+            continue
+        for item in raw.get("available_models") or []:
+            name = str(item or "").strip()
+            if name and name not in models:
+                models.append(name)
+    return models
+
+
+def _pick_vision_model(
+    *,
+    explicit: str,
+    available: list[str],
+    agent_fallbacks: list[str],
+) -> str:
+    """Choose a vision-capable model; ignore text-only aliases like ``coder``."""
+    explicit = str(explicit or "").strip()
+    if explicit and not _is_text_only_model(explicit):
+        return explicit
+
+    pool = available or [m for m in agent_fallbacks if m and not _is_text_only_model(m)]
+    for preferred in _VISION_MODEL_PREFERENCES:
+        if preferred in pool:
+            return preferred
+    for name in pool:
+        if not _is_text_only_model(name):
+            return name
+    return explicit or _pick_model(*agent_fallbacks) or "auto"
+
+
+def _vision_models_to_try(*, profile: str) -> list[str]:
+    """Ordered vision model list for describe retries."""
+    base = resolve_vision_config(profile=profile)
+    tried: list[str] = []
+    for name in [base.model, *_VISION_MODEL_PREFERENCES]:
+        model = str(name or "").strip()
+        if not model or model in tried or _is_text_only_model(model):
+            continue
+        tried.append(model)
+    if not tried:
+        tried.append(base.model)
+    return tried
 
 
 def resolve_vision_config(*, profile: str) -> VisionConfig:
@@ -190,11 +269,19 @@ def resolve_vision_config(*, profile: str) -> VisionConfig:
         if openai_creds:
             api_key, base_url = openai_creds
 
-    model = _pick_model(*model_candidates)
+    available_models: list[str] = []
+    if config is not None and isinstance(getattr(config, "providers", None), dict):
+        available_models = _collect_available_models(config.providers)
+
+    model = _pick_vision_model(
+        explicit=explicit_model,
+        available=available_models,
+        agent_fallbacks=[m for m in model_candidates if m],
+    )
     if not model:
         raise RuntimeError(
             "Vision: не задана модель. Укажите HOLIX_TELEGRAM_VISION_MODEL "
-            "или назначьте модель для main в holix models setup."
+            "(например gemini-flash или auto) или настройте holix models setup."
         )
     if not api_key or not base_url:
         raise RuntimeError(
@@ -325,18 +412,20 @@ async def _vision_describe_bytes(
     *,
     profile: str,
     mime: str = "image/jpeg",
+    model: str | None = None,
 ) -> str:
     image_b64 = base64.standard_b64encode(image_bytes).decode("ascii")
     from core.models.client_factory import create_openai_client
 
     vision = resolve_vision_config(profile=profile)
+    use_model = str(model or vision.model).strip() or vision.model
     client = create_openai_client(
         base_url=vision.base_url,
         api_key=vision.api_key,
         metadata=vision.provider_metadata,
     )
     response = await client.chat.completions.create(
-        model=vision.model,
+        model=use_model,
         messages=[
             {
                 "role": "user",
@@ -358,7 +447,10 @@ async def _vision_describe_bytes(
         max_tokens=2000,
         temperature=0.2,
     )
-    return (response.choices[0].message.content or "").strip()
+    text = (response.choices[0].message.content or "").strip()
+    if not text:
+        raise RuntimeError(f"модель {use_model} вернула пустой ответ (нет поддержки vision?)")
+    return text
 
 
 async def describe_image_from_url(url: str, *, profile: str) -> str:
@@ -387,7 +479,19 @@ async def describe_image_from_url(url: str, *, profile: str) -> str:
 async def describe_image(path: Path, *, profile: str) -> str:
     mime, _ = mimetypes.guess_type(str(path))
     mime = mime or "image/jpeg"
-    return await _vision_describe_bytes(path.read_bytes(), profile=profile, mime=mime)
+    image_bytes = path.read_bytes()
+    errors: list[str] = []
+    for model in _vision_models_to_try(profile=profile):
+        try:
+            return await _vision_describe_bytes(
+                image_bytes,
+                profile=profile,
+                mime=mime,
+                model=model,
+            )
+        except Exception as exc:
+            errors.append(f"{model}: {exc}")
+    raise RuntimeError("; ".join(errors) or "vision unavailable")
 
 
 async def enrich_saved_file(saved: SavedTelegramFile, *, profile: str) -> SavedTelegramFile:

--- a/integrations/telegram/file_handler.py
+++ b/integrations/telegram/file_handler.py
@@ -56,6 +56,7 @@ _TEXT_SUFFIXES = frozenset(
 _PLACEHOLDER_KEYS = frozenset({"", "ollama", "dummy", "sk-...", "your-api-key"})
 # LiteLLM aliases known to handle image input (ordered preference).
 _VISION_MODEL_PREFERENCES: tuple[str, ...] = (
+    "vision-auto",
     "gemini-flash",
     "auto",
     "claude-sonnet-4-6",
@@ -89,6 +90,8 @@ class SavedTelegramFile:
     kind: str
     size_bytes: int
     description: str = ""
+    image_category: str = ""
+    specialist_model: str = ""
 
 
 @dataclass(slots=True)
@@ -407,24 +410,69 @@ def _extract_docx_text(path: Path, *, max_chars: int = 12000) -> str:
         return ""
 
 
-async def _vision_describe_bytes(
-    image_bytes: bytes,
+_OVERVIEW_VISION_PROMPT = (
+    "Describe this image in detail. Transcribe visible text (OCR), "
+    "objects, tables, and diagrams."
+)
+
+
+async def _chat_completion_text(
     *,
     profile: str,
-    mime: str = "image/jpeg",
-    model: str | None = None,
+    model: str,
+    messages: list[dict[str, Any]],
+    max_tokens: int = 2000,
 ) -> str:
-    image_b64 = base64.standard_b64encode(image_bytes).decode("ascii")
     from core.models.client_factory import create_openai_client
 
     vision = resolve_vision_config(profile=profile)
-    use_model = str(model or vision.model).strip() or vision.model
     client = create_openai_client(
         base_url=vision.base_url,
         api_key=vision.api_key,
         metadata=vision.provider_metadata,
     )
     response = await client.chat.completions.create(
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=0.2,
+    )
+    text = (response.choices[0].message.content or "").strip()
+    if not text:
+        raise RuntimeError(f"модель {model} вернула пустой ответ")
+    return text
+
+
+async def _text_analyze(
+    *,
+    profile: str,
+    model: str,
+    system_prompt: str,
+    user_text: str,
+) -> str:
+    return await _chat_completion_text(
+        profile=profile,
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_text},
+        ],
+    )
+
+
+async def _vision_describe_bytes(
+    image_bytes: bytes,
+    *,
+    profile: str,
+    mime: str = "image/jpeg",
+    model: str | None = None,
+    prompt: str | None = None,
+) -> str:
+    image_b64 = base64.standard_b64encode(image_bytes).decode("ascii")
+    vision = resolve_vision_config(profile=profile)
+    use_model = str(model or vision.model).strip() or vision.model
+    return await _chat_completion_text(
+        profile=profile,
         model=use_model,
         messages=[
             {
@@ -432,10 +480,7 @@ async def _vision_describe_bytes(
                 "content": [
                     {
                         "type": "text",
-                        "text": (
-                            "Describe this image in detail. Transcribe visible text (OCR), "
-                            "objects, tables, and diagrams."
-                        ),
+                        "text": prompt or _OVERVIEW_VISION_PROMPT,
                     },
                     {
                         "type": "image_url",
@@ -444,25 +489,102 @@ async def _vision_describe_bytes(
                 ],
             }
         ],
-        max_tokens=2000,
-        temperature=0.2,
     )
-    text = (response.choices[0].message.content or "").strip()
-    if not text:
-        raise RuntimeError(f"модель {use_model} вернула пустой ответ (нет поддержки vision?)")
-    return text
 
 
-async def describe_image_from_url(url: str, *, profile: str) -> str:
-    """Describe an inline or remote image URL (Hermes multimodal gateway path)."""
+def _parse_vision_auto_metadata(description: str) -> tuple[str, str]:
+    """Extract category and specialist model from LiteLLM vision-auto response."""
+    category = "general"
+    specialist = ""
+    match = re.search(r"Категория:\s*\S+\s*\((\w+)\)", description)
+    if match:
+        category = match.group(1)
+    spec_match = re.search(
+        r"## Специализированный анализ —\s*\S+\s*\(([^)]+)\)",
+        description,
+    )
+    if spec_match:
+        specialist = spec_match.group(1).strip()
+    return category, specialist
+
+
+async def _describe_image_routed(
+    image_bytes: bytes,
+    *,
+    profile: str,
+    mime: str = "image/jpeg",
+) -> tuple[str, str, str]:
+    """Return (description, image_category, specialist_model)."""
+    from integrations.telegram.image_router import (
+        analyze_with_specialist,
+        classify_image_overview,
+    )
+
+    vision_cfg = resolve_vision_config(profile=profile)
+    if vision_cfg.model == "vision-auto":
+        errors: list[str] = []
+        for model in ["vision-auto"]:
+            try:
+                description = await _vision_describe_bytes(
+                    image_bytes,
+                    profile=profile,
+                    mime=mime,
+                    model=model,
+                )
+                category, specialist = _parse_vision_auto_metadata(description)
+                return description, category, specialist
+            except Exception as exc:
+                errors.append(f"{model}: {exc}")
+        raise RuntimeError("; ".join(errors) or "vision-auto unavailable")
+
+    errors: list[str] = []
+    overview = ""
+    overview_model = ""
+    for model in _vision_models_to_try(profile=profile):
+        try:
+            overview = await _vision_describe_bytes(
+                image_bytes,
+                profile=profile,
+                mime=mime,
+                model=model,
+                prompt=_OVERVIEW_VISION_PROMPT,
+            )
+            overview_model = model
+            break
+        except Exception as exc:
+            errors.append(f"{model}: {exc}")
+
+    if not overview:
+        raise RuntimeError("; ".join(errors) or "vision unavailable")
+
+    if not settings.telegram_image_router_enabled:
+        return overview, "general", ""
+
+    route = classify_image_overview(overview)
+    if route.category == "general":
+        return overview, route.category, ""
+
+    description = await analyze_with_specialist(
+        overview=overview,
+        overview_model=overview_model,
+        image_bytes=image_bytes,
+        mime=mime,
+        profile=profile,
+        route=route,
+        vision_describe_fn=_vision_describe_bytes,
+        text_analyze_fn=_text_analyze,
+    )
+    return description, route.category, route.specialist_model
+
+
+async def _load_image_bytes_from_url(url: str) -> tuple[bytes, str]:
     raw = (url or "").strip()
     if raw.startswith("data:"):
         header, _, payload = raw.partition(",")
         mime = "image/jpeg"
         if header.startswith("data:") and ";" in header:
             mime = header[5:].split(";", 1)[0] or mime
-        image_bytes = base64.standard_b64decode(payload)
-        return await _vision_describe_bytes(image_bytes, profile=profile, mime=mime)
+        return base64.standard_b64decode(payload), mime
 
     if raw.startswith(("http://", "https://")):
         import httpx
@@ -471,27 +593,31 @@ async def describe_image_from_url(url: str, *, profile: str) -> str:
             response = await client.get(raw)
             response.raise_for_status()
             mime = response.headers.get("content-type", "image/jpeg").split(";", 1)[0]
-            return await _vision_describe_bytes(response.content, profile=profile, mime=mime)
+            return response.content, mime
 
     raise ValueError(f"Unsupported image URL: {raw[:80]}")
+
+
+async def describe_image_from_url(url: str, *, profile: str) -> str:
+    """Describe an inline or remote image URL (Hermes multimodal gateway path)."""
+    image_bytes, mime = await _load_image_bytes_from_url(url)
+    description, _, _ = await _describe_image_routed(
+        image_bytes,
+        profile=profile,
+        mime=mime,
+    )
+    return description
 
 
 async def describe_image(path: Path, *, profile: str) -> str:
     mime, _ = mimetypes.guess_type(str(path))
     mime = mime or "image/jpeg"
-    image_bytes = path.read_bytes()
-    errors: list[str] = []
-    for model in _vision_models_to_try(profile=profile):
-        try:
-            return await _vision_describe_bytes(
-                image_bytes,
-                profile=profile,
-                mime=mime,
-                model=model,
-            )
-        except Exception as exc:
-            errors.append(f"{model}: {exc}")
-    raise RuntimeError("; ".join(errors) or "vision unavailable")
+    description, _, _ = await _describe_image_routed(
+        path.read_bytes(),
+        profile=profile,
+        mime=mime,
+    )
+    return description
 
 
 async def enrich_saved_file(saved: SavedTelegramFile, *, profile: str) -> SavedTelegramFile:
@@ -500,7 +626,16 @@ async def enrich_saved_file(saved: SavedTelegramFile, *, profile: str) -> SavedT
 
     if saved.kind == "image" or _is_image(saved.mime_type, saved.original_name):
         try:
-            saved.description = await describe_image(path, profile=profile)
+            mime, _ = mimetypes.guess_type(str(path))
+            mime = mime or saved.mime_type or "image/jpeg"
+            description, category, specialist = await _describe_image_routed(
+                path.read_bytes(),
+                profile=profile,
+                mime=mime,
+            )
+            saved.description = description
+            saved.image_category = category
+            saved.specialist_model = specialist
             saved.kind = "image"
         except Exception as exc:
             saved.description = f"(Не удалось распознать изображение: {exc})"
@@ -596,6 +731,11 @@ def format_files_preview(
         lines.append(f"{idx}. <b>{label}</b> {escape_html(item.original_name)}")
         lines.append(f"   <code>{escape_html(str(item.path))}</code>")
         lines.append(f"   {item.size_bytes // 1024} KB")
+        if item.image_category and item.image_category != "general":
+            label_bits = [f"категория: {item.image_category}"]
+            if item.specialist_model:
+                label_bits.append(f"модель: {item.specialist_model}")
+            lines.append(f"   <i>{escape_html(', '.join(label_bits))}</i>")
         if item.description:
             short = item.description[:max_desc_chars]
             if len(item.description) > max_desc_chars:
@@ -639,8 +779,13 @@ def build_agent_prompt(user_text: str, files: list[SavedTelegramFile]) -> str:
                 "  Тип: изображение — read_file для JPEG/PNG не подходит; "
                 "используй блок «Содержимое / распознавание» ниже."
             )
+        if is_image and item.image_category and item.image_category != "general":
+            meta = f"категория: {item.image_category}"
+            if item.specialist_model:
+                meta += f", specialist: {item.specialist_model}"
+            lines.append(f"  Маршрут vision: {meta}")
         if item.description:
-            lines.append("  Содержимое / распознавание (vision, уже выполнено):")
+            lines.append("  Содержимое / распознавание (vision + autorouter, уже выполнено):")
             lines.append("  ```")
             lines.append(item.description.strip())
             lines.append("  ```")

--- a/integrations/telegram/image_router.py
+++ b/integrations/telegram/image_router.py
@@ -1,0 +1,329 @@
+"""Classify Telegram image overviews and route to specialist models."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# Minimum keyword score to pick a specialist route (else general-only overview).
+_ROUTE_SCORE_THRESHOLD = 2
+
+
+@dataclass(frozen=True, slots=True)
+class ImageRouteSpec:
+    category: str
+    label_ru: str
+    specialist_model: str
+    use_image: bool
+    keywords: tuple[str, ...]
+    specialist_prompt: str
+
+
+@dataclass(slots=True)
+class ImageRouteResult:
+    category: str
+    label_ru: str
+    specialist_model: str
+    score: int
+    use_image: bool
+    specialist_prompt: str
+
+
+_IMAGE_ROUTES: tuple[ImageRouteSpec, ...] = (
+    ImageRouteSpec(
+        category="medicine",
+        label_ru="медицина",
+        specialist_model="medgemma:27b",
+        use_image=True,
+        keywords=(
+            "x-ray",
+            "xray",
+            "mri",
+            "ct scan",
+            "ultrasound",
+            "medical",
+            "clinical",
+            "patient",
+            "diagnosis",
+            "anatomy",
+            "fracture",
+            "tumor",
+            "lesion",
+            "radiograph",
+            "медицин",
+            "рентген",
+            "снимок",
+            "диагноз",
+            "пациент",
+            "мрт",
+            "кт",
+            "узи",
+            "перелом",
+            "анатом",
+        ),
+        specialist_prompt=(
+            "You are a medical imaging assistant. Analyze this clinical image in detail. "
+            "Describe visible structures, findings, and regions of interest. "
+            "Transcribe labels and measurements. "
+            "End with a short disclaimer that this is not a medical diagnosis."
+        ),
+    ),
+    ImageRouteSpec(
+        category="code",
+        label_ru="код",
+        specialist_model="coder",
+        use_image=False,
+        keywords=(
+            "code",
+            "python",
+            "javascript",
+            "typescript",
+            "function",
+            "class ",
+            "def ",
+            "import ",
+            "syntax",
+            "ide",
+            "vscode",
+            "terminal",
+            "stack trace",
+            "error message",
+            "github",
+            "repository",
+            "sql",
+            "api",
+            "код",
+            "функци",
+            "ошибк",
+            "терминал",
+            "репозитор",
+            "программ",
+        ),
+        specialist_prompt=(
+            "You are a senior software engineer. Based on the image overview and OCR below, "
+            "analyze the code or technical screenshot: structure, intent, bugs, and improvements. "
+            "If code is present, quote the important fragments."
+        ),
+    ),
+    ImageRouteSpec(
+        category="food",
+        label_ru="еда",
+        specialist_model="balanced",
+        use_image=True,
+        keywords=(
+            "food",
+            "meal",
+            "dish",
+            "plate",
+            "nutrition",
+            "calorie",
+            "recipe",
+            "ingredient",
+            "fruit",
+            "vegetable",
+            "restaurant",
+            "breakfast",
+            "lunch",
+            "dinner",
+            "еда",
+            "блюдо",
+            "тарелк",
+            "калори",
+            "нутриент",
+            "рецепт",
+            "ингредиент",
+            "завтрак",
+            "обед",
+            "ужин",
+        ),
+        specialist_prompt=(
+            "You are a nutrition assistant. Analyze this food image: identify dishes and "
+            "ingredients, estimate portions, and give approximate calories and macros. "
+            "Note uncertainty where visibility is limited."
+        ),
+    ),
+    ImageRouteSpec(
+        category="document",
+        label_ru="документ",
+        specialist_model="research",
+        use_image=False,
+        keywords=(
+            "chart",
+            "graph",
+            "table",
+            "diagram",
+            "spreadsheet",
+            "invoice",
+            "receipt",
+            "form",
+            "document",
+            "report",
+            "slide",
+            "presentation",
+            "диаграм",
+            "график",
+            "таблиц",
+            "документ",
+            "отчёт",
+            "отчет",
+            "счёт",
+            "счет",
+            "презентац",
+        ),
+        specialist_prompt=(
+            "You are a document analyst. Based on the overview and OCR, extract structured facts, "
+            "summarize tables/charts, and list key figures and conclusions."
+        ),
+    ),
+)
+
+_GENERAL_ROUTE = ImageRouteResult(
+    category="general",
+    label_ru="общее",
+    specialist_model="",
+    score=0,
+    use_image=False,
+    specialist_prompt="",
+)
+
+
+def _normalize_overview(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _score_route(spec: ImageRouteSpec, overview: str) -> int:
+    score = 0
+    for keyword in spec.keywords:
+        if keyword in overview:
+            score += 2 if " " in keyword else 1
+    return score
+
+
+def classify_image_overview(overview: str) -> ImageRouteResult:
+    """Pick a specialist route from a high-level vision overview."""
+    normalized = _normalize_overview(overview)
+    if not normalized:
+        return _GENERAL_ROUTE
+
+    best: ImageRouteResult | None = None
+    for spec in _IMAGE_ROUTES:
+        score = _score_route(spec, normalized)
+        if score < _ROUTE_SCORE_THRESHOLD:
+            continue
+        candidate = ImageRouteResult(
+            category=spec.category,
+            label_ru=spec.label_ru,
+            specialist_model=spec.specialist_model,
+            score=score,
+            use_image=spec.use_image,
+            specialist_prompt=spec.specialist_prompt,
+        )
+        if best is None or candidate.score > best.score:
+            best = candidate
+
+    return best or _GENERAL_ROUTE
+
+
+def _route_spec_for(category: str) -> ImageRouteSpec | None:
+    for spec in _IMAGE_ROUTES:
+        if spec.category == category:
+            return spec
+    return None
+
+
+def format_routed_description(
+    *,
+    overview: str,
+    overview_model: str,
+    route: ImageRouteResult,
+    specialist_text: str = "",
+    specialist_model: str = "",
+) -> str:
+    """Merge overview and optional specialist analysis for agent prompts."""
+    parts = [
+        f"Категория: {route.label_ru} ({route.category})",
+        "",
+        f"## Обзор ({overview_model})",
+        overview.strip(),
+    ]
+    if specialist_text.strip():
+        model_label = specialist_model or route.specialist_model or "specialist"
+        parts.extend(
+            [
+                "",
+                f"## Специализированный анализ — {route.label_ru} ({model_label})",
+                specialist_text.strip(),
+            ]
+        )
+    return "\n".join(parts).strip()
+
+
+async def analyze_with_specialist(
+    *,
+    overview: str,
+    overview_model: str,
+    image_bytes: bytes,
+    mime: str,
+    profile: str,
+    route: ImageRouteResult,
+    vision_describe_fn: Any,
+    text_analyze_fn: Any,
+) -> str:
+    """Run a second pass with the routed specialist model."""
+    if not route.specialist_model or route.category == "general":
+        return format_routed_description(overview=overview, overview_model=overview_model, route=route)
+
+    spec = _route_spec_for(route.category)
+    if spec is None:
+        return format_routed_description(overview=overview, overview_model=overview_model, route=route)
+
+    specialist_text = ""
+    specialist_model = route.specialist_model
+    context = f"Image overview:\n{overview.strip()}"
+
+    try:
+        if route.use_image:
+            specialist_text = await vision_describe_fn(
+                image_bytes,
+                profile=profile,
+                mime=mime,
+                model=specialist_model,
+                prompt=spec.specialist_prompt,
+            )
+        else:
+            specialist_text = await text_analyze_fn(
+                profile=profile,
+                model=specialist_model,
+                system_prompt=spec.specialist_prompt,
+                user_text=context,
+            )
+    except Exception as exc:
+        fallback_model = "fast" if specialist_model != "fast" else "balanced"
+        try:
+            if route.use_image:
+                specialist_text = await vision_describe_fn(
+                    image_bytes,
+                    profile=profile,
+                    mime=mime,
+                    model=fallback_model,
+                    prompt=spec.specialist_prompt,
+                )
+            else:
+                specialist_text = await text_analyze_fn(
+                    profile=profile,
+                    model=fallback_model,
+                    system_prompt=spec.specialist_prompt,
+                    user_text=context,
+                )
+            specialist_model = fallback_model
+        except Exception:
+            specialist_text = f"(Специализированный анализ недоступен: {exc})"
+
+    return format_routed_description(
+        overview=overview,
+        overview_model=overview_model,
+        route=route,
+        specialist_text=specialist_text,
+        specialist_model=specialist_model,
+    )

--- a/integrations/telegram/profile_auth.py
+++ b/integrations/telegram/profile_auth.py
@@ -59,7 +59,11 @@ def init_profile_for_telegram(
     authorize_telegram_profile_access(bot_profile, telegram_user_id, holix_profile)
     import os
 
+    from core.crypto.profile_crypto import profile_has_crypto_metadata
+
     unlock_key = os.getenv("HOLIX_UNLOCK_KEY", "").strip() or None
+    if unlock_key and not profile_has_crypto_metadata(holix_profile):
+        unlock_key = None
     return init_profile(
         holix_profile,
         profile_key=profile_key,

--- a/integrations/telegram/profile_seed.py
+++ b/integrations/telegram/profile_seed.py
@@ -134,11 +134,16 @@ def _seed_profile_env_from_bot(bot_profile: str, user_profile: str) -> None:
     if not to_copy:
         return
 
+    from core.crypto.profile_files import read_profile_file_text, write_profile_file_text
+    from core.crypto.unlock_context import bootstrap_profile_unlock_from_env
+
+    bootstrap_profile_unlock_from_env(user_profile)
+
     user_env = profile_env_path(user_profile)
     user_env.parent.mkdir(parents=True, exist_ok=True)
     lines: list[str] = []
     if user_env.is_file():
-        lines.append(user_env.read_text(encoding="utf-8").rstrip())
+        lines.append(read_profile_file_text(user_env, profile=user_profile).rstrip())
         lines.append("")
     else:
         lines.append(
@@ -146,7 +151,7 @@ def _seed_profile_env_from_bot(bot_profile: str, user_profile: str) -> None:
         )
     for key in sorted(to_copy):
         lines.append(f"{key}={to_copy[key]}")
-    user_env.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_profile_file_text(user_env, "\n".join(lines) + "\n", profile=user_profile)
 
 
 def seed_telegram_user_profile_from_bot(

--- a/integrations/telegram/voice_handler.py
+++ b/integrations/telegram/voice_handler.py
@@ -254,6 +254,8 @@ async def warm_local_whisper_model_async(*, profile: str | None = None) -> None:
     """Background-friendly wrapper for :func:`warm_local_whisper_model`."""
     from config import settings
 
+    if not settings.whisper_auto_download or not settings.telegram_voice_enabled:
+        return
     model = (settings.whisper_local_model or "base").strip()
     root = local_whisper_download_root()
     print(f"Whisper: downloading local model '{model}' to {root} …", flush=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "0.1.16"
+version = "0.1.17"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import tempfile
 import uuid
+from pathlib import Path
 
 import pytest
 from core.tools.registry import ToolRegistry
@@ -147,6 +148,19 @@ def gateway_client(gateway_auth_headers, monkeypatch: pytest.MonkeyPatch):
     client = TestClient(api.gateway.app)
     yield client
     api.gateway.app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_holix_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep profile paths off the developer/CI machine (~/.holix)."""
+    import cli.core as cli_core
+
+    holix_home = tmp_path / ".holix"
+    profiles = holix_home / "profiles"
+    profiles.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOLIX_HOME", str(holix_home))
+    monkeypatch.setattr(cli_core, "HOLIX_HOME", holix_home)
+    monkeypatch.setattr(cli_core, "PROFILES_DIR", profiles)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -3,7 +3,6 @@
 import json
 
 import pytest
-
 from api.errors import (
     agent_error_to_http,
     client_safe_message,

--- a/tests/test_cron_global_scheduler.py
+++ b/tests/test_cron_global_scheduler.py
@@ -1,0 +1,109 @@
+"""Global cron scheduler and profile discovery."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from core.cron.discovery import CronProfileIndex, invalidate_profile
+from core.cron.scheduler import GlobalCronScheduler
+from core.cron.store import CronStore
+
+
+def _fake_profile_dir(tmp_path: Path, profile: str) -> Path:
+    d = tmp_path / profile
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "config.yaml").write_text(f"profile_name: {profile}\n", encoding="utf-8")
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _reset_profile_index() -> None:
+    import core.cron.discovery as discovery
+
+    discovery._index = None
+    yield
+    discovery._index = None
+
+
+@pytest.fixture
+def profiles_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from cli.core import ProfileManager
+
+    def fake_dir(self, profile: str) -> Path:
+        return _fake_profile_dir(tmp_path, profile)
+
+    monkeypatch.setattr(ProfileManager, "get_profile_dir", fake_dir)
+    monkeypatch.setattr("cli.core.profiles_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def test_index_discovers_multiple_profiles(profiles_root: Path) -> None:
+    CronStore("alice").add(task="task a", cron_expression="0 9 * * *")
+    CronStore("bob").add(task="task b", cron_expression="0 10 * * *")
+
+    index = CronProfileIndex(discovery_interval_s=0)
+    profiles = index.scan_profiles_with_jobs()
+    assert profiles == ["alice", "bob"]
+
+    by_profile = dict(index.iter_enabled_jobs())
+    assert set(by_profile) == {"alice", "bob"}
+    assert len(by_profile["alice"]) == 1
+    assert len(by_profile["bob"]) == 1
+
+
+def test_index_uses_mtime_cache(profiles_root: Path) -> None:
+    store = CronStore("alice")
+    store.add(task="cached", cron_expression="0 9 * * *")
+    index = CronProfileIndex(discovery_interval_s=9999)
+
+    first = dict(index.iter_enabled_jobs())
+    second = dict(index.iter_enabled_jobs())
+    assert first == second
+    assert "alice" in index._cache
+
+
+def test_invalidate_profile_refreshes_after_save(profiles_root: Path) -> None:
+    from core.cron.discovery import get_profile_index
+
+    index = get_profile_index()
+    assert dict(index.iter_enabled_jobs()) == {}
+
+    CronStore("alice").add(task="new job", cron_expression="0 * * * *")
+    invalidate_profile("alice")
+
+    jobs = dict(index.iter_enabled_jobs())
+    assert "alice" in jobs
+    assert jobs["alice"][0].task == "new job"
+
+
+@pytest.mark.asyncio
+async def test_global_scheduler_dispatches_due_jobs_from_any_profile(
+    profiles_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    past = datetime(2020, 1, 1, tzinfo=UTC).isoformat()
+    CronStore("alice").add(task="run a", cron_expression="0 9 * * *")
+    CronStore("bob").add(task="run b", cron_expression="0 10 * * *")
+    for profile in ("alice", "bob"):
+        store = CronStore(profile)
+        data = store.load()
+        data.jobs[0].next_run_at = past
+        store.save(data)
+
+    run_mock = AsyncMock()
+    monkeypatch.setattr("core.cron.scheduler.run_cron_job", run_mock)
+
+    scheduler = GlobalCronScheduler(tick_seconds=30, max_concurrent=2)
+    await scheduler.tick()
+    for _ in range(100):
+        if run_mock.await_count >= 2:
+            break
+        await asyncio.sleep(0.01)
+
+    assert run_mock.await_count == 2
+    profiles_run = {call.args[0].profile for call in run_mock.await_args_list}
+    assert profiles_run == {"alice", "bob"}

--- a/tests/test_cron_global_scheduler.py
+++ b/tests/test_cron_global_scheduler.py
@@ -33,12 +33,15 @@ def _reset_profile_index() -> None:
 def profiles_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     from cli.core import ProfileManager
 
+    profiles = tmp_path / "profiles"
+    profiles.mkdir(parents=True, exist_ok=True)
+
     def fake_dir(self, profile: str) -> Path:
-        return _fake_profile_dir(tmp_path, profile)
+        return _fake_profile_dir(profiles, profile)
 
     monkeypatch.setattr(ProfileManager, "get_profile_dir", fake_dir)
-    monkeypatch.setattr("cli.core.profiles_dir", lambda: tmp_path)
-    return tmp_path
+    monkeypatch.setattr("cli.core.profiles_dir", lambda: profiles)
+    return profiles
 
 
 def test_index_discovers_multiple_profiles(profiles_root: Path) -> None:

--- a/tests/test_di.py
+++ b/tests/test_di.py
@@ -72,7 +72,9 @@ async def test_dishka_container_provides_agent(temp_dir):
 
 @pytest.mark.asyncio
 async def test_create_agent_initializes(memory_manager, temp_dir):
-    """create_agent uses profile paths without mutating global settings."""
+    """create_agent binds storage to the profile tree without mutating global settings."""
+    from cli.core import ProfileManager
+
     profile = ProfileConfig(
         profile_name="di_test",
         memory_db_path=f"{temp_dir}/mem.db",
@@ -80,6 +82,9 @@ async def test_create_agent_initializes(memory_manager, temp_dir):
         skills_dir=f"{temp_dir}/skills",
     )
     runtime_config = resolve_runtime_config(profile)
+    expected_memory = (
+        ProfileManager().get_profile_dir("di_test") / "data" / "memory" / "memory.db"
+    )
     container = None
     try:
         agent, container = await create_agent(
@@ -87,9 +92,7 @@ async def test_create_agent_initializes(memory_manager, temp_dir):
             enable_monitoring=False,
         )
         assert agent._initialized
-        assert Path(agent.config.memory_db_path).resolve() == Path(
-            f"{temp_dir}/mem.db"
-        ).resolve()
+        assert Path(agent.config.memory_db_path).resolve() == expected_memory.resolve()
     finally:
         if container:
             await container.close()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -44,9 +44,8 @@ def test_check_invalid_default_provider(tmp_path: Path, monkeypatch: pytest.Monk
     assert any(f.code == "profile.invalid_default_provider" for f in findings)
 
 
-def test_fix_create_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("cli.core.HOLIX_HOME", tmp_path)
-    monkeypatch.setattr("cli.core.PROFILES_DIR", tmp_path / "profiles")
+def test_fix_create_profile() -> None:
+    from cli.core import PROFILES_DIR
 
     finding = DoctorFinding(
         code="profile.missing",
@@ -59,7 +58,7 @@ def test_fix_create_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     )
     applied = apply_deterministic_fixes("newprof", [finding])
     assert applied
-    assert (tmp_path / "profiles" / "newprof" / "config.yaml").exists()
+    assert (PROFILES_DIR / "newprof" / "config.yaml").exists()
 
 
 def test_check_hub_missing_bundle(tmp_path: Path) -> None:

--- a/tests/test_holix_md.py
+++ b/tests/test_holix_md.py
@@ -22,17 +22,18 @@ def test_holix_md_path_under_dot_helix(tmp_path: Path) -> None:
 
 
 def test_load_and_inject(tmp_path: Path, monkeypatch) -> None:
-
-    monkeypatch.chdir(tmp_path)
-    holix = tmp_path / ".helix"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    holix = project / ".holix"
     holix.mkdir()
     (holix / "HOLIX.md").write_text("# Demo\n\nREST on /api/v1\n", encoding="utf-8")
 
-    assert holix_md_exists()
-    assert "REST" in load_holix_md()
+    assert holix_md_exists(project)
+    assert "REST" in load_holix_md(project)
     block = format_holix_md_block()
     assert "REST" in block
-    out = append_holix_project_context("BASE", tmp_path)
+    out = append_holix_project_context("BASE", project)
     assert "BASE" in out
     assert "REST" in out
 

--- a/tests/test_image_router.py
+++ b/tests/test_image_router.py
@@ -1,0 +1,68 @@
+"""Image overview classification and specialist routing."""
+
+from __future__ import annotations
+
+from integrations.telegram.image_router import (
+    classify_image_overview,
+    format_routed_description,
+)
+
+
+def test_classify_medicine_xray() -> None:
+    route = classify_image_overview(
+        "Chest X-ray showing ribs, lungs and heart silhouette. Medical radiograph."
+    )
+    assert route.category == "medicine"
+    assert route.specialist_model == "medgemma:27b"
+    assert route.use_image is True
+
+
+def test_classify_code_screenshot() -> None:
+    route = classify_image_overview(
+        "Screenshot of Python code in VS Code with a function definition and import statement."
+    )
+    assert route.category == "code"
+    assert route.specialist_model == "coder"
+    assert route.use_image is False
+
+
+def test_classify_food_plate() -> None:
+    route = classify_image_overview("A plate with pasta dish, vegetables and sauce in a restaurant.")
+    assert route.category == "food"
+    assert route.specialist_model == "balanced"
+
+
+def test_classify_document_chart() -> None:
+    route = classify_image_overview("Bar chart and table with quarterly revenue figures in a report.")
+    assert route.category == "document"
+    assert route.specialist_model == "research"
+
+
+def test_classify_general_when_ambiguous() -> None:
+    route = classify_image_overview("A person standing near a tree on a sunny day.")
+    assert route.category == "general"
+    assert route.specialist_model == ""
+
+
+def test_format_routed_description_includes_sections() -> None:
+    from integrations.telegram.image_router import ImageRouteResult
+
+    route = ImageRouteResult(
+        category="medicine",
+        label_ru="медицина",
+        specialist_model="medgemma:27b",
+        score=4,
+        use_image=True,
+        specialist_prompt="analyze",
+    )
+    text = format_routed_description(
+        overview="X-ray of shoulder joint.",
+        overview_model="gemini-flash",
+        route=route,
+        specialist_text="Possible joint space narrowing.",
+        specialist_model="medgemma:27b",
+    )
+    assert "Категория: медицина" in text
+    assert "## Обзор (gemini-flash)" in text
+    assert "## Специализированный анализ" in text
+    assert "medgemma:27b" in text

--- a/tests/test_no_cwd_data_leak.py
+++ b/tests/test_no_cwd_data_leak.py
@@ -185,7 +185,8 @@ async def test_api_key_manager_opens_resolved_db(tmp_path, monkeypatch) -> None:
 
 
 def test_doctor_migrates_stray_project_data(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr("cli.core.PROFILES_DIR", tmp_path / "profiles")
+    from cli.core import PROFILES_DIR
+
     repo = tmp_path / "repo"
     repo.mkdir()
     stray = repo / "data" / "memory"
@@ -202,4 +203,4 @@ def test_doctor_migrates_stray_project_data(tmp_path, monkeypatch) -> None:
     applied = apply_deterministic_fixes("default", findings)
     assert applied
     assert not (repo / "data").exists()
-    assert (tmp_path / "profiles" / "default" / "data" / "memory" / "ltm.db").exists()
+    assert (PROFILES_DIR / "default" / "data" / "memory" / "ltm.db").exists()

--- a/tests/test_profile_admin_seed.py
+++ b/tests/test_profile_admin_seed.py
@@ -78,4 +78,7 @@ def test_copy_profile_settings_updates_existing_admin(holix_home) -> None:
         source_profile="default",
         target_profile="admin",
     )
-    assert manager.load_profile("admin").max_steps == 17
+    admin_cfg = manager.load_profile("admin")
+    assert admin_cfg.max_steps == 17
+    assert "profiles/admin/data" in admin_cfg.data_dir.replace("\\", "/")
+    assert "profiles/default/data" not in admin_cfg.data_dir.replace("\\", "/")

--- a/tests/test_profile_names.py
+++ b/tests/test_profile_names.py
@@ -30,10 +30,11 @@ def test_validate_profile_name_rejects_unsafe(bad: str) -> None:
         validate_profile_name(bad)
 
 
-def test_profile_dir_for_name_under_profiles_root(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("HELIX_HOME", str(tmp_path))
+def test_profile_dir_for_name_under_profiles_root() -> None:
+    from cli.core import HOLIX_HOME
+
     path = profile_dir_for_name("alice")
-    assert path == (tmp_path / "profiles" / "alice").resolve()
+    assert path == (HOLIX_HOME / "profiles" / "alice").resolve()
 
 
 def test_resolve_workspace_root_rejects_traversal() -> None:

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -135,14 +135,8 @@ async def test_register_bot_commands_per_user_when_not_allow_all(
 
     names = await register_bot_commands(bot, locale="en", bot_profile="default")
 
-    assert names == ["help"]
-    enable_mock.assert_awaited_once_with(
-        bot,
-        42,
-        locale="en",
-        bot_profile="default",
-        user_id=42,
-    )
+    assert names == []
+    enable_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_files.py
+++ b/tests/test_telegram_files.py
@@ -49,6 +49,38 @@ def test_resolve_vision_config_uses_env_when_model_explicit(
     assert cfg.base_url.endswith("/v1")
 
 
+def test_resolve_vision_config_skips_text_only_explicit_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LITELLM_API_KEY", "sk-test-key")
+    monkeypatch.setenv("LITELLM_API_BASE", "http://localhost:4000/v1")
+    _patch_vision_settings(monkeypatch, telegram_vision_model="coder")
+
+    class _Cfg:
+        providers = {
+            "litellm": {
+                "api_key": "sk-test-key",
+                "base_url": "http://localhost:4000/v1",
+                "available_models": ["coder", "gemini-flash", "auto"],
+                "default_model": "auto",
+            }
+        }
+        agent_models = {}
+        default_provider = "litellm"
+        model = "coder"
+        api_key = ""
+        base_url = ""
+
+    class _Mgr:
+        def load_profile(self, _profile: str):
+            return _Cfg()
+
+    monkeypatch.setattr("cli.core.get_profile_manager", lambda: _Mgr())
+
+    cfg = resolve_vision_config(profile="admin")
+    assert cfg.model == "gemini-flash"
+
+
 def test_resolve_vision_config_requires_api_when_only_model_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_telegram_files.py
+++ b/tests/test_telegram_files.py
@@ -72,21 +72,24 @@ def test_safe_filename_sanitizes() -> None:
 
 
 def test_profile_files_dir_under_data(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from cli.core import ProfileManager
-
-    profile = "default"
+    profile = "admin"
     pdir = tmp_path / "profiles" / profile
     pdir.mkdir(parents=True)
-    (pdir / "config.yaml").write_text("profile_name: default\n", encoding="utf-8")
-
-    monkeypatch.setattr(
-        ProfileManager,
-        "get_profile_dir",
-        lambda self, name: pdir,
+    (pdir / "config.yaml").write_text(
+        "profile_name: admin\n"
+        "data_dir: " + str(tmp_path / "profiles" / "default" / "data") + "\n",
+        encoding="utf-8",
     )
+
+    monkeypatch.setenv("HOLIX_HOME", str(tmp_path))
+    import cli.core as cli_core
+
+    monkeypatch.setattr(cli_core, "HOLIX_HOME", tmp_path)
+    monkeypatch.setattr(cli_core, "PROFILES_DIR", tmp_path / "profiles")
 
     dest = profile_files_dir(profile, 12345)
     assert dest == pdir / "data" / "files" / "telegram" / "12345"
+    assert "default" not in str(dest)
     assert dest.is_dir()
 
 
@@ -104,6 +107,23 @@ def test_build_agent_prompt_includes_path_and_description() -> None:
     assert "report.pdf" in prompt
     assert "Summary text" in prompt
     assert saved.path.as_posix() in prompt.replace("\\", "/")
+
+
+def test_build_agent_prompt_tells_agent_not_to_reupload_images() -> None:
+    saved = SavedTelegramFile(
+        path=Path("/tmp/profile/data/files/telegram/1/xray.jpg"),
+        original_name="xray.jpg",
+        mime_type="image/jpeg",
+        kind="image",
+        size_bytes=4096,
+        description="Shoulder X-ray with visible joint space.",
+    )
+    prompt = build_agent_prompt("Расшифруй снимок", [saved])
+    assert "Расшифруй снимок" in prompt
+    assert "Shoulder X-ray" in prompt
+    assert "НЕ проси пользователя загрузить" in prompt
+    assert "read_file для JPEG/PNG не подходит" in prompt
+    assert "vision-описание" in prompt
 
 
 def test_extract_pdf_text(tmp_path: Path) -> None:

--- a/tests/test_telegram_profile_auth.py
+++ b/tests/test_telegram_profile_auth.py
@@ -61,6 +61,26 @@ def test_authorize_unlocks_mapped_profile_without_key(holix_home) -> None:
     assert "lain" in cli_core._unlocked_profiles
 
 
+def test_init_profile_for_telegram_ignores_stale_encryption_flag(
+    holix_home, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """encryption_enabled without crypto.json must not break Telegram file saves."""
+    from integrations.telegram.user_profiles import set_user_profile
+
+    manager = ProfileManager()
+    manager.create_profile("admin", inherit_global=True)
+    cfg = manager.load_profile("admin")
+    cfg.encryption_enabled = True
+    manager.save_profile("admin", cfg)
+
+    save_telegram_env({"TELEGRAM_BOT_TOKEN": "1:abc"}, profile="shared")
+    set_user_profile("shared", 77, "admin")
+    monkeypatch.setenv("HOLIX_UNLOCK_KEY", "unlock-key-stale-flag")
+
+    cfg = init_profile_for_telegram("admin", bot_profile="shared", telegram_user_id=77)
+    assert cfg.profile_name == "admin"
+
+
 def test_init_profile_for_telegram_does_not_prompt(holix_home, monkeypatch: pytest.MonkeyPatch) -> None:
     from integrations.telegram.user_profiles import set_user_profile
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,6 +7,18 @@ from core.tools.file_ops import ListDirectoryTool, ReadFileTool, WriteFileTool
 
 
 @pytest.mark.asyncio
+async def test_read_file_rejects_binary_image_with_helpful_message(tmp_path):
+    read_tool = ReadFileTool()
+    image = tmp_path / "scan.jpg"
+    image.write_bytes(b"\xff\xd8\xff\xe0binary")
+
+    result = await read_tool.execute(str(image))
+    assert "binary image" in result
+    assert "vision description" in result
+    assert "re-upload" in result
+
+
+@pytest.mark.asyncio
 async def test_write_and_read_file():
     """Test writing and reading files."""
     write_tool = WriteFileTool()

--- a/uv.lock
+++ b/uv.lock
@@ -1035,7 +1035,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Telegram file storage**: `profile_files_dir` always writes to `profiles/<name>/data/files/telegram/<chat_id>` instead of following a shared `data_dir` from another profile (e.g. admin inheriting `default/data`).
- **Admin profile seed**: `copy_profile_settings_from_source` strips `PROFILE_ONLY_KEYS` (data_dir, memory DB paths, etc.) before copying settings, so production seed no longer rewrites admin paths back to default.
- **Encrypted profiles**: skip unlock when `crypto.json` is missing; seed `.env` via encrypted I/O helpers.
- **Agent UX**: clearer vision prompts for images; `read_file` returns a helpful message for binary images instead of asking re-upload.
- **Bot resilience**: menu setup (`set_my_commands`) has timeouts and failures no longer block every message; `pending_files` cleared only on actual profile switch.

## Test plan

- [x] `pytest tests/test_profile_admin_seed.py tests/test_telegram_files.py tests/test_telegram_profile_auth.py tests/test_tools.py` (25 passed locally)
- [ ] CI matrix (ubuntu/windows/macos, Python 3.12–3.14)
- [ ] Manual: send photo via Telegram → path under `profiles/admin/data/files/telegram/<chat_id>/`

## Production context

Fixes issue where photos for Telegram user mapped to `admin` profile were saved under `/home/itadmin/.holix/profiles/default/data/files/telegram/144802020/`.