### PR TITLE
feat(agent): extend step budget when still making progress

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,6 +27,35 @@ class Settings(BaseSettings):
 
     # Agent Configuration
     max_steps: int = 90
+    max_steps_extend_enabled: bool = Field(
+        default=True,
+        validation_alias=AliasChoices(
+            "HOLIX_MAX_STEPS_EXTEND_ENABLED",
+            "MAX_STEPS_EXTEND_ENABLED",
+        ),
+        description=(
+            "When max_steps is hit, check if agent is still making relevant progress "
+            "and grant extra steps instead of stopping immediately"
+        ),
+    )
+    max_steps_extend_by: int = Field(
+        default=30,
+        validation_alias=AliasChoices("HOLIX_MAX_STEPS_EXTEND_BY", "MAX_STEPS_EXTEND_BY"),
+        description="How many steps to add when progress check passes",
+    )
+    max_steps_max_extensions: int = Field(
+        default=3,
+        validation_alias=AliasChoices(
+            "HOLIX_MAX_STEPS_MAX_EXTENSIONS",
+            "MAX_STEPS_MAX_EXTENSIONS",
+        ),
+        description="Max number of automatic step-budget extensions per run",
+    )
+    max_steps_hard_cap: int = Field(
+        default=0,
+        validation_alias=AliasChoices("HOLIX_MAX_STEPS_HARD_CAP", "MAX_STEPS_HARD_CAP"),
+        description="Absolute max_steps after extensions (0 = base + extend_by * max_extensions)",
+    )
     agent_max_tokens: int = Field(
         default=8192,
         validation_alias=AliasChoices("HOLIX_AGENT_MAX_TOKENS", "AGENT_MAX_TOKENS"),

--- a/core/agent_events.py
+++ b/core/agent_events.py
@@ -35,6 +35,7 @@ class EventType(StrEnum):
     ASSISTANT_DELTA = "assistant_delta"
     FINAL_RESPONSE = "final_response"
     MAX_STEPS_REACHED = "max_steps_reached"
+    MAX_STEPS_EXTENDED = "max_steps_extended"
 
     # Tool execution
     TOOL_CALL_START = "tool_call_start"
@@ -235,6 +236,30 @@ class ToolCallErrorEvent(AgentEvent):
 class MaxStepsReachedEvent(AgentEvent):
     """Agent reached the configured max_steps limit."""
     max_steps: int = 90
+
+
+@dataclass
+class MaxStepsExtendedEvent(AgentEvent):
+    """Step budget was extended after a health/progress check at max_steps."""
+
+    max_steps: int = 90
+    previous_max_steps: int = 0
+    extra_steps: int = 0
+    extensions: int = 0
+    reason: str = ""
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.MAX_STEPS_EXTENDED)
+
+    def _extra_fields(self) -> dict[str, Any]:
+        return {
+            "max_steps": self.max_steps,
+            "previous_max_steps": self.previous_max_steps,
+            "extra_steps": self.extra_steps,
+            "extensions": self.extensions,
+            "reason": self.reason,
+        }
 
 
 @dataclass
