### PR TITLE
feat(telegram): sub-agent delivery, web-research dispatch

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "0.1.19"
+__version__ = "0.1.20"

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"

--- a/cli/shared/commands/subagent_commands.py
+++ b/cli/shared/commands/subagent_commands.py
@@ -75,18 +75,37 @@ def _schedule_subagent_delivery(host: Any, job_id: str) -> None:
         logger.warning("No event loop for sub-agent result delivery (%s)", job_id)
 
 
+def _resolve_subagent_agent(host: Any) -> Any:
+    resolver = getattr(host, "resolve_subagent_agent", None)
+    if callable(resolver):
+        return resolver()
+    try:
+        from integrations.telegram.subagent_delivery import resolve_subagent_agent
+
+        return resolve_subagent_agent(host)
+    except Exception:
+        return _agent(host)
+
+
 async def _deliver_subagent_result_when_ready(host: Any, job_id: str) -> None:
     """Push background sub-agent output to the messenger when the job finishes."""
-    agent = _agent(host)
+    agent = _resolve_subagent_agent(host)
     if not agent or not hasattr(agent, "subagents"):
+        logger.warning("Sub-agent %s: agent not available for delivery", job_id)
         _host_notify(host, f"[red]Sub-agent {job_id}: agent not available for result delivery[/red]")
         return
     mgr = agent.subagents
     handle = mgr.get_handle(job_id)
     if not handle:
+        logger.warning(
+            "Sub-agent %s: handle not found (tracked=%d)",
+            job_id,
+            len(mgr.list_all()),
+        )
         _host_notify(host, f"[yellow]Sub-agent {job_id}: job handle not found[/yellow]")
         return
     try:
+        logger.info("Waiting for sub-agent %s delivery", job_id)
         timeout = handle.config.timeout
         result = await mgr.wait_for(job_id, timeout=timeout)
         text = (result.response or result.error or "").strip()
@@ -97,7 +116,8 @@ async def _deliver_subagent_result_when_ready(host: Any, job_id: str) -> None:
         if hasattr(host, "_send_text"):
             await host._send_text(f"**Субагент `{job_id}` завершил работу:**\n\n{text}")
         elif hasattr(host, "_send_split_plain"):
-            await host._send_split_plain(f"{job_id}:\n{text}")
+            await host._send_split_plain(text)
+            logger.info("Delivered sub-agent %s result (%d chars)", job_id, len(text))
         else:
             _host_notify(host, body[:8000])
     except TimeoutError:
@@ -115,7 +135,7 @@ async def run_subagents_command(host: Any, command: str) -> None:
     """List, spawn, terminate, or show sub-agent results."""
     cmd = command.strip().lower()
     parts = cmd.split()