@@ -741,6 +766,7 @@ def make_event(
         EventType.TOOL_CALL_ERROR: ToolCallErrorEvent,
         EventType.FINAL_RESPONSE: FinalResponseEvent,
         EventType.ERROR: ErrorEvent,
+        EventType.MAX_STEPS_EXTENDED: MaxStepsExtendedEvent,
         EventType.THINKING: ThinkingEvent,
         EventType.SKILL_CREATED: SkillCreatedEvent,
         EventType.CONTEXT_COMPRESSED: ContextCompressedEvent,
@@ -793,6 +819,11 @@ def create_compatibility_print_handler() -> EventHandler:
             print(event.content, end="", flush=True)
         elif isinstance(event, MaxStepsReachedEvent):
             print(f"Agent reached maximum steps ({event.max_steps}). Task may be too complex.")
+        elif isinstance(event, MaxStepsExtendedEvent):
+            print(
+                f"Step budget extended by {event.extra_steps} "
+                f"(now max {event.max_steps}): {event.reason or 'still working'}"
+            )
 
     return handler
 
@@ -833,6 +864,7 @@ __all__ = [
     "ToolCallResultEvent",
     "ToolCallErrorEvent",
     "MaxStepsReachedEvent",
+    "MaxStepsExtendedEvent",
     "ErrorEvent",
     "LLMCallStartedEvent",
     "LLMCallCompletedEvent",

--- a/core/agent_execution.py
+++ b/core/agent_execution.py
@@ -33,6 +33,7 @@ from core.agent_events import (
     AssistantDeltaEvent,
     ErrorEvent,
     FinalResponseEvent,
+    MaxStepsExtendedEvent,
     MaxStepsReachedEvent,
     SelfImprovementStartedEvent,
     SkillCreatedEvent,
@@ -142,6 +143,8 @@ async def run_agent_loop(
     # ------------------------------------------------------------------
     step_count = 0
     max_steps = getattr(agent_config, "max_steps", settings.max_steps)
+    base_max_steps = int(max_steps or 0)
+    step_budget_extensions = 0
     model = getattr(agent, "model", settings.model)
     temperature = getattr(agent_config, "temperature", settings.temperature)
     client: AsyncOpenAI = agent.client
@@ -162,7 +165,8 @@ async def run_agent_loop(
         conversation_id=conversation_id,
     )
 
-    while step_count < max_steps:
+    while True:
+      while step_count < max_steps:
         step_count += 1
 
         # Build API messages: system prompt + recent messages
@@ -464,13 +468,50 @@ async def run_agent_loop(
             )
             return
 
-    # Max steps reached
-    yield MaxStepsReachedEvent(
-        max_steps=max_steps,
-        conversation_id=conversation_id,
-    )
-    timeout_msg = f"Agent reached maximum steps ({max_steps}). Task may be too complex."
-    await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
+      # Inner budget exhausted — health-check before hard stop
+      from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
+
+      decision = evaluate_step_budget(
+          step_count=step_count,
+          max_steps=max_steps,
+          extensions_used=step_budget_extensions,
+          messages=messages,
+          task=str(user_input or "")[:2000],
+          policy=StepBudgetPolicy.from_config(agent_config),
+          base_max_steps=base_max_steps,
+      )
+      if decision.extend:
+          prev_max = max_steps
+          max_steps = decision.new_max_steps
+          step_budget_extensions = decision.extensions_used
+          yield MaxStepsExtendedEvent(
+              max_steps=max_steps,
+              previous_max_steps=prev_max,
+              extra_steps=decision.extra_steps,
+              extensions=step_budget_extensions,
+              reason=decision.reason,
+              conversation_id=conversation_id,
+          )
+          yield ThinkingEvent(
+              message=(
+                  f"Step budget extended by {decision.extra_steps} "
+                  f"(now max {max_steps}): still working"
+              ),
+              conversation_id=conversation_id,
+          )
+          continue
+
+      # Max steps reached (hung / no progress / extension cap)
+      yield MaxStepsReachedEvent(
+          max_steps=max_steps,
+          conversation_id=conversation_id,
+      )
+      timeout_msg = (
+          f"Agent reached maximum steps ({max_steps}). "
+          f"{decision.reason or 'Task may be too complex.'}"
+      )
+      await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
+      return
 
 
 async def _maybe_self_improve(

--- a/core/config_utils.py
+++ b/core/config_utils.py
@@ -59,6 +59,8 @@ from pathlib import Path
 
 _LOCAL_SYSTEM_KEYS: frozenset[str] = frozenset({
     "model", "base_url", "api_key", "temperature", "max_steps",
+    "max_steps_extend_enabled", "max_steps_extend_by",
+    "max_steps_max_extensions", "max_steps_hard_cap",
     "providers", "agent_models", "default_provider",
     "auto_allow_threshold", "non_interactive", "confirmation_timeout",
     "plan_review_enabled", "plan_review_timeout",

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -59,6 +59,8 @@ def prepare_initial_state(
         "relevant_strategies": [],
         "step_count": 0,
         "max_steps": max_steps,
+        "base_max_steps": max_steps,
+        "step_budget_extensions": 0,
         "max_steps_per_plan_step": max_per_step,
         "execution_mode": execution_mode,
         "is_final": False,

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -474,6 +474,14 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
                 max_tokens=max_tokens,
                 tool_choice=tool_choice,
             )
+        from core.runtime.step_budget import maybe_extend_for_graph_result
+
+        result = maybe_extend_for_graph_result(
+            state,
+            result,
+            agent=agent,
+            task=str(state.get("user_input") or ""),
+        )
         return _merge_state_patch(result, messages_patch)
 
     except LLMStepTimeoutError as exc:

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -23,7 +23,6 @@ from core.agent_events import (
     ToolCallStartEvent,
 )
 from core.graph.action_honesty import (
-    denies_visible_workspace,
     has_successful_workspace_listing,
     honesty_refusal_update,
     honesty_retry_update,

--- a/core/graph/state.py
+++ b/core/graph/state.py
@@ -38,6 +38,8 @@ class HolixGraphState(TypedDict, total=False):
     # Execution control
     step_count: int
     max_steps: int
+    base_max_steps: int                  # Original max_steps before auto-extensions
+    step_budget_extensions: int          # How many times max_steps was auto-extended
     max_steps_per_plan_step: int         # Max ReAct iterations per plan step
     execution_mode: str                  # "react" | "plan_and_execute" | "hybrid"
     is_final: bool                       # True when final response generated

--- a/core/runtime/step_budget.py
+++ b/core/runtime/step_budget.py
@@ -1,0 +1,522 @@
+"""Step-budget health check and extension for main agent + sub-agents.
+
+When a run reaches ``max_steps``, Holix does **not** always stop. It evaluates
+whether the agent is still making relevant progress:
+
+* **working + relevant** → grant extra steps (bounded by extension count / hard cap)
+* **hung / looping / no signal** → stop (caller finalizes / fails the job)
+
+This mirrors wait-timeout extension for sub-agents (activity-based), but applies
+to the *reasoning step* budget.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Defaults (overridable via Settings / agent config)
+DEFAULT_EXTEND_BY = 30
+DEFAULT_MAX_EXTENSIONS = 3
+DEFAULT_HARD_CAP = 0  # 0 → derive from base max_steps + extend_by * max_extensions
+DEFAULT_LOOKBACK = 6
+
+_ERROR_MARKERS = (
+    "error",
+    "exception",
+    "traceback",
+    "failed",
+    "timeout",
+    "timed out",
+    "permission denied",
+    "not found",
+    "invalid",
+    "❌",
+    "⛔",
+)
+
+_PROGRESS_MARKERS = (
+    "ok",
+    "done",
+    "success",
+    "created",
+    "updated",
+    "written",
+    "saved",
+    "found",
+    "result",
+    "completed",
+    "✅",
+)
+
+
+@dataclass(slots=True)
+class StepBudgetPolicy:
+    """Tunable limits for step-budget extension."""
+
+    enabled: bool = True
+    extend_by: int = DEFAULT_EXTEND_BY
+    max_extensions: int = DEFAULT_MAX_EXTENSIONS
+    hard_cap: int = DEFAULT_HARD_CAP  # absolute max_steps after extensions
+    lookback: int = DEFAULT_LOOKBACK
+
+    @classmethod
+    def from_config(cls, cfg: Any | None = None) -> StepBudgetPolicy:
+        if cfg is None:
+            return cls()
+        enabled = getattr(cfg, "max_steps_extend_enabled", True)
+        if enabled is None:
+            enabled = True
+        return cls(
+            enabled=bool(enabled),
+            extend_by=max(1, int(getattr(cfg, "max_steps_extend_by", DEFAULT_EXTEND_BY) or DEFAULT_EXTEND_BY)),
+            max_extensions=max(
+                0,
+                int(
+                    getattr(cfg, "max_steps_max_extensions", DEFAULT_MAX_EXTENSIONS)
+                    or DEFAULT_MAX_EXTENSIONS
+                ),
+            ),
+            hard_cap=max(0, int(getattr(cfg, "max_steps_hard_cap", DEFAULT_HARD_CAP) or 0)),
+            lookback=max(3, int(getattr(cfg, "max_steps_lookback", DEFAULT_LOOKBACK) or DEFAULT_LOOKBACK)),
+        )
+
+
+@dataclass(slots=True)
+class StepBudgetDecision:
+    """Outcome of a max-steps health check."""
+
+    extend: bool
+    reason: str
+    status: str  # working | hung | stop | disabled | not_at_limit
+    extra_steps: int = 0
+    new_max_steps: int = 0
+    extensions_used: int = 0
+    signals: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def should_stop(self) -> bool:
+        return not self.extend
+
+
+def _norm_args(raw: Any) -> str:
+    if raw is None:
+        return ""
+    if isinstance(raw, (dict, list)):
+        try:
+            import json
+
+            return json.dumps(raw, sort_keys=True, ensure_ascii=False)[:400]
+        except Exception:
+            return str(raw)[:400]
+    text = str(raw).strip()
+    return text[:400]
+
+
+def _tool_signature(name: str, arguments: Any = None) -> str:
+    return f"{(name or '').strip().lower()}::{_norm_args(arguments)}"
+
+
+def _looks_like_error(text: str) -> bool:
+    low = (text or "").strip().lower()
+    if not low:
+        return True
+    if low.startswith("❌") or low.startswith("⛔"):
+        return True
+    return any(m in low for m in _ERROR_MARKERS)
+
+
+def _looks_like_progress(text: str) -> bool:
+    low = (text or "").strip().lower()
+    if len(low) < 8:
+        return False
+    if _looks_like_error(low):
+        return False
+    if any(m in low for m in _PROGRESS_MARKERS):
+        return True
+    # Non-trivial payload without error markers counts as progress
+    return len(low) >= 40
+
+
+def _token_overlap(a: str, b: str) -> float:
+    """Jaccard-ish overlap on alphanumeric tokens (relevance proxy)."""
+    def toks(s: str) -> set[str]:
+        return {t for t in re.findall(r"[a-zA-Zа-яА-Я0-9_]{3,}", (s or "").lower()) if t}
+
+    ta, tb = toks(a), toks(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / max(1, len(ta | tb))
+
+
+def collect_tool_traces(
+    messages: list[dict[str, Any]] | None = None,
+    *,
+    tool_calls_log: list[dict[str, Any]] | None = None,
+    tool_results: list[dict[str, Any]] | None = None,
+    lookback: int = DEFAULT_LOOKBACK,
+) -> list[dict[str, Any]]:
+    """Build recent tool traces from messages and/or explicit logs."""
+    traces: list[dict[str, Any]] = []
+
+    if tool_calls_log:
+        for item in tool_calls_log[-lookback:]:
+            name = str(item.get("name") or item.get("tool_name") or "")
+            args = item.get("arguments") or item.get("args") or ""
+            result = str(item.get("result") or item.get("content") or item.get("details") or "")
+            traces.append(
+                {
+                    "name": name,
+                    "arguments": args,
+                    "signature": _tool_signature(name, args),
+                    "result": result,
+                    "is_error": _looks_like_error(result) if result else False,
+                }
+            )
+
+    if tool_results:
+        for item in tool_results[-lookback:]:
+            name = str(item.get("name") or item.get("tool_name") or "")
+            content = str(item.get("content") or item.get("result") or "")
+            args = item.get("arguments") or ""
+            traces.append(
+                {
+                    "name": name,
+                    "arguments": args,
+                    "signature": _tool_signature(name, args),
+                    "result": content,
+                    "is_error": bool(item.get("is_error")) or _looks_like_error(content),
+                }
+            )
+
+    # Reconstruct from conversation messages (assistant tool_calls + tool results)
+    if messages and not traces:
+        pending: dict[str, dict[str, Any]] = {}
+        for msg in messages:
+            role = msg.get("role")
+            if role == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    fn = tc.get("function") if isinstance(tc, dict) else None
+                    if not isinstance(fn, dict):
+                        fn = {}
+                    tid = str(tc.get("id") or "")
+                    name = str(fn.get("name") or tc.get("name") or "")
+                    args = fn.get("arguments") if fn else tc.get("arguments")
+                    pending[tid] = {
+                        "name": name,
+                        "arguments": args,
+                        "signature": _tool_signature(name, args),
+                        "result": "",
+                        "is_error": False,
+                    }
+            elif role == "tool":
+                tid = str(msg.get("tool_call_id") or "")
+                content = str(msg.get("content") or "")
+                entry = pending.pop(tid, None) or {
+                    "name": str(msg.get("name") or ""),
+                    "arguments": "",
+                    "signature": _tool_signature(str(msg.get("name") or ""), ""),
+                }
+                entry["result"] = content
+                entry["is_error"] = _looks_like_error(content)
+                traces.append(entry)
+        # leftover unexecuted calls still count as intent to work
+        for entry in pending.values():
+            traces.append(entry)
+
+    return traces[-lookback:]
+
+
+def evaluate_step_budget(
+    *,
+    step_count: int,
+    max_steps: int,
+    extensions_used: int = 0,
+    pending_tool_calls: list[Any] | None = None,
+    messages: list[dict[str, Any]] | None = None,
+    tool_calls_log: list[dict[str, Any]] | None = None,
+    tool_results: list[dict[str, Any]] | None = None,
+    task: str = "",
+    policy: StepBudgetPolicy | None = None,
+    base_max_steps: int | None = None,
+) -> StepBudgetDecision:
+    """Decide whether to extend the step budget at/after the limit.
+
+    Call when ``step_count >= max_steps`` (or about to stop for that reason).
+    """
+    pol = policy or StepBudgetPolicy()
+    sc = int(step_count or 0)
+    ms = int(max_steps or 0)
+    ext_used = max(0, int(extensions_used or 0))
+    base = int(base_max_steps or ms)
+
+    if not pol.enabled:
+        return StepBudgetDecision(
+            extend=False,
+            reason="step budget extension disabled",
+            status="disabled",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+        )
+
+    if ms <= 0 or sc < ms:
+        return StepBudgetDecision(
+            extend=False,
+            reason="not at max_steps",
+            status="not_at_limit",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+        )
+
+    if ext_used >= pol.max_extensions:
+        return StepBudgetDecision(
+            extend=False,
+            reason=f"extension limit reached ({ext_used}/{pol.max_extensions})",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals={"extensions_used": ext_used},
+        )
+
+    hard = pol.hard_cap
+    if hard <= 0:
+        hard = base + pol.extend_by * pol.max_extensions
+    hard = max(ms, hard)
+
+    if ms >= hard:
+        return StepBudgetDecision(
+            extend=False,
+            reason=f"hard cap reached ({ms}>={hard})",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals={"hard_cap": hard},
+        )
+
+    pending = list(pending_tool_calls or [])
+    traces = collect_tool_traces(
+        messages,
+        tool_calls_log=tool_calls_log,
+        tool_results=tool_results,
+        lookback=pol.lookback,
+    )
+
+    sigs = [t.get("signature") or "" for t in traces if t.get("signature")]
+    unique_sigs = {s for s in sigs if s}
+    error_count = sum(1 for t in traces if t.get("is_error"))
+    progress_count = sum(
+        1 for t in traces if _looks_like_progress(str(t.get("result") or ""))
+    )
+    recent_names = " ".join(str(t.get("name") or "") for t in traces)
+    recent_results = " ".join(str(t.get("result") or "")[:200] for t in traces)
+    relevance = max(
+        _token_overlap(task, recent_names),
+        _token_overlap(task, recent_results),
+    ) if task else 0.0
+
+    # Detect tight loops: same signature thrice in a row (or 3+ of last 4)
+    loop_hit = False
+    if len(sigs) >= 3:
+        if sigs[-1] and sigs[-1] == sigs[-2] == sigs[-3]:
+            loop_hit = True
+        elif len(sigs) >= 4:
+            last4 = sigs[-4:]
+            if last4 and last4.count(last4[-1]) >= 3:
+                loop_hit = True
+
+    signals = {
+        "pending_tools": len(pending),
+        "traces": len(traces),
+        "unique_sigs": len(unique_sigs),
+        "error_count": error_count,
+        "progress_count": progress_count,
+        "loop_hit": loop_hit,
+        "relevance": round(relevance, 3),
+        "extensions_used": ext_used,
+        "hard_cap": hard,
+    }
+
+    # --- Hung: repeated identical work or pure error thrash ---
+    if loop_hit:
+        return StepBudgetDecision(
+            extend=False,
+            reason="hung: repeated identical tool calls (loop)",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    if len(traces) >= 3 and error_count == len(traces) and progress_count == 0:
+        return StepBudgetDecision(
+            extend=False,
+            reason="hung: recent tools failed without progress",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    # --- Working: still has tools to run or recent successful relevant work ---
+    working = False
+    if pending:
+        working = True
+    elif progress_count > 0 and (len(unique_sigs) >= 2 or progress_count >= 2):
+        working = True
+    elif traces and progress_count > 0 and error_count < len(traces):
+        working = True
+
+    if not working:
+        return StepBudgetDecision(
+            extend=False,
+            reason="no active work signal at max_steps (stop)",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    # Relevance: require weak signal when we have a task string and tool names
+    if task and recent_names and relevance < 0.02 and progress_count == 0:
+        return StepBudgetDecision(
+            extend=False,
+            reason="work not relevant to the task",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    extra = min(pol.extend_by, hard - ms)
+    if extra <= 0:
+        return StepBudgetDecision(
+            extend=False,
+            reason=f"no room under hard cap ({ms}/{hard})",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    new_max = ms + extra
+    return StepBudgetDecision(
+        extend=True,
+        reason=(
+            f"working with relevant progress; +{extra} steps "
+            f"({sc}/{ms} → max {new_max})"
+        ),
+        status="working",
+        extra_steps=extra,
+        new_max_steps=new_max,
+        extensions_used=ext_used + 1,
+        signals=signals,
+    )
+
+
+def policy_from_agent(agent: Any | None) -> StepBudgetPolicy:
+    cfg = getattr(agent, "config", None) if agent is not None else None
+    return StepBudgetPolicy.from_config(cfg)
+
+
+def apply_decision_to_state(
+    state: dict[str, Any],
+    decision: StepBudgetDecision,
+) -> dict[str, Any]:
+    """Return partial graph state updates when extending."""
+    if not decision.extend:
+        return {}
+    return {
+        "max_steps": int(decision.new_max_steps),
+        "step_budget_extensions": int(decision.extensions_used),
+    }
+
+
+def maybe_extend_for_graph_result(
+    state: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    agent: Any | None = None,
+    task: str = "",
+) -> dict[str, Any]:
+    """If result is at max_steps with pending tools, maybe bump max_steps on result."""
+    step_count = int(result.get("step_count", state.get("step_count", 0)) or 0)
+    max_steps = int(result.get("max_steps", state.get("max_steps", 0)) or 0)
+    if max_steps <= 0:
+        max_steps = int(state.get("max_steps", 0) or 0)
+    if step_count < max_steps:
+        return result
+    if result.get("is_final"):
+        return result
+
+    pending = result.get("tool_calls") or state.get("tool_calls") or []
+    messages = result.get("messages") or state.get("messages") or []
+    tool_results = result.get("tool_results") or state.get("tool_results") or []
+    extensions_used = int(
+        result.get("step_budget_extensions", state.get("step_budget_extensions", 0)) or 0
+    )
+    base_max = int(state.get("base_max_steps") or state.get("max_steps") or max_steps)
+    policy = policy_from_agent(agent)
+    decision = evaluate_step_budget(
+        step_count=step_count,
+        max_steps=max_steps,
+        extensions_used=extensions_used,
+        pending_tool_calls=pending,
+        messages=messages if isinstance(messages, list) else None,
+        tool_results=tool_results if isinstance(tool_results, list) else None,
+        task=task or str(state.get("user_input") or ""),
+        policy=policy,
+        base_max_steps=base_max,
+    )
+    if not decision.extend:
+        logger.info(
+            "step budget stop at %s/%s: %s (%s)",
+            step_count,
+            max_steps,
+            decision.status,
+            decision.reason,
+        )
+        return result
+
+    logger.info(
+        "step budget extended: %s → %s (ext=%s) %s",
+        max_steps,
+        decision.new_max_steps,
+        decision.extensions_used,
+        decision.reason,
+    )
+    out = dict(result)
+    out["max_steps"] = decision.new_max_steps
+    out["step_budget_extensions"] = decision.extensions_used
+    if "base_max_steps" not in state and "base_max_steps" not in out:
+        out["base_max_steps"] = base_max
+    # Notify UIs
+    if agent is not None and hasattr(agent, "emit"):
+        try:
+            from core.agent_events import MaxStepsExtendedEvent, ThinkingEvent
+
+            agent.emit(
+                MaxStepsExtendedEvent(
+                    max_steps=decision.new_max_steps,
+                    previous_max_steps=max_steps,
+                    extra_steps=decision.extra_steps,
+                    extensions=decision.extensions_used,
+                    reason=decision.reason,
+                    conversation_id=str(state.get("conversation_id") or ""),
+                )
+            )
+            agent.emit(
+                ThinkingEvent(
+                    message=(
+                        f"Step budget extended by {decision.extra_steps} "
+                        f"(now max {decision.new_max_steps}): still working"
+                    ),
+                    conversation_id=str(state.get("conversation_id") or ""),
+                )
+            )
+        except Exception:
+            logger.debug("failed to emit step budget events", exc_info=True)
+    return out

--- a/core/subagents/async_runner.py
+++ b/core/subagents/async_runner.py
@@ -94,7 +94,9 @@ class AsyncSubAgentRunner:
         start_time = time.monotonic()
         tool_calls_made: list[dict[str, Any]] = []
         steps_taken = 0
-        max_steps = config.max_steps
+        max_steps = int(config.max_steps or 0)
+        base_max_steps = max_steps
+        step_budget_extensions = 0
 
         # Build client (inherit from parent or use config override)
         model = config.model or self._parent.model
@@ -163,164 +165,207 @@ class AsyncSubAgentRunner:
         # ReAct loop
         tokens_used = 0
         try:
-            while steps_taken < max_steps:
-                steps_taken += 1
+            from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
+
+            step_policy = StepBudgetPolicy.from_config(parent_cfg)
+
+            while True:
+                while steps_taken < max_steps:
+                    steps_taken += 1
+                    handle.max_steps = max_steps
+                    handle.record_activity(
+                        "step",
+                        f"Reasoning step {steps_taken}/{max_steps}",
+                        steps_taken=steps_taken,
+                    )
+                    self._notify_progress(config.name)
+
+                    # Set up timeout
+                    try:
+                        response = await asyncio.wait_for(
+                            client.chat.completions.create(
+                                model=model,
+                                messages=messages,
+                                tools=tools_schemas if tools_schemas else None,
+                                tool_choice="auto" if tools_schemas else None,
+                                temperature=config.temperature,
+                            ),
+                            timeout=config.timeout,
+                        )
+                    except TimeoutError:
+                        handle.status = SubAgentStatus.TIMED_OUT
+                        handle.record_activity(
+                            "status",
+                            f"Timed out after {config.timeout}s",
+                            steps_taken=steps_taken,
+                        )
+                        handle.result = SubAgentResult(
+                            name=config.name,
+                            success=False,
+                            error=f"Sub-agent timed out after {config.timeout}s",
+                            duration_ms=(time.monotonic() - start_time) * 1000,
+                            steps_taken=steps_taken,
+                            tool_calls=tool_calls_made,
+                            tokens_used=tokens_used,
+                        )
+                        return handle.result
+
+                    message = response.choices[0].message
+                    try:
+                        from core.llm.usage import (
+                            completion_text_from_message,
+                            resolve_usage,
+                        )
+
+                        usage = resolve_usage(
+                            response,
+                            messages=messages,
+                            completion_text=completion_text_from_message(message),
+                            model=model,
+                        )
+                        tokens_used += int(usage.get("total_tokens") or 0)
+                    except Exception:
+                        logger.debug("Sub-agent token accounting failed", exc_info=True)
+
+                    if message.tool_calls:
+                        # Execute tool calls
+                        msg_dict = {
+                            "role": "assistant",
+                            "content": message.content or "",
+                            "tool_calls": [
+                                {
+                                    "id": tc.id,
+                                    "type": tc.type,
+                                    "function": {
+                                        "name": tc.function.name,
+                                        "arguments": tc.function.arguments,
+                                    },
+                                }
+                                for tc in message.tool_calls
+                            ],
+                        }
+                        messages.append(msg_dict)
+
+                        for tc in message.tool_calls:
+                            tool_name = tc.function.name
+                            tool_calls_made.append({
+                                "name": tool_name,
+                                "arguments": tc.function.arguments,
+                            })
+                            handle.record_activity(
+                                "tool_start",
+                                f"Calling {tool_name}",
+                                tool_name=tool_name,
+                                details=(tc.function.arguments or "")[:300],
+                                steps_taken=steps_taken,
+                            )
+                            self._notify_progress(config.name)
+                            result = await self._execute_tool(tc, config)
+                            preview = (result or "").strip()
+                            if len(preview) > 240:
+                                preview = preview[:239] + "…"
+                            tool_calls_made[-1]["result"] = result
+                            handle.record_activity(
+                                "tool_result",
+                                f"{tool_name} finished",
+                                tool_name=tool_name,
+                                details=preview,
+                                steps_taken=steps_taken,
+                            )
+                            self._notify_progress(config.name)
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tc.id,
+                                "content": result,
+                            })
+                    else:
+                        # Final response
+                        final_response = message.content or "No response"
+                        messages.append({"role": "assistant", "content": final_response})
+
+                        duration_ms = (time.monotonic() - start_time) * 1000
+                        handle.status = SubAgentStatus.COMPLETED
+                        handle.record_activity(
+                            "status",
+                            "Completed",
+                            steps_taken=steps_taken,
+                        )
+                        handle.result = SubAgentResult(
+                            name=config.name,
+                            success=True,
+                            response=final_response,
+                            duration_ms=duration_ms,
+                            steps_taken=steps_taken,
+                            tool_calls=tool_calls_made,
+                            tokens_used=tokens_used,
+                        )
+                        logger.info(
+                            "Sub-agent '%s' completed (steps=%d, tools=%d, %.0fms)",
+                            config.name,
+                            steps_taken,
+                            len(tool_calls_made),
+                            duration_ms,
+                        )
+                        return handle.result
+
+                # Max steps: health-check — extend if still working with relevant progress
+                decision = evaluate_step_budget(
+                    step_count=steps_taken,
+                    max_steps=max_steps,
+                    extensions_used=step_budget_extensions,
+                    messages=messages,
+                    tool_calls_log=tool_calls_made,
+                    task=task,
+                    policy=step_policy,
+                    base_max_steps=base_max_steps,
+                )
+                if decision.extend:
+                    prev = max_steps
+                    max_steps = decision.new_max_steps
+                    step_budget_extensions = decision.extensions_used
+                    handle.max_steps = max_steps
+                    handle.record_activity(
+                        "step_budget_extended",
+                        (
+                            f"Step budget +{decision.extra_steps} "
+                            f"({prev} → {max_steps}): {decision.reason}"
+                        ),
+                        steps_taken=steps_taken,
+                    )
+                    self._notify_progress(config.name)
+                    logger.info(
+                        "Sub-agent '%s' step budget extended %s → %s (ext=%s)",
+                        config.name,
+                        prev,
+                        max_steps,
+                        step_budget_extensions,
+                    )
+                    continue
+
+                duration_ms = (time.monotonic() - start_time) * 1000
+                handle.status = SubAgentStatus.FAILED
                 handle.record_activity(
-                    "step",
-                    f"Reasoning step {steps_taken}/{max_steps}",
+                    "status",
+                    f"Max steps ({max_steps}) reached: {decision.reason}",
                     steps_taken=steps_taken,
                 )
-                self._notify_progress(config.name)
-
-                # Set up timeout
-                try:
-                    response = await asyncio.wait_for(
-                        client.chat.completions.create(
-                            model=model,
-                            messages=messages,
-                            tools=tools_schemas if tools_schemas else None,
-                            tool_choice="auto" if tools_schemas else None,
-                            temperature=config.temperature,
-                        ),
-                        timeout=config.timeout,
-                    )
-                except TimeoutError:
-                    handle.status = SubAgentStatus.TIMED_OUT
-                    handle.record_activity(
-                        "status",
-                        f"Timed out after {config.timeout}s",
-                        steps_taken=steps_taken,
-                    )
-                    handle.result = SubAgentResult(
-                        name=config.name,
-                        success=False,
-                        error=f"Sub-agent timed out after {config.timeout}s",
-                        duration_ms=(time.monotonic() - start_time) * 1000,
-                        steps_taken=steps_taken,
-                        tool_calls=tool_calls_made,
-                        tokens_used=tokens_used,
-                    )
-                    return handle.result
-
-                message = response.choices[0].message
-                try:
-                    from core.llm.usage import (
-                        completion_text_from_message,
-                        resolve_usage,
-                    )
-
-                    usage = resolve_usage(
-                        response,
-                        messages=messages,
-                        completion_text=completion_text_from_message(message),
-                        model=model,
-                    )
-                    tokens_used += int(usage.get("total_tokens") or 0)
-                except Exception:
-                    logger.debug("Sub-agent token accounting failed", exc_info=True)
-
-                if message.tool_calls:
-                    # Execute tool calls
-                    msg_dict = {
-                        "role": "assistant",
-                        "content": message.content or "",
-                        "tool_calls": [
-                            {
-                                "id": tc.id,
-                                "type": tc.type,
-                                "function": {
-                                    "name": tc.function.name,
-                                    "arguments": tc.function.arguments,
-                                },
-                            }
-                            for tc in message.tool_calls
-                        ],
-                    }
-                    messages.append(msg_dict)
-
-                    for tc in message.tool_calls:
-                        tool_name = tc.function.name
-                        tool_calls_made.append({
-                            "name": tool_name,
-                            "arguments": tc.function.arguments,
-                        })
-                        handle.record_activity(
-                            "tool_start",
-                            f"Calling {tool_name}",
-                            tool_name=tool_name,
-                            details=(tc.function.arguments or "")[:300],
-                            steps_taken=steps_taken,
-                        )
-                        self._notify_progress(config.name)
-                        result = await self._execute_tool(tc, config)
-                        preview = (result or "").strip()
-                        if len(preview) > 240:
-                            preview = preview[:239] + "…"
-                        handle.record_activity(
-                            "tool_result",
-                            f"{tool_name} finished",
-                            tool_name=tool_name,
-                            details=preview,
-                            steps_taken=steps_taken,
-                        )
-                        self._notify_progress(config.name)
-                        messages.append({
-                            "role": "tool",
-                            "tool_call_id": tc.id,
-                            "content": result,
-                        })
-                else:
-                    # Final response
-                    final_response = message.content or "No response"
-                    messages.append({"role": "assistant", "content": final_response})
-
-                    duration_ms = (time.monotonic() - start_time) * 1000
-                    handle.status = SubAgentStatus.COMPLETED
-                    handle.record_activity(
-                        "status",
-                        "Completed",
-                        steps_taken=steps_taken,
-                    )
-                    handle.result = SubAgentResult(
-                        name=config.name,
-                        success=True,
-                        response=final_response,
-                        duration_ms=duration_ms,
-                        steps_taken=steps_taken,
-                        tool_calls=tool_calls_made,
-                        tokens_used=tokens_used,
-                    )
-                    logger.info(
-                        "Sub-agent '%s' completed (steps=%d, tools=%d, %.0fms)",
-                        config.name,
-                        steps_taken,
-                        len(tool_calls_made),
-                        duration_ms,
-                    )
-                    return handle.result
-
-            # Max steps reached
-            duration_ms = (time.monotonic() - start_time) * 1000
-            handle.status = SubAgentStatus.FAILED
-            handle.record_activity(
-                "status",
-                f"Max steps ({max_steps}) reached",
-                steps_taken=steps_taken,
-            )
-            handle.result = SubAgentResult(
-                name=config.name,
-                success=False,
-                response="Sub-agent reached maximum steps",
-                error=f"Max steps ({max_steps}) reached",
-                duration_ms=duration_ms,
-                steps_taken=steps_taken,
-                tool_calls=tool_calls_made,
-                        tokens_used=tokens_used,
-            )
-            logger.warning(
-                "Sub-agent '%s' hit max steps (%d)", config.name, max_steps
-            )
-            return handle.result
+                handle.result = SubAgentResult(
+                    name=config.name,
+                    success=False,
+                    response="Sub-agent reached maximum steps",
+                    error=f"Max steps ({max_steps}) reached: {decision.reason}",
+                    duration_ms=duration_ms,
+                    steps_taken=steps_taken,
+                    tool_calls=tool_calls_made,
+                    tokens_used=tokens_used,
+                )
+                logger.warning(
+                    "Sub-agent '%s' hit max steps (%d): %s",
+                    config.name,
+                    max_steps,
+                    decision.reason,
+                )
+                return handle.result
 
         except asyncio.CancelledError:
             handle.status = SubAgentStatus.CANCELLED

--- a/core/subagents/process.py
+++ b/core/subagents/process.py
@@ -294,10 +294,22 @@ def run_sub_agent_in_process(
     tool_calls_made: list[dict[str, Any]] = []
     steps_taken = 0
     tokens_used = 0
-    max_steps = config.max_steps
+    max_steps = int(config.max_steps or 0)
+    base_max_steps = max_steps
+    step_budget_extensions = 0
     result = None
 
     try:
+        from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
+
+        # Process workers may not have full parent Settings; use env-backed defaults.
+        try:
+            from config import settings as _settings
+
+            step_policy = StepBudgetPolicy.from_config(_settings)
+        except Exception:
+            step_policy = StepBudgetPolicy()
+
         # Start heartbeat in background
         heartbeat_stop = multiprocessing.Event()
 
@@ -319,179 +331,208 @@ def run_sub_agent_in_process(
         hb_thread = threading.Thread(target=heartbeat_worker, daemon=True)
         hb_thread.start()
 
-        while steps_taken < max_steps:
-            # Check for cancel signal
-            try:
-                while not input_queue.empty():
-                    data = input_queue.get_nowait()
-                    msg = AgentMessage.deserialize(data)
-                    if msg.msg_type == "cancel":
-                        result = SubAgentResult(
-                            name=config.name,
-                            success=False,
-                            error="Cancelled by parent",
-                            duration_ms=(time.monotonic() - start_time) * 1000,
+        while True:
+            while steps_taken < max_steps:
+                # Check for cancel signal
+                try:
+                    while not input_queue.empty():
+                        data = input_queue.get_nowait()
+                        msg = AgentMessage.deserialize(data)
+                        if msg.msg_type == "cancel":
+                            result = SubAgentResult(
+                                name=config.name,
+                                success=False,
+                                error="Cancelled by parent",
+                                duration_ms=(time.monotonic() - start_time) * 1000,
+                                steps_taken=steps_taken,
+                                tool_calls=tool_calls_made,
+                                tokens_used=tokens_used,
+                            )
+                            _send_result(output_queue, config.name, result)
+                            heartbeat_stop.set()
+                            return
+                except Exception:
+                    pass
+
+                steps_taken += 1
+                _send_progress(
+                    output_queue,
+                    config.name,
+                    kind="step",
+                    message=f"Reasoning step {steps_taken}/{max_steps}",
+                    steps_taken=steps_taken,
+                )
+
+                # LLM call with timeout
+                try:
+                    response = loop.run_until_complete(
+                        _asyncio.wait_for(
+                            client.chat.completions.create(
+                                model=model,
+                                messages=messages,
+                                tools=tools_schemas if tools_schemas else None,
+                                tool_choice="auto" if tools_schemas else None,
+                                temperature=config.temperature,
+                            ),
+                            timeout=config.timeout,
+                        )
+                    )
+                except TimeoutError:
+                    result = SubAgentResult(
+                        name=config.name,
+                        success=False,
+                        error=f"Timed out after {config.timeout}s",
+                        duration_ms=(time.monotonic() - start_time) * 1000,
+                        steps_taken=steps_taken,
+                        tool_calls=tool_calls_made,
+                        tokens_used=tokens_used,
+                    )
+                    _send_result(output_queue, config.name, result)
+                    heartbeat_stop.set()
+                    return
+
+                message = response.choices[0].message
+                try:
+                    from core.llm.usage import (
+                        completion_text_from_message,
+                        resolve_usage,
+                    )
+
+                    usage = resolve_usage(
+                        response,
+                        messages=messages,
+                        completion_text=completion_text_from_message(message),
+                        model=model,
+                    )
+                    tokens_used += int(usage.get("total_tokens") or 0)
+                except Exception:
+                    pass
+
+                if message.tool_calls:
+                    msg_dict = {
+                        "role": "assistant",
+                        "content": message.content or "",
+                        "tool_calls": [
+                            {
+                                "id": tc.id,
+                                "type": tc.type,
+                                "function": {
+                                    "name": tc.function.name,
+                                    "arguments": tc.function.arguments,
+                                },
+                            }
+                            for tc in message.tool_calls
+                        ],
+                    }
+                    messages.append(msg_dict)
+
+                    for tc in message.tool_calls:
+                        tool_name = tc.function.name
+                        tool_calls_made.append({
+                            "name": tool_name,
+                            "arguments": tc.function.arguments,
+                        })
+                        _send_progress(
+                            output_queue,
+                            config.name,
+                            kind="tool_start",
+                            message=f"Calling {tool_name}",
                             steps_taken=steps_taken,
-                            tool_calls=tool_calls_made,
-                            tokens_used=tokens_used,
+                            tool_name=tool_name,
+                            details=(tc.function.arguments or "")[:300],
                         )
-                        _send_result(output_queue, config.name, result)
-                        heartbeat_stop.set()
-                        return
-            except Exception:
-                pass
 
-            steps_taken += 1
-            _send_progress(
-                output_queue,
-                config.name,
-                kind="step",
-                message=f"Reasoning step {steps_taken}/{max_steps}",
-                steps_taken=steps_taken,
+                        try:
+                            tool_result = _execute_tool_guarded(
+                                registry,
+                                tc,
+                                config=config,
+                                profile_name=profile_name,
+                                output_queue=output_queue,
+                                input_queue=input_queue,
+                                auto_allow_threshold=auto_allow_threshold,
+                                confirmation_timeout=confirmation_timeout,
+                                interactive=interactive,
+                                data_dir=data_dir,
+                                loop=loop,
+                            )
+                        except Exception as e:
+                            tool_result = f"Error: {e}"
+
+                        preview = (tool_result or "").strip()
+                        if len(preview) > 240:
+                            preview = preview[:239] + "…"
+                        tool_calls_made[-1]["result"] = tool_result
+                        _send_progress(
+                            output_queue,
+                            config.name,
+                            kind="tool_result",
+                            message=f"{tool_name} finished",
+                            steps_taken=steps_taken,
+                            tool_name=tool_name,
+                            details=preview,
+                        )
+
+                        messages.append({
+                            "role": "tool",
+                            "tool_call_id": tc.id,
+                            "content": tool_result,
+                        })
+                else:
+                    # Final answer
+                    final_response = message.content or "No response"
+                    result = SubAgentResult(
+                        name=config.name,
+                        success=True,
+                        response=final_response,
+                        duration_ms=(time.monotonic() - start_time) * 1000,
+                        steps_taken=steps_taken,
+                        tool_calls=tool_calls_made,
+                        tokens_used=tokens_used,
+                    )
+                    _send_result(output_queue, config.name, result)
+                    heartbeat_stop.set()
+                    return
+
+            # Max steps: health-check — extend if still working
+            decision = evaluate_step_budget(
+                step_count=steps_taken,
+                max_steps=max_steps,
+                extensions_used=step_budget_extensions,
+                messages=messages,
+                tool_calls_log=tool_calls_made,
+                task=str(task or ""),
+                policy=step_policy,
+                base_max_steps=base_max_steps,
             )
-
-            # LLM call with timeout
-            try:
-                response = loop.run_until_complete(
-                    _asyncio.wait_for(
-                        client.chat.completions.create(
-                            model=model,
-                            messages=messages,
-                            tools=tools_schemas if tools_schemas else None,
-                            tool_choice="auto" if tools_schemas else None,
-                            temperature=config.temperature,
-                        ),
-                        timeout=config.timeout,
-                    )
-                )
-            except TimeoutError:
-                result = SubAgentResult(
-                    name=config.name,
-                    success=False,
-                    error=f"Timed out after {config.timeout}s",
-                    duration_ms=(time.monotonic() - start_time) * 1000,
+            if decision.extend:
+                prev = max_steps
+                max_steps = decision.new_max_steps
+                step_budget_extensions = decision.extensions_used
+                _send_progress(
+                    output_queue,
+                    config.name,
+                    kind="step_budget_extended",
+                    message=(
+                        f"Step budget +{decision.extra_steps} "
+                        f"({prev} → {max_steps}): {decision.reason}"
+                    ),
                     steps_taken=steps_taken,
-                    tool_calls=tool_calls_made,
-                    tokens_used=tokens_used,
                 )
-                _send_result(output_queue, config.name, result)
-                heartbeat_stop.set()
-                return
+                continue
 
-            message = response.choices[0].message
-            try:
-                from core.llm.usage import (
-                    completion_text_from_message,
-                    resolve_usage,
-                )
-
-                usage = resolve_usage(
-                    response,
-                    messages=messages,
-                    completion_text=completion_text_from_message(message),
-                    model=model,
-                )
-                tokens_used += int(usage.get("total_tokens") or 0)
-            except Exception:
-                pass
-
-            if message.tool_calls:
-                msg_dict = {
-                    "role": "assistant",
-                    "content": message.content or "",
-                    "tool_calls": [
-                        {
-                            "id": tc.id,
-                            "type": tc.type,
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            },
-                        }
-                        for tc in message.tool_calls
-                    ],
-                }
-                messages.append(msg_dict)
-
-                for tc in message.tool_calls:
-                    tool_name = tc.function.name
-                    tool_calls_made.append({
-                        "name": tool_name,
-                        "arguments": tc.function.arguments,
-                    })
-                    _send_progress(
-                        output_queue,
-                        config.name,
-                        kind="tool_start",
-                        message=f"Calling {tool_name}",
-                        steps_taken=steps_taken,
-                        tool_name=tool_name,
-                        details=(tc.function.arguments or "")[:300],
-                    )
-
-                    try:
-                        tool_result = _execute_tool_guarded(
-                            registry,
-                            tc,
-                            config=config,
-                            profile_name=profile_name,
-                            output_queue=output_queue,
-                            input_queue=input_queue,
-                            auto_allow_threshold=auto_allow_threshold,
-                            confirmation_timeout=confirmation_timeout,
-                            interactive=interactive,
-                            data_dir=data_dir,
-                            loop=loop,
-                        )
-                    except Exception as e:
-                        tool_result = f"Error: {e}"
-
-                    preview = (tool_result or "").strip()
-                    if len(preview) > 240:
-                        preview = preview[:239] + "…"
-                    _send_progress(
-                        output_queue,
-                        config.name,
-                        kind="tool_result",
-                        message=f"{tool_name} finished",
-                        steps_taken=steps_taken,
-                        tool_name=tool_name,
-                        details=preview,
-                    )
-
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": tool_result,
-                    })
-            else:
-                # Final answer
-                final_response = message.content or "No response"
-                result = SubAgentResult(
-                    name=config.name,
-                    success=True,
-                    response=final_response,
-                    duration_ms=(time.monotonic() - start_time) * 1000,
-                    steps_taken=steps_taken,
-                    tool_calls=tool_calls_made,
-                    tokens_used=tokens_used,
-                )
-                _send_result(output_queue, config.name, result)
-                heartbeat_stop.set()
-                return
-
-        # Max steps
-        result = SubAgentResult(
-            name=config.name,
-            success=False,
-            error=f"Max steps ({max_steps}) reached",
-            duration_ms=(time.monotonic() - start_time) * 1000,
-            steps_taken=steps_taken,
-            tool_calls=tool_calls_made,
-            tokens_used=tokens_used,
-        )
-        _send_result(output_queue, config.name, result)
-        heartbeat_stop.set()
+            result = SubAgentResult(
+                name=config.name,
+                success=False,
+                error=f"Max steps ({max_steps}) reached: {decision.reason}",
+                duration_ms=(time.monotonic() - start_time) * 1000,
+                steps_taken=steps_taken,
+                tool_calls=tool_calls_made,
+                tokens_used=tokens_used,
+            )
+            _send_result(output_queue, config.name, result)
+            heartbeat_stop.set()
+            return
 
     except Exception as e:
         result = SubAgentResult(

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -407,7 +407,6 @@ class HolixTelegramBot:
         """Return False if a plugin gate blocked the message (reply already sent)."""
         from integrations.telegram.plugin_api import (
             get_active_telegram_plugin_api,
-            run_message_gates,
         )
 
         api = getattr(self, "_plugin_api", None) or get_active_telegram_plugin_api()
@@ -603,7 +602,6 @@ class HolixTelegramBot:
             TelegramPluginAPI,
             apply_telegram_handlers,
             load_telegram_plugins,
-            run_message_gates,
         )
 
         plugin_api = TelegramPluginAPI(

--- a/tests/test_browser_tools.py
+++ b/tests/test_browser_tools.py
@@ -258,7 +258,8 @@ async def test_browser_record_stop():
     finally:
         reset_conversation_scope(token)
 
-    assert result == "Video saved: /data/browser_videos/c1.webm"
+    assert result.startswith("Video saved: ")
+    assert Path(result.removeprefix("Video saved: ")) == Path("/data/browser_videos/c1.webm")
     mgr.return_value.stop_recording.assert_awaited_once_with("c1", keep_session=True)
 
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -26,11 +26,12 @@ class _FakeHost:
         self.profile = profile
 
 
-def test_default_locale_is_en(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_locale_is_ru(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Product default UI locale is Russian (Russia-first SaaS)."""
     _patch_holix_home(tmp_path, monkeypatch)
-    store = LocaleStore("default_en")
-    assert store.get() == "en"
-    assert t("cleared", store.get()) == "Chat cleared"
+    store = LocaleStore("default_ru_check")
+    assert store.get() == "ru"
+    assert t("cleared", store.get()) == "Чат очищен"
 
 
 def test_set_locale_ru(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -56,6 +57,8 @@ def test_set_locale_rejects_unknown(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 def test_host_locale_helpers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_holix_home(tmp_path, monkeypatch)
     host = _FakeHost("host_helpers")
+    assert host_locale(host) == "ru"
+    assert set_host_locale(host, "en") == "en"
     assert host_locale(host) == "en"
     assert set_host_locale(host, "ru") == "ru"
     assert host_locale(host) == "ru"

--- a/tests/test_model_discovery_context.py
+++ b/tests/test_model_discovery_context.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from core.models.discovery import ModelDiscovery, extract_context_length
 
 

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -411,6 +411,7 @@ class TestBuildPlanMarkdown:
             ],
             step_count=1,
             user_input="Build a REST API",
+            locale="en",
         )
         assert "Execution Plan" in md
         assert "Build a REST API" in md
@@ -427,6 +428,7 @@ class TestBuildPlanMarkdown:
                        "clarifying_questions": ["Which framework?"], "constraints": ["Python only"]},
             architecture={"approach": "FastAPI", "tech_stack": ["Python", "FastAPI"],
                          "structure": "api/", "risks": [{"risk": "Migration issues", "mitigation": "Use Alembic"}]},
+            locale="en",
         )
         assert "📊 Analysis" in md
         assert "Complex" in md
@@ -455,6 +457,7 @@ class TestBuildPlanMarkdown:
         md = build_plan_markdown(
             plan_steps=[{"step": 1, "description": "Simple task"}],
             step_count=1,
+            locale="en",
         )
         assert "📊 Analysis" not in md
         assert "Step 1" in md

--- a/tests/test_project_init.py
+++ b/tests/test_project_init.py
@@ -86,8 +86,12 @@ async def test_run_project_init_warns_when_agent_busy() -> None:
 
 @pytest.mark.asyncio
 async def test_run_project_init_starts_agent_on_telegram(tmp_path, monkeypatch) -> None:
+    from core.i18n.locale import LocaleStore
+
     monkeypatch.chdir(tmp_path)
     (tmp_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+    # Pin English so assertions stay locale-stable regardless of product default.
+    LocaleStore("default").set("en")
     session = ChatSession(chat_id=1, user_id=1, profile="default", conversation_id="tg")
     host = MagicMock()
     host.profile = "default"

--- a/tests/test_step_budget.py
+++ b/tests/test_step_budget.py
@@ -1,0 +1,154 @@
+"""Tests for step-budget health check and auto-extension."""
+
+from __future__ import annotations
+
+from core.runtime.step_budget import (
+    StepBudgetPolicy,
+    evaluate_step_budget,
+    maybe_extend_for_graph_result,
+)
+
+
+def test_not_at_limit_no_extend() -> None:
+    d = evaluate_step_budget(step_count=10, max_steps=90)
+    assert not d.extend
+    assert d.status == "not_at_limit"
+
+
+def test_extend_when_pending_tools_and_progress() -> None:
+    messages = [
+        {"role": "user", "content": "Implement auth module"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": '{"path":"auth.py"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "1",
+            "content": "OK: wrote auth.py successfully with login handlers",
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "2",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"auth.py"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "2",
+            "content": "def login(): ... found existing helpers",
+        },
+    ]
+    d = evaluate_step_budget(
+        step_count=90,
+        max_steps=90,
+        pending_tool_calls=[{"id": "3", "function": {"name": "run_terminal_command"}}],
+        messages=messages,
+        task="Implement auth module",
+        policy=StepBudgetPolicy(extend_by=30, max_extensions=3),
+        base_max_steps=90,
+    )
+    assert d.extend
+    assert d.status == "working"
+    assert d.new_max_steps == 120
+    assert d.extensions_used == 1
+
+
+def test_hung_on_identical_tool_loop() -> None:
+    log = [
+        {"name": "run_terminal_command", "arguments": "ls", "result": "Error: fail"},
+        {"name": "run_terminal_command", "arguments": "ls", "result": "Error: fail"},
+        {"name": "run_terminal_command", "arguments": "ls", "result": "Error: fail"},
+    ]
+    d = evaluate_step_budget(
+        step_count=50,
+        max_steps=50,
+        pending_tool_calls=[{"id": "x"}],
+        tool_calls_log=log,
+        task="list files",
+        policy=StepBudgetPolicy(),
+    )
+    assert not d.extend
+    assert d.status == "hung"
+    assert "loop" in d.reason.lower()
+
+
+def test_extension_cap() -> None:
+    d = evaluate_step_budget(
+        step_count=150,
+        max_steps=150,
+        extensions_used=3,
+        pending_tool_calls=[{"id": "1"}],
+        tool_calls_log=[
+            {"name": "write_file", "arguments": "a", "result": "OK written successfully"},
+            {"name": "read_file", "arguments": "b", "result": "content found here"},
+        ],
+        task="write code",
+        policy=StepBudgetPolicy(max_extensions=3),
+        base_max_steps=90,
+    )
+    assert not d.extend
+    assert "extension limit" in d.reason
+
+
+def test_graph_result_extends_max_steps() -> None:
+    state = {
+        "user_input": "Build a REST API",
+        "max_steps": 15,
+        "base_max_steps": 15,
+        "step_budget_extensions": 0,
+        "conversation_id": "t1",
+        "messages": [
+            {"role": "user", "content": "Build a REST API"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "1",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": '{"path":"api.py"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "1",
+                "content": "OK: created api.py with endpoints successfully",
+            },
+        ],
+    }
+    result = {
+        "step_count": 15,
+        "tool_calls": [{"id": "2", "function": {"name": "read_file"}}],
+        "is_final": False,
+        "messages": state["messages"],
+    }
+    out = maybe_extend_for_graph_result(state, result, agent=None, task="Build a REST API")
+    assert out["max_steps"] > 15
+    assert out["step_budget_extensions"] == 1
+
+
+def test_graph_result_no_extend_when_final() -> None:
+    state = {"max_steps": 15, "user_input": "hi"}
+    result = {"step_count": 15, "is_final": True, "tool_calls": []}
+    out = maybe_extend_for_graph_result(state, result, agent=None)
+    assert out is result or out.get("max_steps") is None or "max_steps" not in out or out.get("step_count") == 15
+    assert out.get("max_steps", 15) == 15 or "step_budget_extensions" not in out


### PR DESCRIPTION
## Summary
- At `max_steps`, run a health check for the main agent and sub-agents (async + process).
- If the run looks hung (identical tool loops / pure errors), stop; if work is still relevant, grant bounded extra steps.
- Config via `HOLIX_MAX_STEPS_EXTEND_*` settings; emits `MaxStepsExtendedEvent`.

## Test plan
- [x] Local: `pytest tests/test_step_budget.py`
- [ ] GitHub CI (this PR): ruff + pytest matrix + doctor