-    agent = await _resolve_agent(host)
+    agent = _resolve_subagent_agent(host) or await _resolve_agent(host)
 
     if not agent or not hasattr(agent, "subagents"):
         host.transcript_write(

--- a/config.py
+++ b/config.py
@@ -27,6 +27,11 @@ class Settings(BaseSettings):
 
     # Agent Configuration
     max_steps: int = 90
+    agent_max_tokens: int = Field(
+        default=8192,
+        validation_alias=AliasChoices("HOLIX_AGENT_MAX_TOKENS", "AGENT_MAX_TOKENS"),
+        description="Default max_tokens for ReAct agent steps (reasoning models need headroom)",
+    )
     llm_step_timeout: float = 300.0
     data_dir: str = "data"
     context_window: int = 131072

--- a/core/agent_execution.py
+++ b/core/agent_execution.py
@@ -582,5 +582,6 @@ def _build_api_messages(
 
     # Reverse back to chronological order
     selected.reverse()
+    from core.llm.api_messages import finalize_api_messages
 
-    return [system_msg] + selected
+    return [system_msg] + finalize_api_messages(selected)

--- a/core/agent_execution.py
+++ b/core/agent_execution.py
@@ -165,9 +165,11 @@ async def run_agent_loop(
             )
         else:
             # Legacy fallback: just last 20 messages
+            from core.llm.api_messages import prepare_conversation_for_llm
+
             api_messages = [
                 {"role": "system", "content": system_prompt}
-            ] + messages[-20:]
+            ] + prepare_conversation_for_llm(messages[-20:])
 
         try:
             if stream:
@@ -553,7 +555,10 @@ def _build_api_messages(
     Returns:
         List of messages for the API call, starting with the system prompt.
     """
+    from core.llm.api_messages import prepare_conversation_for_llm
+
     system_msg = {"role": "system", "content": system_prompt}
+    history = prepare_conversation_for_llm(messages)
     system_tokens = context_manager.token_counter.count_message_tokens([system_msg])
 
     # Reserve buffer for model's response and tool overhead
@@ -568,7 +573,7 @@ def _build_api_messages(
     selected = []
     running_tokens = 0
 
-    for msg in reversed(messages):
+    for msg in reversed(history):
         msg_tokens = context_manager.token_counter.count_message_tokens([msg])
         if running_tokens + msg_tokens > available_tokens:
             break

--- a/core/cron/scheduler.py
+++ b/core/cron/scheduler.py
@@ -77,11 +77,10 @@ class GlobalCronScheduler:
                 async with self._dispatch_lock:
                     if active_runs.is_active(job.id):
                         continue
-                    task = asyncio.create_task(
+                    asyncio.create_task(
                         self._run_wrapped(profile, job.id),
                         name=f"cron-{profile}-{job.id}",
                     )
-                    active_runs.register_task(job.id, task)
 
     async def _run_wrapped(self, profile: str, job_id: str) -> None:
         async with self._semaphore:
@@ -126,8 +125,7 @@ class CronScheduler:
                 if active_runs.is_active(job.id):
                     continue
 
-            task = asyncio.create_task(self._run_wrapped(job.id), name=f"cron-{job.id}")
-            active_runs.register_task(job.id, task)
+            asyncio.create_task(self._run_wrapped(job.id), name=f"cron-{job.id}")
 
     async def _run_wrapped(self, job_id: str) -> None:
         job = self._store.get(job_id)

--- a/core/direct_dispatch/__init__.py
+++ b/core/direct_dispatch/__init__.py
@@ -5,12 +5,17 @@ from core.direct_dispatch.intent import (
     is_subagent_list_request,
     is_work_activity_request,
 )
+from core.direct_dispatch.search_intent import extract_search_topic, is_web_research_request
+from core.direct_dispatch.web_research import try_web_research_subagent_dispatch
 from core.direct_dispatch.work_status import build_work_status_reply, should_answer_work_status
 
 __all__ = [
     "build_work_status_reply",
+    "extract_search_topic",
     "is_status_request",
     "is_subagent_list_request",
+    "is_web_research_request",
     "is_work_activity_request",
     "should_answer_work_status",
+    "try_web_research_subagent_dispatch",
 ]

--- a/core/direct_dispatch/search_intent.py
+++ b/core/direct_dispatch/search_intent.py
@@ -1,0 +1,234 @@
+"""Detect user messages that need live web research."""
+
+from __future__ import annotations
+
+import re
+
+_REPEAT_SEARCH_RE = re.compile(
+    r"(?:повтори|ещё?\s*раз|снова)\s+(?:поиск|search)",
+    re.IGNORECASE,
+)
+_WEB_SEARCH_CALL_RE = re.compile(
+    r"web_search\s*\(\s*['\"](.+?)['\"]\s*\)",
+    re.IGNORECASE | re.DOTALL,
+)
+_WEB_SEARCH_TOPIC_RES = (
+    re.compile(
+        r"найди\s+(?:в\s+)?(?:интернете?|интеренете?|сети|web)\s+"
+        r"(?:информацию\s+)?(?:по\s+)?(.+)$",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(
+        r"поиск(?:ай)?\s+(?:в\s+)?(?:интернете?|интеренете?|сети)?\s*(.+)$",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(
+        r"search(?:\s+the\s+web|\s+online)?\s+for\s+(.+)$",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(
+        r"исследуй\s+(?:тему\s+)?(.+)$",
+        re.IGNORECASE | re.DOTALL,
+    ),
+)
+
+_SMALL_TALK_RE = re.compile(
+    r"^(?:"
+    r"привет|здравствуй|добрый\s+(?:день|утро|вечер)|"
+    r"спасибо|благодарю|thanks|thank\s+you|"
+    r"ok|ок|да|нет|ага|угу|"
+    r"хорошо|понятно|ладно|пока|до\s+свидания|"
+    r"ты\s+тут|ты\s+здесь"
+    r")\s*[!.?]*$",
+    re.IGNORECASE,
+)
+
+_LOCAL_TASK_RE = re.compile(
+    r"(?:"
+    r"^/|"
+    r"напиши\s+(?:код|функцию|скрипт|тест|класс)|"
+    r"создай\s+(?:файл|скилл|скрипт|проект|ветку|коммит)|"
+    r"исправь\s+(?:баг|ошибк|код)|"
+    r"отредактируй|refactor|рефактор|"
+    r"запусти\s+(?:тест|команд|скрипт|holix)|"
+    r"выполни\s+команд|"
+    r"git\s+(?:commit|push|pull|merge)|"
+    r"сделай\s+(?:commit|pr|pull\s+request)|"
+    r"покажи\s+(?:код|файл|diff|лог|статус\s+профил)|"
+    r"останови|/stop|"
+    r"переключи\s+(?:модель|профиль)|"
+    r"установи\s+пакет|pip\s+install|npm\s+install"
+    r")",
+    re.IGNORECASE,
+)
+
+_SEARCH_ACTION_RE = re.compile(
+    r"(?:"
+    r"найди|найти|поищи|поискать|"
+    r"загугли|гугл(?:ь|и)?|"
+    r"узнай|выясни|"
+    r"проверь|проверить|"
+    r"посмотри|глянь|"
+    r"собери\s+информацию|"
+    r"подбери|"
+    r"сравни|"
+    r"исследуй|"
+    r"search|lookup|look\s+up|find\s+out|google"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_FRESH_DATA_RE = re.compile(
+    r"(?:"
+    r"сегодня|сейчас|вчера|на\s+данный\s+момент|"
+    r"актуальн|последн|свеж|"
+    r"новост|"
+    r"в\s+интернете?|в\s+сети|online|"
+    r"что\s+нового|что\s+случилось"
+    r")",
+    re.IGNORECASE,
+)
+
+_QUESTION_START_RE = re.compile(
+    r"(?:^|[,.:;]\s*)(?:"
+    r"какой|какая|какие|каково|"
+    r"по\s+какой|"
+    r"где|куда|откуда|"
+    r"когда|"
+    r"сколько|"
+    r"кто|"
+    r"что\s+(?:такое|это|случилось|нового|известно|происходит)|"
+    r"почему|зачем|"
+    r"есть\s+ли|"
+    r"были\s+ли|"
+    r"как\s+(?:лучше|обстоят|дела|работает|сейчас|часто)|"
+    r"можно\s+ли|"
+    r"стоит\s+ли|"
+    r"какая\s+ситуация|какая\s+обстановка|"
+    r"расскажи\s+(?:про|о|об)|"
+    r"дай\s+(?:информацию|справку|обзор)|"
+    r"опиши|"
+    r"what\s+is|who\s+is|where\s+is|when\s+did|how\s+much|how\s+many"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_CHOICE_COMPARE_RE = re.compile(
+    r"(?:"
+    r"лучше|хуже|"
+    r"сравни|сравнение|"
+    r"или\s+лучше|"
+    r"что\s+выбрать|"
+    r"какой\s+вариант|"
+    r"какой\s+маршрут|"
+    r"по\s+какой\s+дорог"
+    r")",
+    re.IGNORECASE,
+)
+
+_TOPIC_CONTEXT_RE = re.compile(
+    r"(?:"
+    r"дорог|маршрут|трасс|ехать|лететь|"
+    r"цен[аы]|курс|стоимость|"
+    r"погод|температур|"
+    r"работает|открыт|закрыт|"
+    r"новост|событи|"
+    r"компани|продукт|сервис|"
+    r"закон|регулирован|"
+    r"релиз|верси|"
+    r"азс|бензин|топлив|заправк"
+    r")",
+    re.IGNORECASE,
+)
+
+_MIN_LEN = 8
+
+
+def _clean_query(raw: str) -> str:
+    q = (raw or "").strip().strip("«»\"'.")
+    q = re.split(r"\s+и\s+пришли", q, maxsplit=1, flags=re.IGNORECASE)[0].strip()
+    return q[:500]
+
+
+def _is_agent_meta_request(text: str) -> bool:
+    from core.direct_dispatch.intent import (
+        is_status_request,
+        is_subagent_list_request,
+        is_work_activity_request,
+    )
+
+    return (
+        is_subagent_list_request(text)
+        or is_status_request(text)
+        or is_work_activity_request(text)
+    )
+
+
+def extract_search_topic(text: str) -> str | None:
+    explicit = _WEB_SEARCH_CALL_RE.search(text)
+    if explicit:
+        return _clean_query(explicit.group(1))
+
+    stripped = text.strip()
+    for pattern in _WEB_SEARCH_TOPIC_RES:
+        match = pattern.search(stripped)
+        if match:
+            q = _clean_query(match.group(1))
+            if len(q) >= 3:
+                return q
+    return None
+
+
+def is_web_research_request(text: str) -> bool:
+    """True when the user needs live web data (delegate to web_researcher).
+
+    Detects general information-seeking and search queries, not only
+    fuel/route niche patterns. Local agent tasks and small talk are excluded.
+    """
+    stripped = (text or "").strip()
+    if not stripped or len(stripped) < _MIN_LEN:
+        return False
+
+    if stripped.startswith("/"):
+        return False
+
+    if _SMALL_TALK_RE.match(stripped):
+        return False
+
+    if _is_agent_meta_request(stripped):
+        return False
+
+    if _LOCAL_TASK_RE.search(stripped):
+        return False
+
+    if _REPEAT_SEARCH_RE.search(stripped):
+        return True
+
+    if extract_search_topic(stripped):
+        return True
+
+    if _SEARCH_ACTION_RE.search(stripped):
+        return True
+
+    if _FRESH_DATA_RE.search(stripped):
+        return True
+
+    has_question = "?" in stripped
+    has_question_start = bool(_QUESTION_START_RE.search(stripped))
+
+    if has_question_start and (has_question or len(stripped) >= 12):
+        return True
+
+    if has_question and len(stripped) >= 12 and _TOPIC_CONTEXT_RE.search(stripped):
+        return True
+
+    if _CHOICE_COMPARE_RE.search(stripped) and len(stripped) >= 15:
+        return True
+
+    if has_question_start and _TOPIC_CONTEXT_RE.search(stripped):
+        return True
+
+    if re.search(r"проблем", stripped, re.IGNORECASE) and _TOPIC_CONTEXT_RE.search(stripped):
+        return True
+
+    return False

--- a/core/direct_dispatch/web_research.py
+++ b/core/direct_dispatch/web_research.py
@@ -1,0 +1,86 @@
+"""Auto-delegate web research tasks to the web_researcher sub-agent."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from core.config_utils import is_subagents_enabled
+from core.direct_dispatch.search_intent import is_web_research_request
+
+logger = logging.getLogger(__name__)
+
+NotifyFn = Callable[[str], Awaitable[None]]
+
+
+async def try_web_research_subagent_dispatch(
+    agent: Any,
+    message: str,
+    *,
+    timeout_seconds: float = 600.0,
+    notify: NotifyFn | None = None,
+    wait_for_result: bool = True,
+) -> tuple[bool, str]:
+    """Spawn web_researcher; optionally wait and return (handled, reply_or_job_id)."""
+    text = (message or "").strip()
+    if not text or not is_web_research_request(text):
+        return False, ""
+
+    if not is_subagents_enabled(getattr(agent, "config", None)):
+        return False, ""
+
+    mgr = getattr(agent, "subagents", None)
+    if mgr is None:
+        return False, ""
+
+    from core.tools.subagents import DelegateToSubAgentTool, WaitSubAgentResultTool
+
+    logger.info("Direct dispatch: web_researcher sub-agent (%r)", text[:80])
+
+    delegate = DelegateToSubAgentTool(agent)
+    wait = WaitSubAgentResultTool(agent)
+
+    spawned_raw = await delegate.execute(agent_type="web_researcher", task=text)
+    if spawned_raw.startswith("Error"):
+        return True, spawned_raw
+
+    try:
+        spawned = json.loads(spawned_raw)
+    except json.JSONDecodeError:
+        return True, f"Не удалось разобрать ответ delegate_to_subagent: {spawned_raw[:500]}"
+
+    job_id = spawned.get("job_id")
+    if not job_id:
+        return True, f"Субагент не запущен: {spawned.get('message') or spawned_raw}"
+
+    if notify is not None:
+        from core.presenters.subagent_tool_text import format_subagent_tool_notice
+
+        notice = format_subagent_tool_notice("delegate_to_subagent", spawned_raw)
+        if notice:
+            await notify(notice)
+        else:
+            await notify("🔍 Запускаю субагента **web_researcher**…")
+
+    if not wait_for_result:
+        return True, job_id
+
+    result_raw = await wait.execute(job_id=job_id, timeout_seconds=timeout_seconds)
+    if result_raw.startswith("Error"):
+        return True, result_raw
+
+    try:
+        result = json.loads(result_raw)
+    except json.JSONDecodeError:
+        return True, result_raw
+
+    if result.get("success"):
+        body = (result.get("response") or "").strip()
+        if body:
+            return True, body
+        return True, "Субагент web_researcher завершил работу без текстового ответа."
+
+    err = (result.get("error") or "unknown error").strip()
+    return True, f"Субагент web_researcher завершился с ошибкой: {err}"

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -29,6 +29,7 @@ from core.graph.plan_step import (
 )
 from core.graph.state import HolixGraphState, get_agent_from_config
 from core.i18n.live_ui import live_reasoning_label, live_thinking_step_label
+from core.llm.max_tokens import profile_agent_max_tokens, resolve_agent_max_tokens
 from core.llm.response_text import (
     assistant_message_parts,
     resolve_assistant_text,
@@ -112,6 +113,15 @@ async def _plan_step_result(
         step_count=step_count,
         final_response=final_response,
         include_assistant=not assistant_already_appended,
+    )
+
+
+def _llm_max_tokens(agent, model_manager, agent_slot: str) -> int:
+    from config import settings
+
+    return resolve_agent_max_tokens(
+        profile_max_tokens=profile_agent_max_tokens(model_manager, agent_slot),
+        default_max_tokens=getattr(settings, "agent_max_tokens", None),
     )
 
 
@@ -228,6 +238,7 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
     agent_slot = getattr(agent, "agent_slot", "main") if agent else "main"
     model_manager = getattr(agent, "model_manager", None) if agent else None
     llm_timeout_s = _llm_step_timeout_s(agent)
+    max_tokens = _llm_max_tokens(agent, model_manager, agent_slot)
 
     def _on_fallback_switch(cfg) -> None:
         if agent and hasattr(agent, "set_active_model_config"):
@@ -248,6 +259,7 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
                 agent_slot=agent_slot,
                 on_switch=_on_fallback_switch,
                 llm_timeout_s=llm_timeout_s,
+                max_tokens=max_tokens,
             )
         else:
             return await _react_non_streaming(
@@ -263,6 +275,7 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
                 agent_slot=agent_slot,
                 on_switch=_on_fallback_switch,
                 llm_timeout_s=llm_timeout_s,
+                max_tokens=max_tokens,
             )
 
     except LLMStepTimeoutError as exc:
@@ -328,6 +341,7 @@ async def _react_non_streaming(
     agent_slot: str = "main",
     on_switch=None,
     llm_timeout_s: float = _DEFAULT_LLM_STEP_TIMEOUT_S,
+    max_tokens: int | None = None,
 ) -> dict:
     """Non-streaming ReAct step."""
     conversation_id = state.get("conversation_id", "default")
@@ -344,6 +358,7 @@ async def _react_non_streaming(
                 tools=tools,
                 tool_choice="auto",
                 temperature=temperature,
+                max_tokens=max_tokens,
             )
         return await client.chat.completions.create(
             model=model,
@@ -351,6 +366,7 @@ async def _react_non_streaming(
             tools=tools,
             tool_choice="auto",
             temperature=temperature,
+            max_tokens=max_tokens,
         )
 
     async with asyncio.timeout(llm_timeout_s):
@@ -453,6 +469,7 @@ async def _react_streaming(
     agent_slot: str = "main",
     on_switch=None,
     llm_timeout_s: float = _DEFAULT_LLM_STEP_TIMEOUT_S,
+    max_tokens: int | None = None,
 ) -> dict:
     """Streaming ReAct step."""
     conversation_id = state.get("conversation_id", "default")
@@ -471,6 +488,7 @@ async def _react_streaming(
                     tools=tools,
                     tool_choice="auto",
                     temperature=temperature,
+                    max_tokens=max_tokens,
                     stream=True,
                 ),
             )
@@ -480,6 +498,7 @@ async def _react_streaming(
             tools=tools,
             tool_choice="auto",
             temperature=temperature,
+            max_tokens=max_tokens,
             stream=True,
         )
 
@@ -586,6 +605,7 @@ async def _react_streaming(
                         agent_slot=agent_slot,
                         on_switch=on_switch,
                         llm_timeout_s=llm_timeout_s,
+                        max_tokens=max_tokens,
                     )
                 messages = list(state.get("messages", []))
                 messages.append({"role": "assistant", "content": final_response})
@@ -676,6 +696,7 @@ async def _react_streaming(
             agent_slot=agent_slot,
             on_switch=on_switch,
             llm_timeout_s=llm_timeout_s,
+            max_tokens=max_tokens,
         )
     final_response = _non_empty_final(final_response)
     messages = list(state.get("messages", []))

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -836,4 +836,6 @@ def _build_api_messages(system_prompt, messages, context_manager) -> list:
         running_tokens += msg_tokens
 
     selected.reverse()
-    return [system_msg] + selected
+    from core.llm.api_messages import finalize_api_messages
+
+    return [system_msg] + finalize_api_messages(selected)

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -198,7 +198,11 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
     if agent and hasattr(agent, "context_manager") and agent.context_manager:
         api_messages = _build_api_messages(system_prompt, messages, agent.context_manager)
     else:
-        api_messages = [{"role": "system", "content": system_prompt}] + messages[-20:]
+        from core.llm.api_messages import prepare_conversation_for_llm
+
+        api_messages = [{"role": "system", "content": system_prompt}] + prepare_conversation_for_llm(
+            messages[-20:]
+        )
 
     # Get runtime config
     client: AsyncOpenAI = agent.client if agent else None
@@ -809,7 +813,10 @@ def _build_system_prompt_from_state(state: HolixGraphState, agent=None) -> str:
 
 def _build_api_messages(system_prompt, messages, context_manager) -> list:
     """Build API message list respecting context window limits."""
+    from core.llm.api_messages import prepare_conversation_for_llm
+
     system_msg = {"role": "system", "content": system_prompt}
+    history = prepare_conversation_for_llm(messages)
     system_tokens = context_manager.token_counter.count_message_tokens([system_msg])
 
     response_reserve = 2048
@@ -821,7 +828,7 @@ def _build_api_messages(system_prompt, messages, context_manager) -> list:
     selected = []
     running_tokens = 0
 
-    for msg in reversed(messages):
+    for msg in reversed(history):
         msg_tokens = context_manager.token_counter.count_message_tokens([msg])
         if running_tokens + msg_tokens > available_tokens:
             break

--- a/core/llm/api_messages.py
+++ b/core/llm/api_messages.py
@@ -1,0 +1,64 @@
+"""Normalize Holix conversation history for provider chat APIs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_API_MESSAGE_KEYS = frozenset({"role", "content", "name", "tool_calls", "tool_call_id"})
+
+
+def _to_api_message(message: dict[str, Any]) -> dict[str, Any] | None:
+    """Keep only fields accepted by OpenAI-compatible chat APIs."""
+    role = message.get("role")
+    if role not in {"system", "user", "assistant", "tool"}:
+        return None
+
+    out: dict[str, Any] = {"role": role}
+    content = message.get("content")
+    if content is not None:
+        out["content"] = content
+
+    name = message.get("name")
+    if name:
+        out["name"] = name
+
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        out["tool_calls"] = tool_calls
+
+    tool_call_id = message.get("tool_call_id")
+    if tool_call_id:
+        out["tool_call_id"] = tool_call_id
+
+    return out
+
+
+def prepare_conversation_for_llm(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Strip Holix-only fields and duplicate system turns before an API call.
+
+    Soul blocks are injected into session storage for compression pinning, but
+    the live system prompt already includes ``format_soul_block()``. Providers such
+    as Groq (single system message) and Mistral (strict schema) reject extra
+    ``role:system`` entries and unknown keys like ``metadata``.
+    """
+    from core.profile.soul import strip_soul_messages
+
+    prepared: list[dict[str, Any]] = []
+    for message in strip_soul_messages(messages):
+        role = message.get("role")
+        if role == "system":
+            content = str(message.get("content") or "").strip()
+            if content:
+                prepared.append(
+                    {
+                        "role": "user",
+                        "content": f"[Context note]\n{content}",
+                    }
+                )
+            continue
+
+        api_message = _to_api_message(message)
+        if api_message is not None:
+            prepared.append(api_message)
+
+    return prepared

--- a/core/llm/api_messages.py
+++ b/core/llm/api_messages.py
@@ -7,6 +7,17 @@ from typing import Any
 _API_MESSAGE_KEYS = frozenset({"role", "content", "name", "tool_calls", "tool_call_id"})
 
 
+def _tool_call_ids(message: dict[str, Any]) -> set[str]:
+    ids: set[str] = set()
+    for tc in message.get("tool_calls") or []:
+        if not isinstance(tc, dict):
+            continue
+        tid = tc.get("id")
+        if tid:
+            ids.add(str(tid))
+    return ids
+
+
 def _to_api_message(message: dict[str, Any]) -> dict[str, Any] | None:
     """Keep only fields accepted by OpenAI-compatible chat APIs."""
     role = message.get("role")
@@ -33,6 +44,89 @@ def _to_api_message(message: dict[str, Any]) -> dict[str, Any] | None:
     return out
 
 
+def _append_context_note(target: dict[str, Any], note: str) -> None:
+    body = str(note or "").strip()
+    if not body:
+        return
+    block = f"[Context note]\n{body}" if not body.startswith("[") else body
+    existing = str(target.get("content") or "").strip()
+    target["content"] = f"{existing}\n\n{block}".strip() if existing else block
+
+
+def _prepend_context_notes(target: dict[str, Any], notes: list[str]) -> None:
+    blocks = [f"[Context note]\n{note.strip()}" for note in notes if str(note or "").strip()]
+    if not blocks:
+        return
+    prefix = "\n\n".join(blocks)
+    existing = str(target.get("content") or "").strip()
+    target["content"] = f"{prefix}\n\n{existing}".strip() if existing else prefix
+
+
+def _strip_incomplete_tool_turn(messages: list[dict[str, Any]]) -> None:
+    while messages and messages[-1].get("role") == "tool":
+        messages.pop()
+    if messages and messages[-1].get("role") == "assistant" and messages[-1].get("tool_calls"):
+        messages.pop()
+
+
+def repair_api_message_sequence(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Fix ordering rules enforced by Groq/Mistral/OpenAI-compatible APIs."""
+    if not messages:
+        return messages
+
+    result: list[dict[str, Any]] = []
+    pending_tool_ids: set[str] = set()
+
+    for message in messages:
+        role = message.get("role")
+
+        if role == "assistant":
+            if pending_tool_ids:
+                _strip_incomplete_tool_turn(result)
+                pending_tool_ids = set()
+            pending_tool_ids = _tool_call_ids(message)
+            result.append(message)
+            continue
+
+        if role == "tool":
+            tool_id = str(message.get("tool_call_id") or "")
+            if tool_id and tool_id in pending_tool_ids:
+                result.append(message)
+                pending_tool_ids.discard(tool_id)
+                continue
+            if result and result[-1].get("role") == "user":
+                content = str(message.get("content") or "").strip()
+                if content:
+                    _append_context_note(result[-1], f"[Tool result]\n{content}")
+            continue
+
+        if role == "user":
+            if pending_tool_ids:
+                _strip_incomplete_tool_turn(result)
+                pending_tool_ids = set()
+            result.append(message)
+            continue
+
+        result.append(message)
+
+    if pending_tool_ids:
+        _strip_incomplete_tool_turn(result)
+
+    return result
+
+
+def drop_leading_orphan_tools(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Context truncation may keep tool rows without the assistant tool_calls turn."""
+    trimmed = list(messages)
+    while trimmed and trimmed[0].get("role") == "tool":
+        trimmed.pop(0)
+    return trimmed
+
+
+def finalize_api_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return repair_api_message_sequence(drop_leading_orphan_tools(messages))
+
+
 def prepare_conversation_for_llm(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Strip Holix-only fields and duplicate system turns before an API call.
 
@@ -40,25 +134,78 @@ def prepare_conversation_for_llm(messages: list[dict[str, Any]]) -> list[dict[st
     the live system prompt already includes ``format_soul_block()``. Providers such
     as Groq (single system message) and Mistral (strict schema) reject extra
     ``role:system`` entries and unknown keys like ``metadata``.
+
+    System notes are deferred while a tool-call turn is in progress so we never
+    insert ``role:user`` between ``assistant.tool_calls`` and ``role:tool``.
     """
     from core.profile.soul import strip_soul_messages
 
     prepared: list[dict[str, Any]] = []
+    deferred_notes: list[str] = []
+    pending_tool_ids: set[str] = set()
+
     for message in strip_soul_messages(messages):
         role = message.get("role")
+
         if role == "system":
             content = str(message.get("content") or "").strip()
             if content:
-                prepared.append(
-                    {
-                        "role": "user",
-                        "content": f"[Context note]\n{content}",
-                    }
-                )
+                if pending_tool_ids:
+                    deferred_notes.append(content)
+                else:
+                    prepared.append(
+                        {"role": "user", "content": f"[Context note]\n{content}"}
+                    )
+            continue
+
+        if role == "assistant":
+            if pending_tool_ids:
+                _strip_incomplete_tool_turn(prepared)
+                pending_tool_ids = set()
+            api_message = _to_api_message(message)
+            if api_message is not None:
+                pending_tool_ids = _tool_call_ids(api_message)
+                if not pending_tool_ids and deferred_notes:
+                    _prepend_context_notes(api_message, deferred_notes)
+                    deferred_notes.clear()
+                prepared.append(api_message)
+            continue
+
+        if role == "tool":
+            api_message = _to_api_message(message)
+            if api_message is None:
+                continue
+            tool_id = str(api_message.get("tool_call_id") or "")
+            if tool_id and tool_id in pending_tool_ids:
+                prepared.append(api_message)
+                pending_tool_ids.discard(tool_id)
+            continue
+
+        if role == "user":
+            if pending_tool_ids:
+                _strip_incomplete_tool_turn(prepared)
+                pending_tool_ids = set()
+            api_message = _to_api_message(message)
+            if api_message is None:
+                continue
+            if deferred_notes:
+                _prepend_context_notes(api_message, deferred_notes)
+                deferred_notes.clear()
+            prepared.append(api_message)
             continue
 
         api_message = _to_api_message(message)
         if api_message is not None:
             prepared.append(api_message)
 
-    return prepared
+    if pending_tool_ids:
+        _strip_incomplete_tool_turn(prepared)
+    if deferred_notes:
+        prepared.append(
+            {
+                "role": "user",
+                "content": "[Context note]\n" + "\n\n".join(deferred_notes),
+            }
+        )
+
+    return finalize_api_messages(prepared)

--- a/core/llm/max_tokens.py
+++ b/core/llm/max_tokens.py
@@ -1,0 +1,38 @@
+"""Resolve max_tokens for agent LLM calls (reasoning models need a budget)."""
+
+from __future__ import annotations
+
+DEFAULT_AGENT_MAX_TOKENS = 8192
+
+
+def resolve_agent_max_tokens(
+    *,
+    profile_max_tokens: int | None = None,
+    default_max_tokens: int | None = None,
+) -> int:
+    """Pick generation budget: profile override → global default → built-in default."""
+    if profile_max_tokens is not None and int(profile_max_tokens) > 0:
+        return int(profile_max_tokens)
+    if default_max_tokens is not None and int(default_max_tokens) > 0:
+        return int(default_max_tokens)
+    return DEFAULT_AGENT_MAX_TOKENS
+
+
+def profile_agent_max_tokens(model_manager: object | None, agent_slot: str) -> int | None:
+    """Read ``max_tokens`` from the active agent model config, if any."""
+    if model_manager is None:
+        return None
+    getter = getattr(model_manager, "get_agent_model_config", None)
+    if not callable(getter):
+        return None
+    cfg = getter(agent_slot)
+    if cfg is None:
+        return None
+    raw = getattr(cfg, "max_tokens", None)
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None

--- a/core/presenters/subagent_tool_text.py
+++ b/core/presenters/subagent_tool_text.py
@@ -153,6 +153,18 @@ def _format_list_subagents(raw: str) -> str:
     return "\n".join(lines)
 
 
+def extract_delegate_job_id(body: str) -> str | None:
+    """Return job_id from delegate_to_subagent JSON, if spawn succeeded."""
+    data = _loads_json((body or "").strip())
+    if not data:
+        return None
+    status = str(data.get("status") or "").strip()
+    if status not in {"spawned", "already_running"}:
+        return None
+    job_id = str(data.get("job_id") or "").strip()
+    return job_id or None
+
+
 def _format_delegate_result(raw: str) -> str:
     data = _loads_json(raw)
     if not data:

--- a/core/prompt_builder.py
+++ b/core/prompt_builder.py
@@ -54,6 +54,9 @@ When `enable_subagents` is on, delegate heavy or specialized work without blocki
 
 Types: researcher, coder, analyst, reviewer, writer, web_researcher.
 
+**When to delegate:** Only when the user explicitly asks to use a sub-agent (e.g. `/subagent-spawn`, "delegate to researcher", "запусти субагента").
+Do not auto-spawn sub-agents for ordinary questions — answer yourself or use main-agent tools unless delegation was requested.
+
 **Honesty:** Never claim a sub-agent is running unless you called `delegate_to_subagent` (or `list_subagents` shows it).
 When the user asks for status (what you are doing, open tasks, progress) — call `list_subagents()`, state only verified facts, and list concrete next steps.
 

--- a/core/skills/bundled/holix-subagents/SKILL.md
+++ b/core/skills/bundled/holix-subagents/SKILL.md
@@ -25,7 +25,8 @@ The user wants **background specialized work** without blocking the main Holix c
 - research, coding, review, writing, analysis
 - optional: hand off implementation to **external coding CLIs** (Claude Code, OpenCode, Grok Build) via an assigned `coder` sub-agent
 
-**Always prefer Holix sub-agents** over inventing separate shell scripts or manual tmux unless the user explicitly wants raw terminal control.
+Use sub-agents **only when the user asks** to delegate (`/subagent-spawn`, "запусти субагента", etc.).
+Do not auto-spawn for regular chat questions.
 
 ## Prerequisites
 

--- a/core/skills/bundled/web-researcher/SKILL.md
+++ b/core/skills/bundled/web-researcher/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: web-researcher
+description: >
+  Optional guide for web_researcher sub-agent. Use only when the user explicitly
+  asks to delegate web research (e.g. /subagent-spawn web_researcher, "запусти
+  web_researcher").
+tags:
+  - research
+  - web
+  - search
+  - subagent
+  - delegate
+user-invocable: true
+---
+
+## When to use
+
+Only when the user **explicitly** requests the `web_researcher` sub-agent
+(`/subagent-spawn web_researcher …`, "делегируй web_researcher", etc.).
+Do not auto-spawn for ordinary search questions.
+
+## How to delegate
+
+1. `delegate_to_subagent(agent_type="web_researcher", task="<full user request>")`
+2. `wait_subagent_result(job_id="<returned job_id>")` if the user wants the answer in this reply
+3. Summarize the sub-agent response for the user
+
+## Task text
+
+Include in `task`: what to find, geography/route, date (today), preferred sources, output format.

--- a/core/subagents/manager.py
+++ b/core/subagents/manager.py
@@ -410,12 +410,9 @@ class SubAgentManager:
         if handle.is_done:
             return
         event = self._ensure_done_event(handle)
-        if handle.config.process_mode == ProcessMode.ASYNC and handle.task is not None:
-            try:
-                await handle.task
-            except asyncio.CancelledError:
-                pass
-            return
+        # Always wait on done_event — never `await handle.task` here. Outer
+        # asyncio.wait_for(..., timeout=T) would cancel this waiter and, when
+        # it was tied to handle.task, kill the sub-agent prematurely.
         while not handle.is_done:
             try:
                 await asyncio.wait_for(event.wait(), timeout=0.25)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## 0.1.19 — 2026-06-25
+
+### Fixed
+- **Strict LLM providers (Groq, Mistral, LiteLLM)** — sanitize chat history before API calls: strip `agent_soul` metadata, fold extra `role:system` turns into user context notes (fixes [#41](https://github.com/javded-itres/Holix/issues/41))
+
+### Changed
+- **Version** — package `Holix` 0.1.19
+
+## 0.1.18 — 2026-06-23
+
+### Fixed
+- **Empty model responses** — pass `max_tokens` (default `8192`, env `HOLIX_AGENT_MAX_TOKENS`) in ReAct steps so reasoning models (`coder`, `smart`) return visible answers
+- **Telegram vision** — use `resolve_assistant_text` for reasoning-only vision completions
+
+### Changed
+- **Version** — package `Holix` 0.1.18
+
 ## 0.1.17 — 2026-06-21
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.1.20 — 2026-06-26
+
+### Fixed
+- **Cron jobs never running** — scheduler no longer pre-registers wrapper tasks, so `run_cron_job` is not self-skipped with “already running”
+- **Strict LLM providers (tool ordering)** — defer context notes during tool-call turns; repair orphan `tool` messages after context truncation (Groq/Mistral `role 'tool' after role 'user'`)
+
+### Changed
+- **Version** — package `Holix` 0.1.20
+
 ## 0.1.19 — 2026-06-25
 
 ### Fixed

--- a/integrations/max/tool_dispatch.py
+++ b/integrations/max/tool_dispatch.py
@@ -14,6 +14,7 @@ from core.direct_dispatch.intent import (
 from core.direct_dispatch.intent import (
     is_subagent_list_request,
 )
+from core.direct_dispatch.search_intent import extract_search_topic
 
 logger = logging.getLogger(__name__)
 
@@ -25,25 +26,7 @@ _WEB_SEARCH_CALL_RE = re.compile(
     r"web_search\s*\(\s*['\"](.+?)['\"]\s*\)",
     re.IGNORECASE | re.DOTALL,
 )
-_WEB_SEARCH_TOPIC_RES = (
-    re.compile(
-        r"найди\s+(?:в\s+)?(?:интернете?|интеренете?|сети|web)\s+"
-        r"(?:информацию\s+)?(?:по\s+)?(.+)$",
-        re.IGNORECASE | re.DOTALL,
-    ),
-    re.compile(
-        r"поиск(?:ай)?\s+(?:в\s+)?(?:интернете?|интеренете?|сети)?\s*(.+)$",
-        re.IGNORECASE | re.DOTALL,
-    ),
-    re.compile(
-        r"search(?:\s+the\s+web|\s+online)?\s+for\s+(.+)$",
-        re.IGNORECASE | re.DOTALL,
-    ),
-    re.compile(
-        r"исследуй\s+(?:тему\s+)?(.+)$",
-        re.IGNORECASE | re.DOTALL,
-    ),
-)
+
 _ANALYSIS_TRIGGER_RE = re.compile(
     r"\s+(?:"
     r"проанализируй(?:те)?|анализ(?:ируй(?:те)?)?|"
@@ -66,15 +49,7 @@ def _extract_search_topic(text: str) -> str | None:
     explicit = _WEB_SEARCH_CALL_RE.search(text)
     if explicit:
         return _clean_query(explicit.group(1))
-
-    stripped = text.strip()
-    for pattern in _WEB_SEARCH_TOPIC_RES:
-        match = pattern.search(stripped)
-        if match:
-            q = _clean_query(match.group(1))
-            if len(q) >= 3:
-                return q
-    return None
+    return extract_search_topic(text)
 
 
 def _extract_web_search_query(text: str) -> str | None:

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -240,7 +240,15 @@ class HolixTelegramBot:
                 if target != session.profile:
                     await self._switch_session_profile(session, target, bot=bot)
             if session.agent is None:
-                await self._switch_session_profile(session, session.profile, bot=bot)
+                lock = getattr(session, "_agent_init_lock", None)
+                if lock is None:
+                    lock = asyncio.Lock()
+                    session._agent_init_lock = lock
+                async with lock:
+                    if session.agent is None:
+                        await self._switch_session_profile(
+                            session, session.profile, bot=bot
+                        )
             return session
         except Exception as exc:
             if bot is not None:

--- a/integrations/telegram/event_handler.py
+++ b/integrations/telegram/event_handler.py
@@ -27,6 +27,10 @@ from core.agent_events import (
 from core.i18n.live_ui import live_plan_review_label, live_thinking_label
 from core.plan_review.review_events import PlanReviewRequestEvent
 from core.presenters.final_content import resolve_messenger_final_content
+from core.presenters.subagent_tool_text import (
+    extract_delegate_job_id,
+    format_subagent_tool_notice,
+)
 from core.security.confirmation_events import ConfirmationRequestEvent
 from core.subagents.interaction_events import SubAgentQuestionEvent
 
@@ -84,6 +88,27 @@ class TelegramEventHandler:
                 if (event.tool_name or "") == "send_chat_files" and body.startswith("Sent "):
                     buf.add_note(f"📎 {body[:240]}")
                 self._presenter.schedule_edit()
+                name = (event.tool_name or "").strip()
+                if name == "delegate_to_subagent" and body.strip():
+                    notice = format_subagent_tool_notice(name, body)
+                    if notice and "already_running" not in body:
+                        self._presenter.enqueue_outbound(
+                            self._presenter.send_notice(notice)
+                        )
+                    job_id = extract_delegate_job_id(body)
+                    if job_id and "already_running" not in body:
+                        agent = getattr(self._presenter.session, "agent", None)
+                        if agent is not None:
+                            from integrations.telegram.subagent_delivery import (
+                                schedule_telegram_subagent_delivery,
+                            )
+
+                            schedule_telegram_subagent_delivery(
+                                self._presenter._bot,
+                                self._presenter.session,
+                                job_id,
+                                agent=agent,
+                            )
 
             elif isinstance(event, ToolCallErrorEvent):
                 duration = getattr(event, "duration_ms", None)

--- a/integrations/telegram/file_handler.py
+++ b/integrations/telegram/file_handler.py
@@ -431,13 +431,24 @@ async def _chat_completion_text(
         api_key=vision.api_key,
         metadata=vision.provider_metadata,
     )
+    from core.llm.response_text import assistant_message_parts, resolve_assistant_text
+
     response = await client.chat.completions.create(
         model=model,
         messages=messages,
         max_tokens=max_tokens,
         temperature=0.2,
     )
-    text = (response.choices[0].message.content or "").strip()
+    message = response.choices[0].message
+    content, reasoning = assistant_message_parts(message)
+    finish_reason = response.choices[0].finish_reason if response.choices else None
+    text = resolve_assistant_text(
+        content=content,
+        reasoning_content=reasoning,
+        finish_reason=finish_reason,
+        model=model,
+        profile_name=profile,
+    ).strip()
     if not text:
         raise RuntimeError(f"модель {model} вернула пустой ответ")
     return text

--- a/integrations/telegram/host.py
+++ b/integrations/telegram/host.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 from cli.shared.commands.agent_commands import AgentCommands
@@ -19,6 +20,8 @@ from integrations.telegram.markdown import (
     split_telegram_html,
 )
 from integrations.telegram.typing_indicator import TypingIndicator
+
+logger = logging.getLogger(__name__)
 
 
 class TelegramHost:
@@ -102,31 +105,19 @@ class TelegramHost:
                 plain_to_telegram_html(text[:3900]),
                 parse_mode="HTML",
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "Telegram _send_plain failed (chat=%s, %d chars): %s",
+                self._session.chat_id,
+                len(text or ""),
+                exc,
+            )
 
     async def _send_split_plain(self, text: str) -> None:
         """Send arbitrary long plain-ish text split into multiple TG messages."""
-        try:
-            html = plain_to_telegram_html(text)
-            chunks = split_telegram_html(html)
-            for chunk in chunks:
-                await self._bot.send_message(
-                    self._session.chat_id,
-                    chunk,
-                    parse_mode="HTML",
-                )
-                await asyncio.sleep(0.06)
-        except Exception:
-            # fallback single truncated
-            try:
-                await self._bot.send_message(
-                    self._session.chat_id,
-                    plain_to_telegram_html(text[:3800]),
-                    parse_mode="HTML",
-                )
-            except Exception:
-                pass
+        from integrations.telegram.subagent_delivery import send_long_text
+
+        await send_long_text(self._bot, self._session.chat_id, text)
 
     def run_worker(self, work: Any, **kwargs: Any) -> None:
         if asyncio.iscoroutine(work):

--- a/integrations/telegram/session.py
+++ b/integrations/telegram/session.py
@@ -44,6 +44,7 @@ class ChatSession:
     plan_callback_tokens: dict[str, str] = field(default_factory=dict)
     process_callback_tokens: dict[str, str] = field(default_factory=dict)
     agent: Any = None
+    subagent_owner: Any = None
     profile_manual_override: bool = False
     ui_profiles: list[str] = field(default_factory=list)
     ui_sessions: list[dict] = field(default_factory=list)

--- a/integrations/telegram/subagent_delivery.py
+++ b/integrations/telegram/subagent_delivery.py
@@ -1,0 +1,108 @@
+"""Background sub-agent result delivery for Telegram chats."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from integrations.telegram.markdown import (
+    plain_to_telegram_html,
+    split_telegram_html,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def pin_subagent_agent(session: Any, agent: Any) -> None:
+    """Remember which agent instance owns spawned sub-agents for this chat."""
+    session.subagent_owner = agent
+
+
+def resolve_subagent_agent(host: Any) -> Any:
+    """Prefer the agent that spawned sub-agents; fall back to host.agent."""
+    session = getattr(host, "_session", None)
+    if session is not None:
+        owner = getattr(session, "subagent_owner", None)
+        if owner is not None:
+            return owner
+    return getattr(host, "agent", None)
+
+
+class TelegramSubagentDeliveryHost:
+    """Minimal host adapter for shared subagent_commands delivery."""
+
+    def __init__(self, bot: Any, session: Any, agent: Any) -> None:
+        self._bot = bot
+        self._session = session
+        self._agent = agent
+
+    @property
+    def agent(self) -> Any:
+        return self._agent
+
+    def transcript_write(self, content: object) -> None:
+        from cli.shared.rich_text import content_to_plain_text
+
+        text = content_to_plain_text(content)
+        if text:
+            asyncio.create_task(send_long_text(self._bot, self._session.chat_id, text))
+
+    async def _send_split_plain(self, text: str) -> None:
+        await send_long_text(self._bot, self._session.chat_id, text)
+
+
+async def send_long_text(bot: Any, chat_id: int, text: str) -> bool:
+    """Deliver long assistant text; HTML first, then plain fallback."""
+    body = (text or "").strip()
+    if not body:
+        return False
+
+    try:
+        html = plain_to_telegram_html(body)
+        chunks = split_telegram_html(html) or [html]
+        for chunk in chunks:
+            if not (chunk or "").strip():
+                continue
+            await bot.send_message(chat_id, chunk, parse_mode="HTML")
+            await asyncio.sleep(0.06)
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Telegram HTML delivery failed (chat=%s, %d chars): %s",
+            chat_id,
+            len(body),
+            exc,
+        )
+
+    try:
+        await bot.send_message(chat_id, body[:3900])
+        return True
+    except Exception as exc:
+        logger.error(
+            "Telegram plain delivery failed (chat=%s, %d chars): %s",
+            chat_id,
+            len(body),
+            exc,
+        )
+        return False
+
+
+def schedule_telegram_subagent_delivery(
+    bot: Any,
+    session: Any,
+    job_id: str,
+    *,
+    agent: Any,
+) -> None:
+    """Start background wait + push for a delegated sub-agent job."""
+    from cli.shared.commands.subagent_commands import _schedule_subagent_delivery
+
+    pin_subagent_agent(session, agent)
+    host = TelegramSubagentDeliveryHost(bot, session, agent)
+    logger.info(
+        "Scheduling Telegram sub-agent delivery (chat=%s, job=%s)",
+        getattr(session, "chat_id", "?"),
+        job_id,
+    )
+    _schedule_subagent_delivery(host, job_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "0.1.19"
+version = "0.1.20"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "0.1.18"
+version = "0.1.19"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "0.1.17"
+version = "0.1.18"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cron_global_scheduler.py
+++ b/tests/test_cron_global_scheduler.py
@@ -90,7 +90,6 @@ async def test_scheduler_does_not_self_skip_run_cron_job(
 ) -> None:
     """Regression: pre-registering the wrapper task made run_cron_job skip itself."""
     from core.cron import active_runs
-    from core.cron.runner import run_cron_job
     from core.cron.scheduler import CronScheduler
 
     past = datetime(2020, 1, 1, tzinfo=UTC).isoformat()

--- a/tests/test_cron_global_scheduler.py
+++ b/tests/test_cron_global_scheduler.py
@@ -84,6 +84,40 @@ def test_invalidate_profile_refreshes_after_save(profiles_root: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_scheduler_does_not_self_skip_run_cron_job(
+    profiles_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: pre-registering the wrapper task made run_cron_job skip itself."""
+    from core.cron import active_runs
+    from core.cron.runner import run_cron_job
+    from core.cron.scheduler import CronScheduler
+
+    past = datetime(2020, 1, 1, tzinfo=UTC).isoformat()
+    job = CronStore("alice").add(task="run now", cron_expression="*/10 * * * *")
+    store = CronStore("alice")
+    data = store.load()
+    data.jobs[0].next_run_at = past
+    store.save(data)
+
+    ran: list[str] = []
+
+    async def _fake_run(job_obj) -> None:
+        ran.append(job_obj.id)
+        active_runs.clear(job_obj.id)
+
+    monkeypatch.setattr("core.cron.scheduler.run_cron_job", _fake_run)
+
+    await CronScheduler("alice").tick()
+    for _ in range(50):
+        if ran:
+            break
+        await asyncio.sleep(0.02)
+
+    assert ran == [job.id]
+
+
+@pytest.mark.asyncio
 async def test_global_scheduler_dispatches_due_jobs_from_any_profile(
     profiles_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_llm_api_messages.py
+++ b/tests/test_llm_api_messages.py
@@ -1,0 +1,58 @@
+"""LLM API message sanitization (issue #41)."""
+
+from __future__ import annotations
+
+from core.llm.api_messages import prepare_conversation_for_llm
+from core.profile.soul import build_soul_message
+
+
+def test_prepare_strips_soul_metadata_and_extra_system_role() -> None:
+    soul = build_soul_message("default")
+    messages = [
+        soul,
+        {"role": "system", "content": "Context compressed. Summary…"},
+        {"role": "user", "content": "hello"},
+    ]
+
+    prepared = prepare_conversation_for_llm(messages)
+
+    assert len(prepared) == 2
+    assert prepared[0]["role"] == "user"
+    assert prepared[0]["content"].startswith("[Context note]")
+    assert prepared[1] == {"role": "user", "content": "hello"}
+    assert "metadata" not in prepared[0]
+    assert all(msg.get("role") != "system" for msg in prepared)
+
+
+def test_prepare_keeps_tool_turns_without_metadata() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+            ],
+            "metadata": {"step": 1},
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "ok",
+            "metadata": {"tool_name": "read_file"},
+        },
+    ]
+
+    prepared = prepare_conversation_for_llm(messages)
+
+    assert prepared == [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": messages[0]["tool_calls"],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+    ]

--- a/tests/test_llm_api_messages.py
+++ b/tests/test_llm_api_messages.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from core.llm.api_messages import prepare_conversation_for_llm
+from core.llm.api_messages import (
+    finalize_api_messages,
+    prepare_conversation_for_llm,
+    repair_api_message_sequence,
+)
 from core.profile.soul import build_soul_message
 
 
@@ -56,3 +60,57 @@ def test_prepare_keeps_tool_turns_without_metadata() -> None:
         },
         {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
     ]
+
+
+def test_prepare_defers_system_note_during_tool_turn() -> None:
+    """Regression: system→user in the middle of tool_calls broke provider ordering."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "system", "content": "Context compressed. Summary…"},
+        {"role": "tool", "tool_call_id": "call_1", "content": "hits"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    prepared = prepare_conversation_for_llm(messages)
+
+    assert prepared[0]["role"] == "assistant"
+    assert prepared[1] == {"role": "tool", "tool_call_id": "call_1", "content": "hits"}
+    assert prepared[2]["role"] == "user"
+    assert prepared[2]["content"].startswith("[Context note]")
+    assert "continue" in prepared[2]["content"]
+    assert not any(i > 0 and prepared[i]["role"] == "tool" and prepared[i - 1]["role"] == "user" for i in range(len(prepared)))
+
+
+def test_repair_tool_after_user_from_truncation() -> None:
+    messages = [
+        {"role": "user", "content": "latest question"},
+        {"role": "tool", "tool_call_id": "call_1", "content": "orphan after truncate"},
+    ]
+
+    repaired = repair_api_message_sequence(messages)
+
+    assert repaired == [
+        {
+            "role": "user",
+            "content": "latest question\n\n[Tool result]\norphan after truncate",
+        }
+    ]
+
+
+def test_finalize_drops_leading_orphan_tools() -> None:
+    messages = [
+        {"role": "tool", "tool_call_id": "call_1", "content": "dropped"},
+        {"role": "user", "content": "hi"},
+    ]
+
+    assert finalize_api_messages(messages) == [{"role": "user", "content": "hi"}]

--- a/tests/test_llm_max_tokens.py
+++ b/tests/test_llm_max_tokens.py
@@ -1,0 +1,37 @@
+"""Agent max_tokens resolution."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.llm.max_tokens import (
+    DEFAULT_AGENT_MAX_TOKENS,
+    profile_agent_max_tokens,
+    resolve_agent_max_tokens,
+)
+
+
+def test_resolve_prefers_profile_override() -> None:
+    assert resolve_agent_max_tokens(profile_max_tokens=2048, default_max_tokens=4096) == 2048
+
+
+def test_resolve_uses_global_default() -> None:
+    assert resolve_agent_max_tokens(default_max_tokens=6000) == 6000
+
+
+def test_resolve_builtin_default() -> None:
+    assert resolve_agent_max_tokens() == DEFAULT_AGENT_MAX_TOKENS
+
+
+def test_profile_agent_max_tokens_reads_model_manager() -> None:
+    manager = SimpleNamespace(
+        get_agent_model_config=lambda _slot: SimpleNamespace(max_tokens=3000),
+    )
+    assert profile_agent_max_tokens(manager, "main") == 3000
+
+
+def test_profile_agent_max_tokens_ignores_invalid() -> None:
+    manager = SimpleNamespace(
+        get_agent_model_config=lambda _slot: SimpleNamespace(max_tokens="bad"),
+    )
+    assert profile_agent_max_tokens(manager, "main") is None

--- a/tests/test_subagent_wait.py
+++ b/tests/test_subagent_wait.py
@@ -115,3 +115,34 @@ async def test_async_spawn_wait_returns_result(monkeypatch: pytest.MonkeyPatch) 
     result = await mgr.wait_for(handle.name, timeout=2.0)
     assert result.success is True
     assert result.response == "ok:summarize"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_timeout_does_not_cancel_async_subagent() -> None:
+    """Outer wait_for timeout must not kill a still-running async sub-agent."""
+    mgr = _manager()
+    cfg = SubAgentConfig(name="web_researcher", process_mode=ProcessMode.ASYNC)
+    handle = SubAgentHandle(name="web_researcher", config=cfg, status=SubAgentStatus.RUNNING)
+
+    async def slow_runner() -> None:
+        await asyncio.sleep(0.15)
+        handle.result = SubAgentResult(
+            name="web_researcher",
+            success=True,
+            response="finished after slow work",
+            duration_ms=150.0,
+        )
+        handle.status = SubAgentStatus.COMPLETED
+        mgr.notify_handle_finished("web_researcher")
+
+    handle.task = asyncio.create_task(slow_runner())
+    mgr._register_handle("web_researcher", handle)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await mgr.wait_for("web_researcher", timeout=0.05)
+
+    assert handle.task is not None
+    await asyncio.wait_for(handle.task, timeout=2.0)
+    assert handle.result is not None
+    assert handle.result.success is True
+    assert handle.result.response == "finished after slow work"

--- a/tests/test_web_research_dispatch.py
+++ b/tests/test_web_research_dispatch.py
@@ -1,0 +1,163 @@
+"""Web research intent detection and sub-agent direct dispatch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from core.direct_dispatch.search_intent import extract_search_topic, is_web_research_request
+from core.direct_dispatch.web_research import try_web_research_subagent_dispatch
+from core.subagents.manager import SubAgentManager
+from core.tools.registry import ToolRegistry
+
+
+def test_is_web_research_route_fuel_ru() -> None:
+    msg = "Проверь, работают ли заправки по трассе М-11 из Москвы в Петрозаводск сегодня"
+    assert is_web_research_request(msg)
+
+
+def test_is_web_research_natural_search() -> None:
+    msg = "Найди в интернете информацию по запуску SaaS агентов"
+    assert is_web_research_request(msg)
+    assert extract_search_topic(msg) is not None
+
+
+def test_is_not_web_research_small_talk() -> None:
+    assert not is_web_research_request("Привет")
+    assert not is_web_research_request("спасибо")
+    assert not is_web_research_request("ты тут?")
+
+
+def test_is_not_web_research_local_tasks() -> None:
+    assert not is_web_research_request("Напиши функцию на Python для сортировки")
+    assert not is_web_research_request("Создай файл config.yaml")
+    assert not is_web_research_request("/subagents")
+    assert not is_web_research_request("что делаешь?")
+
+
+def test_is_web_research_fuel_problem_variants() -> None:
+    assert is_web_research_request("проблема с бензином в Петрозаводске")
+    assert is_web_research_request("Какая ситуация с бензином на М-11")
+    assert is_web_research_request("Как обстановка на М-11 сегодня?")
+
+
+def test_is_web_research_route_planning() -> None:
+    assert is_web_research_request("По какой дороге лучше ехать из москвы в мурманск")
+    assert is_web_research_request("Какой маршрут быстрее до Петрозаводска")
+
+
+def test_is_web_research_general_questions() -> None:
+    assert is_web_research_request("Какой курс доллара сегодня")
+    assert is_web_research_request("Сколько стоит iPhone 16 в России")
+    assert is_web_research_request("Кто CEO OpenAI")
+    assert is_web_research_request("Расскажи про последний релиз Python")
+    assert is_web_research_request("What is the weather in Helsinki today?")
+
+
+def test_is_web_research_implicit_search_verbs() -> None:
+    assert is_web_research_request("Узнай когда выходит новый сезон сериала")
+    assert is_web_research_request("Проверь открыт ли сегодня аэропорт Шереметьево")
+
+
+@pytest.mark.asyncio
+async def test_try_web_research_subagent_dispatch_roundtrip() -> None:
+    parent = MagicMock()
+    parent.model = "test-model"
+    parent.config = SimpleNamespace(
+        enable_subagents=True,
+        subagent_max_concurrent=4,
+        subagent_default_process_mode="async",
+        subagent_process_timeout=30.0,
+        profile_name="default",
+        confirmation_timeout=0,
+        mcp_assignments={},
+    )
+    parent.skills = None
+    parent.memory = None
+    parent.tools = ToolRegistry(profile_name="default")
+    parent.tools.register_all()
+
+    message = MagicMock()
+    message.content = "SYNTHESIZED_WEB_ANSWER"
+    message.tool_calls = None
+    choice = MagicMock(message=message)
+    response = MagicMock(choices=[choice])
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+    parent.client = client
+    parent.subagents = SubAgentManager(parent)
+
+    notices: list[str] = []
+
+    async def capture_notice(text: str) -> None:
+        notices.append(text)
+
+    handled, body = await try_web_research_subagent_dispatch(
+        parent,
+        "Проверь статус АЗС на М-11 сегодня",
+        timeout_seconds=30.0,
+        notify=capture_notice,
+    )
+    assert handled is True
+    assert "SYNTHESIZED_WEB_ANSWER" in body
+    assert len(notices) == 1
+    assert "web_researcher" in notices[0].lower() or "Субагент" in notices[0]
+
+
+@pytest.mark.asyncio
+async def test_try_web_research_spawn_only_returns_job_id() -> None:
+    parent = MagicMock()
+    parent.model = "test-model"
+    parent.config = SimpleNamespace(
+        enable_subagents=True,
+        subagent_max_concurrent=4,
+        subagent_default_process_mode="async",
+        subagent_process_timeout=30.0,
+        profile_name="default",
+        confirmation_timeout=0,
+        mcp_assignments={},
+    )
+    parent.skills = None
+    parent.memory = None
+    parent.tools = ToolRegistry(profile_name="default")
+    parent.tools.register_all()
+    parent.subagents = SubAgentManager(parent)
+
+    handled, job_id = await try_web_research_subagent_dispatch(
+        parent,
+        "Найди в интернете последние новости про Holix AI agent",
+        wait_for_result=False,
+    )
+    assert handled is True
+    assert job_id == "web_researcher"
+    handle = parent.subagents.get_handle(job_id)
+    assert handle is not None
+    assert handle.is_running
+
+
+@pytest.mark.asyncio
+async def test_try_web_research_dispatch_murmansk_route() -> None:
+    parent = MagicMock()
+    parent.config = SimpleNamespace(
+        enable_subagents=True,
+        subagent_max_concurrent=4,
+        subagent_default_process_mode="async",
+        subagent_process_timeout=30.0,
+        profile_name="default",
+        confirmation_timeout=0,
+        mcp_assignments={},
+    )
+    parent.skills = None
+    parent.memory = None
+    parent.tools = ToolRegistry(profile_name="default")
+    parent.tools.register_all()
+    parent.subagents = SubAgentManager(parent)
+
+    handled, job_id = await try_web_research_subagent_dispatch(
+        parent,
+        "По какой дороге лучше ехать из москвы в мурманск",
+        wait_for_result=False,
+    )
+    assert handled is True
+    assert job_id == "web_researcher"

--- a/uv.lock
+++ b/uv.lock
@@ -1035,7 +1035,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "0.1.17"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- **Telegram sub-agent delivery** — results are delivered in the background so handlers are not blocked for minutes
- **`/subagents` fix** — pin `subagent_owner` per chat so spawned handles survive agent re-init
- **Web-research dispatch** — `search_intent` + `web_research` modules and `web-researcher` skill (sub-agent only on explicit user request)
- **Reliability** — agent init lock, logged Telegram send failures, tests for wait/dispatch

## Test plan
- [x] `uv run ruff check core cli api integrations tests`
- [x] `uv run pytest -m "not llm" -q` — 1389 passed locally
- [ ] CI matrix (ubuntu/windows/macos, Python 3.12–3.14)