### PR TITLE
release: Holix 1.0.2 — orchestration, Reflexion, A2A, Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,29 @@ TEMPERATURE=0.7
 # VLLM_HOST=http://127.0.0.1:8000
 
 # --- Agent ---
-MAX_STEPS=15
+# Base ReAct/graph step budget (Settings field: max_steps; env alias may vary by layer)
+MAX_STEPS=90
 DATA_DIR=data
+# Meta / Reflexion (defaults on when unset in Settings)
+# HOLIX_ENABLE_META_AGENT=true
+# HOLIX_ENABLE_SELF_REFINEMENT=true
+# HOLIX_MAX_REFINEMENT_ITERATIONS=2
+# HOLIX_REFINEMENT_QUALITY_THRESHOLD=0.7
+# Step budget extension when still making progress
+# HOLIX_MAX_STEPS_EXTEND_ENABLED=true
+# Agent2Agent (A2A) — gateway Agent Card + client tools (see docs/en/A2A.md)
+# HOLIX_A2A_ENABLED=true
+# HOLIX_A2A_PUBLIC_URL=https://agent.example.com/a2a
+# HOLIX_A2A_TIMEOUT_S=300
+# HOLIX_MAX_STEPS_EXTEND_BY=30
+# HOLIX_MAX_STEPS_MAX_EXTENSIONS=3
+# HOLIX_MAX_STEPS_HARD_CAP=0
+# Subagent supervisor (mid-job guidance + plan-mode rework)
+# HOLIX_SUBAGENT_SUPERVISOR_ENABLED=true
+# HOLIX_SUBAGENT_SUPERVISOR_POLL_S=4
+# HOLIX_SUBAGENT_SUPERVISOR_IDLE_S=90
+# HOLIX_SUBAGENT_SUPERVISOR_MAX_INTERVENTIONS=3
+# HOLIX_SUBAGENT_SUPERVISOR_COOLDOWN_S=45
 
 # --- Logging (holix logs) ---
 # HOLIX_LOG_LEVEL=INFO

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN mkdir -p data/memory data/skills data/security \
     && uv run playwright install chromium
 
 ENV HOLIX_HOME=/data/.holix
+ENV HOLIX_PROFILE=shared
 ENV HOLIX_ENV=production
 ENV HOLIX_REQUIRE_AUTH=true
 ENV HOLIX_GATEWAY_HOST=0.0.0.0
@@ -45,18 +46,22 @@ ENV HOLIX_GATEWAY_PORT=8000
 ENV HOLIX_TELEGRAM_ACCESS_REQUESTS=true
 ENV HOLIX_TELEGRAM_VOICE_ENABLED=true
 ENV HOLIX_TELEGRAM_FILES_ENABLED=true
+ENV HOLIX_TELEGRAM_AUTOSTART=true
+ENV HOLIX_MAX_AUTOSTART=true
+ENV HOLIX_WORKSPACE_JAIL=true
 ENV ENABLE_BROWSER_TOOLS=true
 ENV BROWSER_HEADLESS=true
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
     CMD curl -f "http://127.0.0.1:${HOLIX_GATEWAY_PORT:-8000}/health" || exit 1
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-VOLUME ["/data/.holix"]
+VOLUME ["/data/.holix", "/data/files"]
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["gateway"]
+# agent = gateway + Telegram/MAX companions; use "gateway" with HOLIX_TELEGRAM_AUTOSTART=false for API-only
+CMD ["agent"]

--- a/README.md
+++ b/README.md
@@ -159,8 +159,19 @@ Details: [docs/en/ARCHITECTURE.md](docs/en/ARCHITECTURE.md)
 ## Docker
 
 ```bash
-docker compose up -d
+cp docker/env.example .env
+# set TELEGRAM_BOT_TOKEN, MODEL, BASE_URL, API_KEY, HOLIX_API_KEY_PEPPER
+docker compose up -d --build
 ```
+
+| Mode | Command |
+|------|---------|
+| Full agent (gateway + Telegram) | `docker compose up -d` |
+| + local Ollama | `docker compose --profile ollama up -d` |
+| Gateway API only | `docker compose --profile gateway-only up -d holix-gateway` |
+| Multi-user prod (bind mounts) | `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` |
+
+Drop-in extensions: put packages under `./extensions/`. Full guide: [docs/en/INSTALLATION.md § Path B](docs/en/INSTALLATION.md#path-b--docker).
 
 ---
 

--- a/api/gateway.py
+++ b/api/gateway.py
@@ -26,6 +26,7 @@ from api import state
 from api.deps import verify_admin_key
 from api.docs_chat import router as docs_chat_router
 from api.routers import (
+    a2a,
     admin,
     health,
     hermes_jobs,
@@ -128,6 +129,7 @@ app.add_middleware(
 app.add_middleware(SecurityHeadersMiddleware)
 
 app.include_router(health.router)
+app.include_router(a2a.router)
 app.include_router(hermes_v1.router)
 app.include_router(legacy_v1.router)
 app.include_router(hermes_jobs.router)

--- a/api/routers/a2a.py
+++ b/api/routers/a2a.py
@@ -1,0 +1,504 @@
+"""A2A (Agent2Agent) protocol endpoints for Holix gateway."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from dishka.integrations.fastapi import DishkaRoute, FromDishka
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from api.deps import ensure_key_profile_allowed, resolve_profile_name, verify_api_key
+from api.di import GatewayLocks, HostProfileName, ProfileAgentRegistry
+from api.errors import sse_streaming_response
+from api.services.path_visibility import gateway_agent_path_visibility
+from core.a2a.card import build_agent_card
+from core.a2a.config import load_a2a_config
+from core.a2a.server import (
+    cancel_task,
+    get_task_public,
+    handle_message_send,
+    handle_message_stream,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["a2a"], route_class=DishkaRoute)
+
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+
+def _profile_from_headers(
+    key_info: dict,
+    host_profile: str,
+    x_holix_profile: str | None,
+    x_hermes_profile: str | None,
+) -> str:
+    from api.deps import _header_alias
+
+    profile = resolve_profile_name(
+        header_profile=_header_alias(x_holix_profile, x_hermes_profile),
+        model=None,
+        host_profile=host_profile or "default",
+    )
+    ensure_key_profile_allowed(key_info, profile)
+    return profile
+
+
+def _public_base(request: Request, cfg_url: str | None) -> str:
+    if cfg_url:
+        return cfg_url.rstrip("/")
+    # Reconstruct from request
+    root = str(request.base_url).rstrip("/")
+    return f"{root}/a2a"
+
+
+def _require_a2a(profile: str) -> None:
+    cfg = load_a2a_config(profile)
+    if not cfg.server_enabled:
+        raise HTTPException(
+            status_code=404,
+            detail="A2A is disabled for this profile (a2a.enabled / HOLIX_A2A_ENABLED)",
+        )
+
+
+@router.get("/.well-known/agent.json")
+@router.get("/.well-known/agent-card.json")
+async def well_known_agent_card(
+    request: Request,
+    host_profile: FromDishka[HostProfileName],
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    """Public Agent Card discovery (authenticated with gateway API key)."""
+    profile = _profile_from_headers(
+        key_info, str(host_profile), x_holix_profile, x_hermes_profile
+    )
+    _require_a2a(profile)
+    cfg = load_a2a_config(profile)
+    public = _public_base(request, cfg.public_url)
+    return build_agent_card(profile, public_url=public, config=cfg)
+
+
+@router.get("/a2a/.well-known/agent.json")
+@router.get("/a2a/agent-card")
+async def a2a_agent_card(
+    request: Request,
+    host_profile: FromDishka[HostProfileName],
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    profile = _profile_from_headers(
+        key_info, str(host_profile), x_holix_profile, x_hermes_profile
+    )
+    _require_a2a(profile)
+    cfg = load_a2a_config(profile)
+    public = _public_base(request, cfg.public_url)
+    return build_agent_card(profile, public_url=public, config=cfg)
+
+
+def _jsonrpc_error(
+    req_id: Any, code: int, message: str, *, http_status: int = 200
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=http_status,
+        content={
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": code, "message": message},
+        },
+    )
+
+
+def _sse_data(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload, ensure_ascii=False, default=str)}\n\n"
+
+
+async def _jsonrpc_stream(
+    *,
+    req_id: Any,
+    agent: Any,
+    message: Any,
+    profile: str,
+    configuration: dict[str, Any] | None,
+    key_info: dict,
+    locks: Any,
+) -> AsyncIterator[str]:
+    """SSE stream of JSON-RPC responses (one result object per event)."""
+    try:
+        async with locks.agent_request:
+            with gateway_agent_path_visibility(agent, key_info):
+                async for item in handle_message_stream(
+                    agent=agent,
+                    message=message,
+                    profile=profile,
+                    configuration=configuration,
+                ):
+                    yield _sse_data(
+                        {"jsonrpc": "2.0", "id": req_id, "result": item}
+                    )
+    except ValueError as exc:
+        yield _sse_data(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32602, "message": str(exc)},
+            }
+        )
+    except Exception as exc:
+        logger.exception("A2A message/stream failed")
+        yield _sse_data(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32000, "message": str(exc)},
+            }
+        )
+
+
+async def _rest_stream(
+    *,
+    agent: Any,
+    message: Any,
+    profile: str,
+    configuration: dict[str, Any] | None,
+    key_info: dict,
+    locks: Any,
+) -> AsyncIterator[str]:
+    """SSE stream of bare StreamResponse objects (REST binding)."""
+    try:
+        async with locks.agent_request:
+            with gateway_agent_path_visibility(agent, key_info):
+                async for item in handle_message_stream(
+                    agent=agent,
+                    message=message,
+                    profile=profile,
+                    configuration=configuration,
+                ):
+                    yield _sse_data(item)
+    except ValueError as exc:
+        yield _sse_data({"error": {"code": "invalid_params", "message": str(exc)}})
+    except Exception as exc:
+        logger.exception("A2A REST stream failed")
+        yield _sse_data({"error": {"code": "internal", "message": str(exc)}})
+
+
+@router.post("/a2a")
+@router.post("/a2a/")
+async def a2a_jsonrpc(
+    request: Request,
+    locks: FromDishka[GatewayLocks],
+    registry: FromDishka[ProfileAgentRegistry],
+    host_profile: FromDishka[HostProfileName],
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    """JSON-RPC 2.0: message/send, message/stream (SSE), tasks/*, agent card."""
+    profile = _profile_from_headers(
+        key_info, str(host_profile), x_holix_profile, x_hermes_profile
+    )
+    _require_a2a(profile)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return _jsonrpc_error(None, -32700, "Parse error")
+
+    if not isinstance(body, dict):
+        return _jsonrpc_error(None, -32600, "Invalid Request")
+
+    req_id = body.get("id")
+    method = str(body.get("method") or "").strip()
+    params = body.get("params") if isinstance(body.get("params"), dict) else {}
+
+    if method in {"agent/getAuthenticatedExtendedCard", "agent/card", "get_agent_card"}:
+        cfg = load_a2a_config(profile)
+        public = _public_base(request, cfg.public_url)
+        card = build_agent_card(profile, public_url=public, config=cfg)
+        return {"jsonrpc": "2.0", "id": req_id, "result": card}
+
+    if method in {
+        "message/stream",
+        "message/sendStreamingMessage",
+        "message/sendSubscribe",
+        "send_streaming_message",
+    }:
+        message = params.get("message")
+        if not message:
+            return _jsonrpc_error(req_id, -32602, "params.message is required")
+        configuration = params.get("configuration")
+        agent = await registry.get_agent(profile)
+        return sse_streaming_response(
+            _jsonrpc_stream(
+                req_id=req_id,
+                agent=agent,
+                message=message,
+                profile=profile,
+                configuration=configuration
+                if isinstance(configuration, dict)
+                else None,
+                key_info=key_info,
+                locks=locks,
+            )
+        )
+
+    if method in {"message/send", "message/sendMessage", "send_message"}:
+        message = params.get("message")
+        if not message:
+            return _jsonrpc_error(req_id, -32602, "params.message is required")
+        configuration = params.get("configuration")
+        agent = await registry.get_agent(profile)
+        # Optional: stream if client asks via Accept
+        accept = (request.headers.get("accept") or "").lower()
+        if "text/event-stream" in accept:
+            return sse_streaming_response(
+                _jsonrpc_stream(
+                    req_id=req_id,
+                    agent=agent,
+                    message=message,
+                    profile=profile,
+                    configuration=configuration
+                    if isinstance(configuration, dict)
+                    else None,
+                    key_info=key_info,
+                    locks=locks,
+                )
+            )
+        try:
+            async with locks.agent_request:
+                with gateway_agent_path_visibility(agent, key_info):
+                    result = await handle_message_send(
+                        agent=agent,
+                        message=message,
+                        profile=profile,
+                        configuration=configuration
+                        if isinstance(configuration, dict)
+                        else None,
+                    )
+        except ValueError as exc:
+            return _jsonrpc_error(req_id, -32602, str(exc))
+        except Exception as exc:
+            logger.exception("A2A message/send failed")
+            return _jsonrpc_error(req_id, -32000, str(exc))
+        return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+    if method in {"tasks/get", "tasks/getTask", "get_task"}:
+        task_id = str(params.get("id") or params.get("taskId") or "").strip()
+        if not task_id:
+            return _jsonrpc_error(req_id, -32602, "params.id is required")
+        hist = params.get("historyLength")
+        try:
+            hist_n = int(hist) if hist is not None else None
+        except (TypeError, ValueError):
+            hist_n = None
+        task = get_task_public(task_id, history_length=hist_n, profile=profile)
+        if task is None:
+            return _jsonrpc_error(req_id, -32001, "Task not found")
+        return {"jsonrpc": "2.0", "id": req_id, "result": task}
+
+    if method in {"tasks/cancel", "tasks/cancelTask", "cancel_task"}:
+        task_id = str(params.get("id") or params.get("taskId") or "").strip()
+        if not task_id:
+            return _jsonrpc_error(req_id, -32602, "params.id is required")
+        task = cancel_task(task_id, profile=profile)
+        if task is None:
+            return _jsonrpc_error(req_id, -32001, "Task not found")
+        return {"jsonrpc": "2.0", "id": req_id, "result": task}
+
+    if method in {"tasks/list", "list_tasks"}:
+        from core.a2a.store import get_a2a_task_store
+
+        context_id = params.get("contextId") or params.get("context_id")
+        limit = params.get("pageSize") or params.get("limit") or 50
+        try:
+            limit_n = int(limit)
+        except (TypeError, ValueError):
+            limit_n = 50
+        tasks = get_a2a_task_store().list_tasks(
+            profile=profile,
+            context_id=str(context_id) if context_id else None,
+            limit=limit_n,
+        )
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "tasks": [t.to_public_dict(history_length=0) for t in tasks],
+                "nextPageToken": "",
+                "pageSize": limit_n,
+                "totalSize": len(tasks),
+            },
+        }
+
+    return _jsonrpc_error(req_id, -32601, f"Method not found: {method}")
+
+
+@router.post("/a2a/message:send")
+async def a2a_rest_message_send(
+    request: Request,
+    locks: FromDishka[GatewayLocks],
+    registry: FromDishka[ProfileAgentRegistry],
+    host_profile: FromDishka[HostProfileName],
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    """HTTP+JSON REST-style Send Message (A2A REST binding subset).
+
+    Send ``Accept: text/event-stream`` to receive SSE StreamResponse events
+    instead of a single completed Task JSON body.
+    """
+    profile = _profile_from_headers(
+        key_info, str(host_profile), x_holix_profile, x_hermes_profile
+    )
+    _require_a2a(profile)
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Body must be an object")
+    message = body.get("message")
+    if not message:
+        raise HTTPException(status_code=400, detail="message is required")
+    agent = await registry.get_agent(profile)
+    configuration = (
+        body.get("configuration")
+        if isinstance(body.get("configuration"), dict)
+        else None
+    )
+    accept = (request.headers.get("accept") or "").lower()
+    if "text/event-stream" in accept:
+        return sse_streaming_response(
+            _rest_stream(
+                agent=agent,
+                message=message,
+                profile=profile,
+                configuration=configuration,
+                key_info=key_info,
+                locks=locks,
+            )
+        )
+    try:
+        async with locks.agent_request:
+            with gateway_agent_path_visibility(agent, key_info):
+                return await handle_message_send(
+                    agent=agent,
+                    message=message,
+                    profile=profile,
+                    configuration=configuration,
+                )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/a2a/message:stream")
+async def a2a_rest_message_stream(
+    request: Request,
+    locks: FromDishka[GatewayLocks],
+    registry: FromDishka[ProfileAgentRegistry],
+    host_profile: FromDishka[HostProfileName],
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    """REST streaming Send Message — always ``text/event-stream``."""
+    profile = _profile_from_headers(
+        key_info, str(host_profile), x_holix_profile, x_hermes_profile
+    )
+    _require_a2a(profile)
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON") from exc
+    if not isinstance(body, dict) or not body.get("message"):
+        raise HTTPException(status_code=400, detail="message is required")
+    agent = await registry.get_agent(profile)
+    return sse_streaming_response(
+        _rest_stream(
+            agent=agent,
+            message=body["message"],
+            profile=profile,
+            configuration=body.get("configuration")
+            if isinstance(body.get("configuration"), dict)
+            else None,
+            key_info=key_info,
+            locks=locks,
+        )
+    )
+
+
+@router.get("/a2a/tasks/{task_id}")
+async def a2a_rest_get_task(
+    task_id: str,
+    host_profile: FromDishka[HostProfileName],
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+    historyLength: int | None = None,
+):
+    profile = _profile_from_headers(
+        key_info, str(host_profile), x_holix_profile, x_hermes_profile
+    )
+    _require_a2a(profile)
+    task = get_task_public(task_id, history_length=historyLength, profile=profile)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return task
+
+
+@router.get("/a2a/tasks/{task_id}/subscribe")
+async def a2a_rest_subscribe_task(
+    task_id: str,
+    host_profile: FromDishka[HostProfileName],
+    key_info: dict = Depends(verify_api_key),
+    x_holix_profile: str | None = Header(None),
+    x_hermes_profile: str | None = Header(None),
+):
+    """SSE snapshot for an existing task (terminal or current state).
+
+    For in-flight tasks started via blocking send, returns current state then
+    closes. Prefer ``message/stream`` for live progress during a new run.
+    """
+    profile = _profile_from_headers(
+        key_info, str(host_profile), x_holix_profile, x_hermes_profile
+    )
+    _require_a2a(profile)
+    task = get_task_public(task_id, profile=profile)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    async def _gen() -> AsyncIterator[str]:
+        yield _sse_data({"task": task})
+        state = ((task.get("status") or {}).get("state") or "").lower()
+        terminal = state in {
+            "completed",
+            "failed",
+            "canceled",
+            "cancelled",
+            "rejected",
+        }
+        yield _sse_data(
+            {
+                "statusUpdate": {
+                    "taskId": task.get("id"),
+                    "contextId": task.get("contextId"),
+                    "status": task.get("status"),
+                    "final": terminal,
+                }
+            }
+        )
+
+    return StreamingResponse(
+        _gen(), media_type="text/event-stream", headers=_SSE_HEADERS
+    )

--- a/api/routers/a2a.py
+++ b/api/routers/a2a.py
@@ -7,14 +7,6 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
-from dishka.integrations.fastapi import DishkaRoute, FromDishka
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
-from fastapi.responses import JSONResponse, StreamingResponse
-
-from api.deps import ensure_key_profile_allowed, resolve_profile_name, verify_api_key
-from api.di import GatewayLocks, HostProfileName, ProfileAgentRegistry
-from api.errors import sse_streaming_response
-from api.services.path_visibility import gateway_agent_path_visibility
 from core.a2a.card import build_agent_card
 from core.a2a.config import load_a2a_config
 from core.a2a.server import (
@@ -23,6 +15,14 @@ from core.a2a.server import (
     handle_message_send,
     handle_message_stream,
 )
+from dishka.integrations.fastapi import DishkaRoute, FromDishka
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from api.deps import ensure_key_profile_allowed, resolve_profile_name, verify_api_key
+from api.di import GatewayLocks, HostProfileName, ProfileAgentRegistry
+from api.errors import sse_streaming_response
+from api.services.path_visibility import gateway_agent_path_visibility
 
 logger = logging.getLogger(__name__)
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/cli/services/supervisor.py
+++ b/cli/services/supervisor.py
@@ -28,13 +28,23 @@ from cli.utils.ports import resolve_listen_port
 from cli.utils.rich_console import print_info, print_success, print_warning
 
 
+def _companion_autostart(env_name: str, *, default: bool = True) -> bool:
+    """``HOLIX_*_AUTOSTART`` — false disables OS companions (gateway-only Docker)."""
+    raw = os.getenv(env_name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "true", "yes", "on"}
+
+
 def telegram_enabled(profile: str = "default") -> bool:
     """True when a Telegram bot token is configured."""
     return bool(load_telegram_settings(profile).bot_token.strip())
 
 
 def telegram_should_start(profile: str = "default") -> bool:
-    """True when token is set and optional aiogram dependency is installed."""
+    """True when token is set, aiogram is available, and autostart is enabled."""
+    if not _companion_autostart("HOLIX_TELEGRAM_AUTOSTART", default=True):
+        return False
     return telegram_enabled(profile) and telegram_aiogram_available()
 
 

--- a/config.py
+++ b/config.py
@@ -27,6 +27,35 @@ class Settings(BaseSettings):
 
     # Agent Configuration
     max_steps: int = 90
+    max_steps_extend_enabled: bool = Field(
+        default=True,
+        validation_alias=AliasChoices(
+            "HOLIX_MAX_STEPS_EXTEND_ENABLED",
+            "MAX_STEPS_EXTEND_ENABLED",
+        ),
+        description=(
+            "When max_steps is hit, check if agent is still making relevant progress "
+            "and grant extra steps instead of stopping immediately"
+        ),
+    )
+    max_steps_extend_by: int = Field(
+        default=30,
+        validation_alias=AliasChoices("HOLIX_MAX_STEPS_EXTEND_BY", "MAX_STEPS_EXTEND_BY"),
+        description="How many steps to add when progress check passes",
+    )
+    max_steps_max_extensions: int = Field(
+        default=3,
+        validation_alias=AliasChoices(
+            "HOLIX_MAX_STEPS_MAX_EXTENSIONS",
+            "MAX_STEPS_MAX_EXTENSIONS",
+        ),
+        description="Max number of automatic step-budget extensions per run",
+    )
+    max_steps_hard_cap: int = Field(
+        default=0,
+        validation_alias=AliasChoices("HOLIX_MAX_STEPS_HARD_CAP", "MAX_STEPS_HARD_CAP"),
+        description="Absolute max_steps after extensions (0 = base + extend_by * max_extensions)",
+    )
     agent_max_tokens: int = Field(
         default=8192,
         validation_alias=AliasChoices("HOLIX_AGENT_MAX_TOKENS", "AGENT_MAX_TOKENS"),

--- a/config.py
+++ b/config.py
@@ -76,14 +76,62 @@ class Settings(BaseSettings):
     subagent_max_concurrent: int = 4
     subagent_process_timeout: float = 900.0
     subagent_heartbeat_interval: float = 5.0
+    # Runtime supervisor: watch stuck jobs and inject guidance (same job)
+    subagent_supervisor_enabled: bool = Field(
+        default=True,
+        validation_alias=AliasChoices(
+            "HOLIX_SUBAGENT_SUPERVISOR_ENABLED",
+            "SUBAGENT_SUPERVISOR_ENABLED",
+        ),
+        description="Background supervisor watches sub-agents and injects guidance on loop/hang",
+    )
+    subagent_supervisor_poll_s: float = Field(
+        default=4.0,
+        validation_alias=AliasChoices("HOLIX_SUBAGENT_SUPERVISOR_POLL_S"),
+        description="Supervisor poll interval seconds",
+    )
+    subagent_supervisor_idle_s: float = Field(
+        default=90.0,
+        validation_alias=AliasChoices("HOLIX_SUBAGENT_SUPERVISOR_IDLE_S"),
+        description="Seconds without activity before treating a job as hung",
+    )
+    subagent_supervisor_max_interventions: int = Field(
+        default=3,
+        validation_alias=AliasChoices("HOLIX_SUBAGENT_SUPERVISOR_MAX_INTERVENTIONS"),
+        description="Max guidance interventions per sub-agent job",
+    )
+    subagent_supervisor_cooldown_s: float = Field(
+        default=45.0,
+        validation_alias=AliasChoices("HOLIX_SUBAGENT_SUPERVISOR_COOLDOWN_S"),
+        description="Minimum seconds between interventions for the same job",
+    )
 
-    # Meta-Agent Configuration
-    enable_meta_agent: bool = False
+    # Meta-Agent Configuration (pre-thinking advisory — Reflexion setup)
+    enable_meta_agent: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("HOLIX_ENABLE_META_AGENT", "ENABLE_META_AGENT"),
+        description="Run meta-agent after memory retrieval for strategic hints",
+    )
 
-    # Self-Refinement Configuration
-    enable_self_refinement: bool = False
-    max_refinement_iterations: int = 2
-    refinement_quality_threshold: float = 0.7
+    # Self-Refinement / Reflexion Configuration (evaluate draft → verbal feedback → retry)
+    enable_self_refinement: bool = Field(
+        default=True,
+        validation_alias=AliasChoices(
+            "HOLIX_ENABLE_SELF_REFINEMENT",
+            "ENABLE_SELF_REFINEMENT",
+        ),
+        description="After a draft final answer, evaluate quality and retry with reflection",
+    )
+    max_refinement_iterations: int = Field(
+        default=2,
+        validation_alias=AliasChoices("HOLIX_MAX_REFINEMENT_ITERATIONS"),
+        description="Max Reflexion retries after a draft answer",
+    )
+    refinement_quality_threshold: float = Field(
+        default=0.7,
+        validation_alias=AliasChoices("HOLIX_REFINEMENT_QUALITY_THRESHOLD"),
+        description="Accept draft when quality_score >= threshold",
+    )
 
     # Evolution Configuration
     enable_evolution: bool = False

--- a/core/a2a/__init__.py
+++ b/core/a2a/__init__.py
@@ -1,0 +1,25 @@
+"""Agent2Agent (A2A) protocol support for Holix.
+
+Holix can act as:
+- **A2A Server** — expose the profile agent via gateway (Agent Card + message/send)
+- **A2A Client** — call remote A2A agents via tools (a2a_discover, a2a_send_message, …)
+
+Protocol: https://a2a-protocol.org (JSON-RPC + Agent Card discovery).
+"""
+
+from core.a2a.card import build_agent_card
+from core.a2a.client import A2AClient, A2AClientError
+from core.a2a.config import A2AConfig, load_a2a_config
+from core.a2a.models import A2AMessage, A2APart, A2ATask, TaskState
+
+__all__ = [
+    "A2AClient",
+    "A2AClientError",
+    "A2AConfig",
+    "A2AMessage",
+    "A2APart",
+    "A2ATask",
+    "TaskState",
+    "build_agent_card",
+    "load_a2a_config",
+]

--- a/core/a2a/card.py
+++ b/core/a2a/card.py
@@ -43,9 +43,9 @@ def build_agent_card(
 
     # Optional: surface installed skills as A2A skills (bounded)
     try:
+        from core.di import resolve_runtime_config
         from core.profile import ProfileManager
         from core.skills.manager import SkillsManager
-        from core.di import resolve_runtime_config
 
         prof = ProfileManager().load_profile(profile)
         runtime = resolve_runtime_config(prof)

--- a/core/a2a/card.py
+++ b/core/a2a/card.py
@@ -1,0 +1,111 @@
+"""Build A2A Agent Card for a Holix profile."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.a2a.config import A2AConfig, load_a2a_config
+
+
+def build_agent_card(
+    profile: str = "default",
+    *,
+    public_url: str | None = None,
+    config: A2AConfig | None = None,
+) -> dict[str, Any]:
+    """Return Agent Card JSON (discovery document)."""
+    cfg = config or load_a2a_config(profile)
+    url = (public_url or cfg.public_url or "").strip().rstrip("/")
+    if not url:
+        # Relative service base; clients should resolve against gateway origin
+        url = "/a2a"
+
+    name = cfg.card_name or f"Holix ({profile})"
+    description = cfg.card_description or (
+        "Holix self-improving AI agent with memory, skills, MCP tools, "
+        "sub-agents, and SDD. Exposed via the Agent2Agent (A2A) protocol."
+    )
+
+    skills: list[dict[str, Any]] = [
+        {
+            "id": "general-assistant",
+            "name": "General assistant",
+            "description": "Answer questions, write code, run tools in the Holix workspace.",
+            "tags": ["general", "coding", "tools"],
+            "examples": [
+                "Explain this stack and suggest next steps",
+                "Implement a feature and open a PR plan",
+            ],
+            "inputModes": ["text/plain"],
+            "outputModes": ["text/plain"],
+        }
+    ]
+
+    # Optional: surface installed skills as A2A skills (bounded)
+    try:
+        from core.profile import ProfileManager
+        from core.skills.manager import SkillsManager
+        from core.di import resolve_runtime_config
+
+        prof = ProfileManager().load_profile(profile)
+        runtime = resolve_runtime_config(prof)
+        mgr = SkillsManager(runtime)
+        listed = []
+        try:
+            listed = list(mgr.list_skills() or [])[:12]
+        except Exception:
+            listed = []
+        for item in listed:
+            if isinstance(item, dict):
+                sid = str(item.get("name") or item.get("id") or "").strip()
+                desc = str(item.get("description") or "")[:240]
+            else:
+                sid = str(getattr(item, "name", "") or "").strip()
+                desc = str(getattr(item, "description", "") or "")[:240]
+            if not sid:
+                continue
+            skills.append(
+                {
+                    "id": f"skill-{sid}"[:64],
+                    "name": sid,
+                    "description": desc or f"Holix skill: {sid}",
+                    "tags": ["skill"],
+                    "inputModes": ["text/plain"],
+                    "outputModes": ["text/plain"],
+                }
+            )
+    except Exception:
+        pass
+
+    return {
+        "name": name,
+        "description": description,
+        "url": url,
+        "version": cfg.card_version,
+        "protocolVersion": "0.3.0",
+        "preferredTransport": "JSONRPC",
+        "capabilities": {
+            "streaming": True,
+            "pushNotifications": False,
+            "stateTransitionHistory": False,
+        },
+        "defaultInputModes": ["text/plain", "text"],
+        "defaultOutputModes": ["text/plain", "text"],
+        "skills": skills,
+        "supportsAuthenticatedExtendedCard": False,
+        "provider": {
+            "organization": "Holix",
+            "url": "https://holix-agent.ru",
+        },
+        "additionalInterfaces": [
+            {
+                "url": url,
+                "transport": "JSONRPC",
+            }
+        ],
+        # Holix extensions (non-normative metadata)
+        "metadata": {
+            "holix_profile": profile,
+            "framework": "Holix",
+        },
+    }

--- a/core/a2a/client.py
+++ b/core/a2a/client.py
@@ -1,0 +1,207 @@
+"""HTTP client for remote A2A agents."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+
+from core.a2a.models import A2AMessage, new_id
+
+logger = logging.getLogger(__name__)
+
+
+class A2AClientError(Exception):
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class A2AClient:
+    """Discover Agent Cards and send messages to remote A2A servers."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout_s: float = 300.0,
+    ) -> None:
+        self.base_url = (base_url or "").strip().rstrip("/")
+        if not self.base_url:
+            raise A2AClientError("base_url is required")
+        self.headers = dict(headers or {})
+        self.timeout_s = max(5.0, float(timeout_s or 300))
+
+    def _rpc_url(self) -> str:
+        # Prefer base itself as JSON-RPC endpoint; card may refine
+        return self.base_url
+
+    async def fetch_agent_card(self) -> dict[str, Any]:
+        candidates = [
+            urljoin(self.base_url + "/", ".well-known/agent.json"),
+            urljoin(self.base_url + "/", ".well-known/agent-card.json"),
+            f"{self.base_url}/.well-known/agent.json",
+            # When base is host root
+            urljoin(self.base_url.rsplit("/a2a", 1)[0] + "/", ".well-known/agent.json")
+            if "/a2a" in self.base_url
+            else None,
+        ]
+        last_err: str | None = None
+        async with httpx.AsyncClient(timeout=min(30.0, self.timeout_s)) as client:
+            for url in candidates:
+                if not url:
+                    continue
+                try:
+                    resp = await client.get(url, headers=self.headers)
+                    if resp.status_code == 200:
+                        data = resp.json()
+                        if isinstance(data, dict) and (data.get("name") or data.get("url")):
+                            # Update base from card if present
+                            card_url = str(data.get("url") or "").strip().rstrip("/")
+                            if card_url:
+                                self.base_url = card_url
+                            return data
+                    last_err = f"{url} → HTTP {resp.status_code}"
+                except Exception as exc:
+                    last_err = f"{url} → {exc}"
+        raise A2AClientError(f"Agent Card not found ({last_err or 'no candidates'})")
+
+    async def send_message(
+        self,
+        text: str,
+        *,
+        context_id: str | None = None,
+        configuration: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Send user text via JSON-RPC message/send (A2A 0.3/1.0)."""
+        msg = A2AMessage.from_user_text(text, context_id=context_id)
+        params: dict[str, Any] = {
+            "message": msg.model_dump(exclude_none=True),
+        }
+        if configuration:
+            params["configuration"] = configuration
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": new_id("rpc_"),
+            "method": "message/send",
+            "params": params,
+        }
+        async with httpx.AsyncClient(timeout=self.timeout_s) as client:
+            try:
+                resp = await client.post(
+                    self._rpc_url(),
+                    json=payload,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                        **self.headers,
+                    },
+                )
+            except httpx.TimeoutException as exc:
+                raise A2AClientError(f"Remote A2A timeout after {self.timeout_s}s") from exc
+            except httpx.HTTPError as exc:
+                raise A2AClientError(f"Remote A2A HTTP error: {exc}") from exc
+
+        if resp.status_code >= 400:
+            raise A2AClientError(
+                f"Remote A2A HTTP {resp.status_code}: {resp.text[:500]}",
+                status_code=resp.status_code,
+            )
+        try:
+            data = resp.json()
+        except Exception as exc:
+            raise A2AClientError(f"Invalid JSON from remote A2A: {exc}") from exc
+
+        if isinstance(data, dict) and data.get("error"):
+            err = data["error"]
+            if isinstance(err, dict):
+                raise A2AClientError(
+                    f"A2A RPC error {err.get('code')}: {err.get('message')}"
+                )
+            raise A2AClientError(f"A2A RPC error: {err}")
+
+        result = data.get("result") if isinstance(data, dict) else data
+        if not isinstance(result, dict):
+            raise A2AClientError("A2A message/send returned non-object result")
+        return result
+
+    async def get_task(self, task_id: str, *, history_length: int | None = None) -> dict[str, Any]:
+        params: dict[str, Any] = {"id": task_id}
+        if history_length is not None:
+            params["historyLength"] = history_length
+        payload = {
+            "jsonrpc": "2.0",
+            "id": new_id("rpc_"),
+            "method": "tasks/get",
+            "params": params,
+        }
+        async with httpx.AsyncClient(timeout=min(60.0, self.timeout_s)) as client:
+            resp = await client.post(
+                self._rpc_url(),
+                json=payload,
+                headers={"Content-Type": "application/json", **self.headers},
+            )
+        if resp.status_code >= 400:
+            raise A2AClientError(
+                f"tasks/get HTTP {resp.status_code}: {resp.text[:400]}",
+                status_code=resp.status_code,
+            )
+        data = resp.json()
+        if isinstance(data, dict) and data.get("error"):
+            err = data["error"]
+            msg = err.get("message") if isinstance(err, dict) else str(err)
+            raise A2AClientError(f"tasks/get error: {msg}")
+        result = data.get("result") if isinstance(data, dict) else data
+        if not isinstance(result, dict):
+            raise A2AClientError("tasks/get returned non-object")
+        return result
+
+
+def extract_task_text(task: dict[str, Any]) -> str:
+    """Best-effort plain text from an A2A Task response."""
+    if not isinstance(task, dict):
+        return str(task)
+    # status.message
+    status = task.get("status") or {}
+    if isinstance(status, dict):
+        msg = status.get("message")
+        if isinstance(msg, dict):
+            parts = msg.get("parts") or []
+            texts = [
+                str(p.get("text"))
+                for p in parts
+                if isinstance(p, dict) and p.get("text")
+            ]
+            if texts:
+                return "\n".join(texts)
+    # artifacts
+    for art in task.get("artifacts") or []:
+        if not isinstance(art, dict):
+            continue
+        parts = art.get("parts") or []
+        texts = [
+            str(p.get("text"))
+            for p in parts
+            if isinstance(p, dict) and p.get("text")
+        ]
+        if texts:
+            return "\n".join(texts)
+    # history last agent message
+    for msg in reversed(task.get("history") or []):
+        if not isinstance(msg, dict):
+            continue
+        if str(msg.get("role") or "") != "agent":
+            continue
+        parts = msg.get("parts") or []
+        texts = [
+            str(p.get("text"))
+            for p in parts
+            if isinstance(p, dict) and p.get("text")
+        ]
+        if texts:
+            return "\n".join(texts)
+    return ""

--- a/core/a2a/config.py
+++ b/core/a2a/config.py
@@ -1,0 +1,124 @@
+"""A2A configuration from Holix profile / global / env."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class RemoteA2AAgent:
+    name: str
+    url: str
+    description: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class A2AConfig:
+    """Whether Holix exposes/consumes A2A for a profile."""
+
+    enabled: bool = True
+    # Server
+    public_url: str | None = None  # e.g. https://agent.example.com/a2a
+    card_name: str | None = None
+    card_description: str | None = None
+    card_version: str = "1.0.0"
+    # Client
+    remote_agents: list[RemoteA2AAgent] = field(default_factory=list)
+    request_timeout_s: float = 300.0
+
+    @property
+    def server_enabled(self) -> bool:
+        return self.enabled
+
+    @property
+    def client_enabled(self) -> bool:
+        return self.enabled
+
+
+def _as_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_remotes(raw: Any) -> list[RemoteA2AAgent]:
+    if not isinstance(raw, list):
+        return []
+    out: list[RemoteA2AAgent] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        url = str(item.get("url") or item.get("base_url") or "").strip().rstrip("/")
+        if not name or not url:
+            continue
+        headers: dict[str, str] = {}
+        hdr = item.get("headers")
+        if isinstance(hdr, dict):
+            headers = {str(k): str(v) for k, v in hdr.items() if k and v is not None}
+        out.append(
+            RemoteA2AAgent(
+                name=name,
+                url=url,
+                description=str(item.get("description") or ""),
+                headers=headers,
+            )
+        )
+    return out
+
+
+def load_a2a_config(profile: str | None = None, *, raw: dict[str, Any] | None = None) -> A2AConfig:
+    """Load A2A config: explicit raw → profile yaml → env defaults."""
+    data: dict[str, Any] = {}
+    if raw and isinstance(raw, dict):
+        data = dict(raw.get("a2a") if isinstance(raw.get("a2a"), dict) else raw)
+    elif profile:
+        try:
+            from core.profile import ProfileManager
+
+            cfg = ProfileManager().load_profile(profile)
+            a2a = getattr(cfg, "a2a", None)
+            if isinstance(a2a, dict):
+                data = dict(a2a)
+            else:
+                dumped = cfg.model_dump() if hasattr(cfg, "model_dump") else {}
+                if isinstance(dumped.get("a2a"), dict):
+                    data = dict(dumped["a2a"])
+            # Extension-style settings can override
+            ext = getattr(cfg, "extension_settings", None) or {}
+            if isinstance(ext, dict) and isinstance(ext.get("a2a"), dict):
+                data = {**data, **ext["a2a"]}
+        except Exception:
+            pass
+
+    env_enabled = os.getenv("HOLIX_A2A_ENABLED")
+    enabled = _as_bool(data.get("enabled"), default=True)
+    if env_enabled is not None and str(env_enabled).strip() != "":
+        enabled = _as_bool(env_enabled, default=enabled)
+
+    public_url = data.get("public_url") or data.get("url") or os.getenv("HOLIX_A2A_PUBLIC_URL")
+    if public_url:
+        public_url = str(public_url).strip().rstrip("/") or None
+
+    timeout = data.get("request_timeout_s") or os.getenv("HOLIX_A2A_TIMEOUT_S") or 300
+    try:
+        timeout_f = float(timeout)
+    except (TypeError, ValueError):
+        timeout_f = 300.0
+
+    return A2AConfig(
+        enabled=enabled,
+        public_url=public_url,
+        card_name=(str(data["name"]).strip() if data.get("name") else None),
+        card_description=(
+            str(data["description"]).strip() if data.get("description") else None
+        ),
+        card_version=str(data.get("version") or "1.0.0"),
+        remote_agents=_parse_remotes(data.get("remote_agents") or data.get("remotes")),
+        request_timeout_s=max(5.0, min(timeout_f, 3600.0)),
+    )

--- a/core/a2a/models.py
+++ b/core/a2a/models.py
@@ -1,0 +1,178 @@
+"""Minimal A2A data model (spec 0.3 / 1.0 compatible subset)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def new_id(prefix: str = "") -> str:
+    body = uuid.uuid4().hex
+    return f"{prefix}{body}" if prefix else body
+
+
+class TaskState(StrEnum):
+    SUBMITTED = "submitted"
+    WORKING = "working"
+    INPUT_REQUIRED = "input-required"
+    AUTH_REQUIRED = "auth-required"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+    REJECTED = "rejected"
+    UNKNOWN = "unknown"
+
+
+class A2APart(BaseModel):
+    """Content part (text-first; files/data optional)."""
+
+    kind: str = "text"  # text | file | data
+    text: str | None = None
+    # file / data payloads (opaque for MVP)
+    file: dict[str, Any] | None = None
+    data: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+
+    def as_text(self) -> str:
+        if self.kind == "text" and self.text is not None:
+            return str(self.text)
+        if self.data is not None:
+            return str(self.data)
+        if self.file is not None:
+            return f"[file:{self.file.get('name') or self.file.get('uri') or 'attachment'}]"
+        return ""
+
+
+class A2AMessage(BaseModel):
+    role: str = "user"  # user | agent
+    parts: list[A2APart] = Field(default_factory=list)
+    messageId: str = Field(default_factory=lambda: new_id("msg_"))
+    contextId: str | None = None
+    taskId: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    def text_content(self) -> str:
+        chunks = [p.as_text() for p in self.parts]
+        return "\n".join(c for c in chunks if c).strip()
+
+    @classmethod
+    def from_user_text(
+        cls,
+        text: str,
+        *,
+        context_id: str | None = None,
+        task_id: str | None = None,
+    ) -> A2AMessage:
+        return cls(
+            role="user",
+            parts=[A2APart(kind="text", text=text)],
+            contextId=context_id,
+            taskId=task_id,
+        )
+
+    @classmethod
+    def from_agent_text(
+        cls,
+        text: str,
+        *,
+        context_id: str | None = None,
+        task_id: str | None = None,
+    ) -> A2AMessage:
+        return cls(
+            role="agent",
+            parts=[A2APart(kind="text", text=text)],
+            contextId=context_id,
+            taskId=task_id,
+        )
+
+    @classmethod
+    def parse(cls, raw: Any) -> A2AMessage:
+        if isinstance(raw, cls):
+            return raw
+        if not isinstance(raw, dict):
+            raise ValueError("message must be an object")
+        parts_raw = raw.get("parts") or []
+        parts: list[A2APart] = []
+        for p in parts_raw:
+            if not isinstance(p, dict):
+                continue
+            kind = str(p.get("kind") or p.get("type") or "text")
+            if kind in {"text", "text/plain"}:
+                kind = "text"
+            parts.append(
+                A2APart(
+                    kind=kind,
+                    text=p.get("text"),
+                    file=p.get("file") if isinstance(p.get("file"), dict) else None,
+                    data=p.get("data") if isinstance(p.get("data"), dict) else None,
+                    metadata=p.get("metadata") if isinstance(p.get("metadata"), dict) else None,
+                )
+            )
+        if not parts and raw.get("content"):
+            parts = [A2APart(kind="text", text=str(raw["content"]))]
+        return cls(
+            role=str(raw.get("role") or "user"),
+            parts=parts,
+            messageId=str(raw.get("messageId") or raw.get("message_id") or new_id("msg_")),
+            contextId=raw.get("contextId") or raw.get("context_id"),
+            taskId=raw.get("taskId") or raw.get("task_id"),
+            metadata=raw.get("metadata") if isinstance(raw.get("metadata"), dict) else None,
+        )
+
+
+class A2ATaskStatus(BaseModel):
+    state: TaskState = TaskState.SUBMITTED
+    message: A2AMessage | None = None
+    timestamp: str = Field(default_factory=_now_iso)
+
+
+class A2AArtifact(BaseModel):
+    artifactId: str = Field(default_factory=lambda: new_id("art_"))
+    name: str | None = None
+    description: str | None = None
+    parts: list[A2APart] = Field(default_factory=list)
+    metadata: dict[str, Any] | None = None
+
+
+class A2ATask(BaseModel):
+    id: str = Field(default_factory=lambda: new_id("task_"))
+    contextId: str = Field(default_factory=lambda: new_id("ctx_"))
+    status: A2ATaskStatus = Field(default_factory=A2ATaskStatus)
+    history: list[A2AMessage] = Field(default_factory=list)
+    artifacts: list[A2AArtifact] = Field(default_factory=list)
+    metadata: dict[str, Any] | None = None
+    # Holix-internal
+    profile: str = "default"
+    conversation_id: str | None = None
+
+    def to_public_dict(self, *, history_length: int | None = None) -> dict[str, Any]:
+        history = list(self.history)
+        if history_length is not None:
+            if history_length <= 0:
+                history = []
+            else:
+                history = history[-history_length:]
+        payload = {
+            "id": self.id,
+            "contextId": self.contextId,
+            "status": {
+                "state": str(self.status.state.value if isinstance(self.status.state, TaskState) else self.status.state),
+                "timestamp": self.status.timestamp,
+            },
+            "artifacts": [a.model_dump(exclude_none=True) for a in self.artifacts],
+        }
+        if self.status.message is not None:
+            payload["status"]["message"] = self.status.message.model_dump(exclude_none=True)
+        if history:
+            payload["history"] = [m.model_dump(exclude_none=True) for m in history]
+        if self.metadata:
+            payload["metadata"] = self.metadata
+        return payload

--- a/core/a2a/server.py
+++ b/core/a2a/server.py
@@ -1,0 +1,365 @@
+"""Execute A2A messages against a Holix agent instance."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+from core.a2a.models import (
+    A2AArtifact,
+    A2AMessage,
+    A2APart,
+    A2ATask,
+    A2ATaskStatus,
+    TaskState,
+    new_id,
+)
+from core.a2a.store import A2ATaskStore, get_a2a_task_store
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _history_len(cfg: dict[str, Any]) -> int | None:
+    history_length = cfg.get("historyLength")
+    try:
+        return int(history_length) if history_length is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _prepare_task(
+    *,
+    message: A2AMessage | dict[str, Any],
+    profile: str,
+    store: A2ATaskStore | None,
+) -> tuple[A2AMessage, A2ATask, A2ATaskStore, str, str]:
+    msg = A2AMessage.parse(message) if not isinstance(message, A2AMessage) else message
+    text = msg.text_content()
+    if not text:
+        raise ValueError("message must include at least one text part")
+
+    task_store = store or get_a2a_task_store()
+    context_id = (msg.contextId or "").strip() or new_id("ctx_")
+    task_id = (msg.taskId or "").strip() or new_id("task_")
+    conversation_id = f"a2a:{context_id}"
+
+    existing = task_store.get(task_id)
+    if existing is not None:
+        task = existing
+        task.history.append(msg)
+    else:
+        task = A2ATask(
+            id=task_id,
+            contextId=context_id,
+            status=A2ATaskStatus(state=TaskState.WORKING, timestamp=_now()),
+            history=[msg],
+            profile=profile,
+            conversation_id=conversation_id,
+        )
+        task_store.put(task)
+
+    task.status = A2ATaskStatus(state=TaskState.WORKING, timestamp=_now())
+    task.conversation_id = conversation_id
+    task_store.put(task)
+    return msg, task, task_store, text, conversation_id
+
+
+def _complete_task(
+    task: A2ATask,
+    task_store: A2ATaskStore,
+    *,
+    answer: str,
+    failed: bool = False,
+) -> None:
+    context_id = task.contextId
+    task_id = task.id
+    agent_msg = A2AMessage.from_agent_text(
+        answer, context_id=context_id, task_id=task_id
+    )
+    task.history.append(agent_msg)
+    task.artifacts = [
+        A2AArtifact(
+            name="response",
+            description="Agent reply",
+            parts=[A2APart(kind="text", text=answer)],
+        )
+    ]
+    task.status = A2ATaskStatus(
+        state=TaskState.FAILED if failed else TaskState.COMPLETED,
+        message=agent_msg,
+        timestamp=_now(),
+    )
+    task_store.put(task)
+
+
+def _status_update(
+    task: A2ATask,
+    state: TaskState,
+    *,
+    message: A2AMessage | None = None,
+    final: bool = False,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "taskId": task.id,
+        "contextId": task.contextId,
+        "status": {
+            "state": state.value,
+            "timestamp": _now(),
+        },
+        "final": final,
+    }
+    if message is not None:
+        payload["status"]["message"] = message.model_dump(exclude_none=True)
+    return {"statusUpdate": payload}
+
+
+def _artifact_update(
+    task: A2ATask,
+    *,
+    text: str,
+    append: bool = True,
+    last_chunk: bool = False,
+    name: str = "response",
+) -> dict[str, Any]:
+    art_id = f"art_{task.id}"
+    return {
+        "artifactUpdate": {
+            "taskId": task.id,
+            "contextId": task.contextId,
+            "artifact": {
+                "artifactId": art_id,
+                "name": name,
+                "parts": [{"kind": "text", "text": text}],
+            },
+            "append": append,
+            "lastChunk": last_chunk,
+        }
+    }
+
+
+async def handle_message_send(
+    *,
+    agent: Any,
+    message: A2AMessage | dict[str, Any],
+    profile: str = "default",
+    configuration: dict[str, Any] | None = None,
+    store: A2ATaskStore | None = None,
+) -> dict[str, Any]:
+    """Process an A2A message and return a Task (blocking by default).
+
+    Maps A2A contextId → Holix conversation_id for multi-turn continuity.
+    """
+    cfg = configuration if isinstance(configuration, dict) else {}
+    _msg, task, task_store, text, conversation_id = _prepare_task(
+        message=message, profile=profile, store=store
+    )
+
+    try:
+        result = await agent.run(
+            user_input=text,
+            conversation_id=conversation_id,
+        )
+        answer = (result if isinstance(result, str) else str(result or "")).strip()
+        if not answer:
+            answer = "(empty response)"
+        _complete_task(task, task_store, answer=answer, failed=False)
+    except Exception as exc:
+        logger.exception("A2A message/send failed profile=%s task=%s", profile, task.id)
+        _complete_task(task, task_store, answer=f"Error: {exc}", failed=True)
+
+    return task.to_public_dict(history_length=_history_len(cfg))
+
+
+async def handle_message_stream(
+    *,
+    agent: Any,
+    message: A2AMessage | dict[str, Any],
+    profile: str = "default",
+    configuration: dict[str, Any] | None = None,
+    store: A2ATaskStore | None = None,
+) -> AsyncIterator[dict[str, Any]]:
+    """Yield A2A StreamResponse objects while running Holix with stream=True.
+
+    Sequence:
+    1. ``{"task": ...}`` — working task snapshot
+    2. zero+ ``{"statusUpdate": ...}`` / ``{"artifactUpdate": ...}`` for progress
+    3. final ``{"statusUpdate": ..., "final": true}`` and/or completed task fields
+    """
+    cfg = configuration if isinstance(configuration, dict) else {}
+    _msg, task, task_store, text, conversation_id = _prepare_task(
+        message=message, profile=profile, store=store
+    )
+    hist_n = _history_len(cfg)
+
+    # 1) Initial task event
+    yield {"task": task.to_public_dict(history_length=hist_n)}
+
+    answer_parts: list[str] = []
+    final_text = ""
+    last_tool = ""
+
+    try:
+        from core.agent_events import (
+            AssistantDeltaEvent,
+            ErrorEvent,
+            FinalResponseEvent,
+            ThinkingEvent,
+            ToolCallResultEvent,
+            ToolCallStartEvent,
+        )
+        from core.runtime.executor import run_holix
+
+        # Ensure agent ready
+        if not getattr(agent, "_initialized", True):
+            await agent.initialize()
+
+        async for event in run_holix(
+            agent,
+            text,
+            conversation_id,
+            stream=True,
+        ):
+            # Fan-out to agent bus when present (metrics / studio)
+            emit = getattr(agent, "emit", None)
+            if callable(emit):
+                try:
+                    emit(event)
+                except Exception:
+                    pass
+
+            if isinstance(event, ThinkingEvent):
+                note = (getattr(event, "message", None) or "thinking…")[:240]
+                yield _status_update(
+                    task,
+                    TaskState.WORKING,
+                    message=A2AMessage.from_agent_text(
+                        note, context_id=task.contextId, task_id=task.id
+                    ),
+                )
+            elif isinstance(event, ToolCallStartEvent):
+                last_tool = str(getattr(event, "tool_name", "") or "tool")
+                yield _status_update(
+                    task,
+                    TaskState.WORKING,
+                    message=A2AMessage.from_agent_text(
+                        f"tool: {last_tool}",
+                        context_id=task.contextId,
+                        task_id=task.id,
+                    ),
+                )
+            elif isinstance(event, ToolCallResultEvent):
+                tool = str(getattr(event, "tool_name", "") or last_tool or "tool")
+                yield _status_update(
+                    task,
+                    TaskState.WORKING,
+                    message=A2AMessage.from_agent_text(
+                        f"tool done: {tool}",
+                        context_id=task.contextId,
+                        task_id=task.id,
+                    ),
+                )
+            elif isinstance(event, AssistantDeltaEvent):
+                chunk = str(getattr(event, "content", None) or getattr(event, "delta", "") or "")
+                if chunk:
+                    answer_parts.append(chunk)
+                    yield _artifact_update(task, text=chunk, append=True, last_chunk=False)
+            elif isinstance(event, FinalResponseEvent):
+                final_text = (getattr(event, "content", None) or "").strip()
+            elif isinstance(event, ErrorEvent):
+                final_text = str(getattr(event, "error", None) or event)
+                _complete_task(task, task_store, answer=final_text or "Error", failed=True)
+                yield _status_update(
+                    task,
+                    TaskState.FAILED,
+                    message=task.status.message,
+                    final=True,
+                )
+                return
+
+        if not final_text and answer_parts:
+            final_text = "".join(answer_parts).strip()
+        if not final_text:
+            # Fallback non-stream if graph produced no final
+            try:
+                result = await agent.run(
+                    user_input=text,
+                    conversation_id=conversation_id,
+                )
+                final_text = (result if isinstance(result, str) else str(result or "")).strip()
+            except Exception:
+                final_text = ""
+        if not final_text:
+            final_text = "(empty response)"
+
+        _complete_task(task, task_store, answer=final_text, failed=False)
+        # Final artifact (full text) + status
+        yield _artifact_update(
+            task, text=final_text, append=False, last_chunk=True
+        )
+        yield _status_update(
+            task,
+            TaskState.COMPLETED,
+            message=task.status.message,
+            final=True,
+        )
+        # Optional full task snapshot for clients that only watch task objects
+        yield {"task": task.to_public_dict(history_length=hist_n)}
+    except Exception as exc:
+        logger.exception(
+            "A2A message/stream failed profile=%s task=%s", profile, task.id
+        )
+        _complete_task(task, task_store, answer=f"Error: {exc}", failed=True)
+        yield _status_update(
+            task,
+            TaskState.FAILED,
+            message=task.status.message,
+            final=True,
+        )
+
+
+
+def get_task_public(
+    task_id: str,
+    *,
+    store: A2ATaskStore | None = None,
+    history_length: int | None = None,
+    profile: str | None = None,
+) -> dict[str, Any] | None:
+    task_store = store or get_a2a_task_store()
+    task = task_store.get(task_id)
+    if task is None:
+        return None
+    if profile and task.profile != profile:
+        return None
+    return task.to_public_dict(history_length=history_length)
+
+
+def cancel_task(
+    task_id: str,
+    *,
+    store: A2ATaskStore | None = None,
+    profile: str | None = None,
+) -> dict[str, Any] | None:
+    task_store = store or get_a2a_task_store()
+    task = task_store.get(task_id)
+    if task is None:
+        return None
+    if profile and task.profile != profile:
+        return None
+    state = task.status.state
+    if state in {
+        TaskState.COMPLETED,
+        TaskState.FAILED,
+        TaskState.CANCELED,
+        TaskState.REJECTED,
+    }:
+        return task.to_public_dict()
+    task.status = A2ATaskStatus(state=TaskState.CANCELED, timestamp=_now())
+    task_store.put(task)
+    return task.to_public_dict()

--- a/core/a2a/store.py
+++ b/core/a2a/store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-from typing import Any
 
 from core.a2a.models import A2ATask
 

--- a/core/a2a/store.py
+++ b/core/a2a/store.py
@@ -1,0 +1,62 @@
+"""In-memory A2A task store (process-local; gateway lifetime)."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from core.a2a.models import A2ATask
+
+
+class A2ATaskStore:
+    """Thread-safe task registry for A2A server side."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._tasks: dict[str, A2ATask] = {}
+
+    def put(self, task: A2ATask) -> A2ATask:
+        with self._lock:
+            self._tasks[task.id] = task
+            return task
+
+    def get(self, task_id: str) -> A2ATask | None:
+        with self._lock:
+            return self._tasks.get(task_id)
+
+    def delete(self, task_id: str) -> bool:
+        with self._lock:
+            return self._tasks.pop(task_id, None) is not None
+
+    def list_tasks(
+        self,
+        *,
+        profile: str | None = None,
+        context_id: str | None = None,
+        limit: int = 50,
+    ) -> list[A2ATask]:
+        with self._lock:
+            items = list(self._tasks.values())
+        if profile:
+            items = [t for t in items if t.profile == profile]
+        if context_id:
+            items = [t for t in items if t.contextId == context_id]
+        items.sort(key=lambda t: t.status.timestamp, reverse=True)
+        return items[: max(1, min(int(limit or 50), 100))]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._tasks.clear()
+
+
+# Process-wide store for gateway
+_default_store: A2ATaskStore | None = None
+_store_lock = threading.Lock()
+
+
+def get_a2a_task_store() -> A2ATaskStore:
+    global _default_store
+    with _store_lock:
+        if _default_store is None:
+            _default_store = A2ATaskStore()
+        return _default_store

--- a/core/agent.py
+++ b/core/agent.py
@@ -334,6 +334,12 @@ class HolixAgent:
             from core.tools.sdd import register_sdd_dispatch_tool
 
             register_sdd_dispatch_tool(self.tools, self)
+        try:
+            from core.tools.a2a import register_a2a_tools
+
+            register_a2a_tools(self.tools, self)
+        except Exception:
+            pass
         # Register MCP tools (if configured in profile/runtime). Non-fatal.
         mcp_count = 0
         if getattr(self.config, "mcp_enabled", True) and getattr(self.config, "mcp_servers", None):

--- a/core/agent_events.py
+++ b/core/agent_events.py
@@ -35,6 +35,7 @@ class EventType(StrEnum):
     ASSISTANT_DELTA = "assistant_delta"
     FINAL_RESPONSE = "final_response"
     MAX_STEPS_REACHED = "max_steps_reached"
+    MAX_STEPS_EXTENDED = "max_steps_extended"
 
     # Tool execution
     TOOL_CALL_START = "tool_call_start"
@@ -235,6 +236,30 @@ class ToolCallErrorEvent(AgentEvent):
 class MaxStepsReachedEvent(AgentEvent):
     """Agent reached the configured max_steps limit."""
     max_steps: int = 90
+
+
+@dataclass
+class MaxStepsExtendedEvent(AgentEvent):
+    """Step budget was extended after a health/progress check at max_steps."""
+
+    max_steps: int = 90
+    previous_max_steps: int = 0
+    extra_steps: int = 0
+    extensions: int = 0
+    reason: str = ""
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.MAX_STEPS_EXTENDED)
+
+    def _extra_fields(self) -> dict[str, Any]:
+        return {
+            "max_steps": self.max_steps,
+            "previous_max_steps": self.previous_max_steps,
+            "extra_steps": self.extra_steps,
+            "extensions": self.extensions,
+            "reason": self.reason,
+        }
 
 
 @dataclass
@@ -741,6 +766,7 @@ def make_event(
         EventType.TOOL_CALL_ERROR: ToolCallErrorEvent,
         EventType.FINAL_RESPONSE: FinalResponseEvent,
         EventType.ERROR: ErrorEvent,
+        EventType.MAX_STEPS_EXTENDED: MaxStepsExtendedEvent,
         EventType.THINKING: ThinkingEvent,
         EventType.SKILL_CREATED: SkillCreatedEvent,
         EventType.CONTEXT_COMPRESSED: ContextCompressedEvent,
@@ -793,6 +819,11 @@ def create_compatibility_print_handler() -> EventHandler:
             print(event.content, end="", flush=True)
         elif isinstance(event, MaxStepsReachedEvent):
             print(f"Agent reached maximum steps ({event.max_steps}). Task may be too complex.")
+        elif isinstance(event, MaxStepsExtendedEvent):
+            print(
+                f"Step budget extended by {event.extra_steps} "
+                f"(now max {event.max_steps}): {event.reason or 'still working'}"
+            )
 
     return handler
 
@@ -833,6 +864,7 @@ __all__ = [
     "ToolCallResultEvent",
     "ToolCallErrorEvent",
     "MaxStepsReachedEvent",
+    "MaxStepsExtendedEvent",
     "ErrorEvent",
     "LLMCallStartedEvent",
     "LLMCallCompletedEvent",

--- a/core/agent_events.py
+++ b/core/agent_events.py
@@ -67,6 +67,7 @@ class EventType(StrEnum):
     SUBAGENT_STARTED = "subagent_started"
     SUBAGENT_PROGRESS = "subagent_progress"
     SUBAGENT_TIMEOUT_EXTENDED = "subagent_timeout_extended"
+    SUBAGENT_SUPERVISOR = "subagent_supervisor"
     SUBAGENT_FINISHED = "subagent_finished"
 
     # Background project processes
@@ -543,6 +544,38 @@ class SubAgentTimeoutExtendedEvent(AgentEvent):
 
 
 @dataclass
+class SubAgentSupervisorEvent(AgentEvent):
+    """Runtime supervisor intervened (or exhausted interventions) for a sub-agent."""
+
+    name: str = ""
+    agent_type: str = ""
+    kind: str = ""  # loop | thrash | hung | stall | ok
+    severity: str = ""
+    attempt: int = 0
+    max_interventions: int = 0
+    summary: str = ""
+    message: str = ""
+    exhausted: bool = False
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.SUBAGENT_SUPERVISOR)
+
+    def _extra_fields(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "agent_type": self.agent_type,
+            "kind": self.kind,
+            "severity": self.severity,
+            "attempt": self.attempt,
+            "max_interventions": self.max_interventions,
+            "summary": self.summary,
+            "message": self.message,
+            "exhausted": self.exhausted,
+        }
+
+
+@dataclass
 class SubAgentFinishedEvent(AgentEvent):
     """A delegated sub-agent finished (success, failure, cancel, or timeout)."""
 
@@ -880,6 +913,7 @@ __all__ = [
     "SubAgentStartedEvent",
     "SubAgentProgressEvent",
     "SubAgentTimeoutExtendedEvent",
+    "SubAgentSupervisorEvent",
     "SubAgentFinishedEvent",
     # helpers
     "make_event",

--- a/core/agent_execution.py
+++ b/core/agent_execution.py
@@ -33,6 +33,7 @@ from core.agent_events import (
     AssistantDeltaEvent,
     ErrorEvent,
     FinalResponseEvent,
+    MaxStepsExtendedEvent,
     MaxStepsReachedEvent,
     SelfImprovementStartedEvent,
     SkillCreatedEvent,
@@ -142,6 +143,8 @@ async def run_agent_loop(
     # ------------------------------------------------------------------
     step_count = 0
     max_steps = getattr(agent_config, "max_steps", settings.max_steps)
+    base_max_steps = int(max_steps or 0)
+    step_budget_extensions = 0
     model = getattr(agent, "model", settings.model)
     temperature = getattr(agent_config, "temperature", settings.temperature)
     client: AsyncOpenAI = agent.client
@@ -162,7 +165,8 @@ async def run_agent_loop(
         conversation_id=conversation_id,
     )
 
-    while step_count < max_steps:
+    while True:
+      while step_count < max_steps:
         step_count += 1
 
         # Build API messages: system prompt + recent messages
@@ -464,13 +468,50 @@ async def run_agent_loop(
             )
             return
 
-    # Max steps reached
-    yield MaxStepsReachedEvent(
-        max_steps=max_steps,
-        conversation_id=conversation_id,
-    )
-    timeout_msg = f"Agent reached maximum steps ({max_steps}). Task may be too complex."
-    await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
+      # Inner budget exhausted — health-check before hard stop
+      from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
+
+      decision = evaluate_step_budget(
+          step_count=step_count,
+          max_steps=max_steps,
+          extensions_used=step_budget_extensions,
+          messages=messages,
+          task=str(user_input or "")[:2000],
+          policy=StepBudgetPolicy.from_config(agent_config),
+          base_max_steps=base_max_steps,
+      )
+      if decision.extend:
+          prev_max = max_steps
+          max_steps = decision.new_max_steps
+          step_budget_extensions = decision.extensions_used
+          yield MaxStepsExtendedEvent(
+              max_steps=max_steps,
+              previous_max_steps=prev_max,
+              extra_steps=decision.extra_steps,
+              extensions=step_budget_extensions,
+              reason=decision.reason,
+              conversation_id=conversation_id,
+          )
+          yield ThinkingEvent(
+              message=(
+                  f"Step budget extended by {decision.extra_steps} "
+                  f"(now max {max_steps}): still working"
+              ),
+              conversation_id=conversation_id,
+          )
+          continue
+
+      # Max steps reached (hung / no progress / extension cap)
+      yield MaxStepsReachedEvent(
+          max_steps=max_steps,
+          conversation_id=conversation_id,
+      )
+      timeout_msg = (
+          f"Agent reached maximum steps ({max_steps}). "
+          f"{decision.reason or 'Task may be too complex.'}"
+      )
+      await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
+      return
 
 
 async def _maybe_self_improve(

--- a/core/config_utils.py
+++ b/core/config_utils.py
@@ -27,6 +27,26 @@ def substitute_env_in_string(text: str, *, leave_missing: bool = True) -> str:
     return _INLINE_ENV_REF.sub(_repl, text)
 
 
+def is_meta_agent_enabled(cfg: Any, *, default: bool = True) -> bool:
+    """Whether the meta-agent advisory node should run."""
+    if cfg is None:
+        return default
+    value = getattr(cfg, "enable_meta_agent", None)
+    if value is None:
+        return default
+    return bool(value)
+
+
+def is_self_refinement_enabled(cfg: Any, *, default: bool = True) -> bool:
+    """Whether Reflexion / self-refinement after draft answers is enabled."""
+    if cfg is None:
+        return default
+    value = getattr(cfg, "enable_self_refinement", None)
+    if value is None:
+        return default
+    return bool(value)
+
+
 def is_subagents_enabled(cfg: Any, *, default: bool = True) -> bool:
     """Return whether sub-agents are enabled (default on when unset)."""
     if cfg is None:
@@ -61,6 +81,9 @@ _LOCAL_SYSTEM_KEYS: frozenset[str] = frozenset({
     "model", "base_url", "api_key", "temperature", "max_steps",
     "max_steps_extend_enabled", "max_steps_extend_by",
     "max_steps_max_extensions", "max_steps_hard_cap",
+    "subagent_supervisor_enabled", "subagent_supervisor_poll_s",
+    "subagent_supervisor_idle_s", "subagent_supervisor_max_interventions",
+    "subagent_supervisor_cooldown_s",
     "providers", "agent_models", "default_provider",
     "auto_allow_threshold", "non_interactive", "confirmation_timeout",
     "plan_review_enabled", "plan_review_timeout",

--- a/core/config_utils.py
+++ b/core/config_utils.py
@@ -59,6 +59,8 @@ from pathlib import Path
 
 _LOCAL_SYSTEM_KEYS: frozenset[str] = frozenset({
     "model", "base_url", "api_key", "temperature", "max_steps",
+    "max_steps_extend_enabled", "max_steps_extend_by",
+    "max_steps_max_extensions", "max_steps_hard_cap",
     "providers", "agent_models", "default_provider",
     "auto_allow_threshold", "non_interactive", "confirmation_timeout",
     "plan_review_enabled", "plan_review_timeout",

--- a/core/di/runtime_config.py
+++ b/core/di/runtime_config.py
@@ -44,6 +44,7 @@ class HolixRuntimeConfig:
     subagent_max_concurrent: int
     subagent_process_timeout: float
     subagent_heartbeat_interval: float
+    subagent_supervisor_enabled: bool
 
     # Meta-agent / refinement / evolution
     enable_meta_agent: bool
@@ -52,6 +53,12 @@ class HolixRuntimeConfig:
     refinement_quality_threshold: float
     enable_evolution: bool
     evolution_auto_learn: bool
+
+    # Step budget auto-extension when agent is still making progress
+    max_steps_extend_enabled: bool
+    max_steps_extend_by: int
+    max_steps_max_extensions: int
+    max_steps_hard_cap: int
 
     # Safety / plan review
     auto_allow_threshold: str
@@ -141,12 +148,23 @@ class HolixRuntimeConfig:
             subagent_max_concurrent=s.subagent_max_concurrent,
             subagent_process_timeout=s.subagent_process_timeout,
             subagent_heartbeat_interval=s.subagent_heartbeat_interval,
+            subagent_supervisor_enabled=bool(
+                getattr(s, "subagent_supervisor_enabled", True)
+            ),
             enable_meta_agent=s.enable_meta_agent,
             enable_self_refinement=s.enable_self_refinement,
             max_refinement_iterations=s.max_refinement_iterations,
             refinement_quality_threshold=s.refinement_quality_threshold,
             enable_evolution=s.enable_evolution,
             evolution_auto_learn=s.evolution_auto_learn,
+            max_steps_extend_enabled=bool(
+                getattr(s, "max_steps_extend_enabled", True)
+            ),
+            max_steps_extend_by=int(getattr(s, "max_steps_extend_by", 30) or 30),
+            max_steps_max_extensions=int(
+                getattr(s, "max_steps_max_extensions", 3) or 3
+            ),
+            max_steps_hard_cap=int(getattr(s, "max_steps_hard_cap", 0) or 0),
             auto_allow_threshold=s.auto_allow_threshold,
             non_interactive=s.non_interactive,
             confirmation_timeout=s.confirmation_timeout,
@@ -231,6 +249,18 @@ class HolixRuntimeConfig:
             overrides["subagent_default_process_mode"] = profile.subagent_default_process_mode
         if getattr(profile, "subagent_max_concurrent", None) is not None:
             overrides["subagent_max_concurrent"] = profile.subagent_max_concurrent
+        if getattr(profile, "subagent_supervisor_enabled", None) is not None:
+            overrides["subagent_supervisor_enabled"] = bool(
+                profile.subagent_supervisor_enabled
+            )
+        if getattr(profile, "enable_meta_agent", None) is not None:
+            overrides["enable_meta_agent"] = bool(profile.enable_meta_agent)
+        if getattr(profile, "enable_self_refinement", None) is not None:
+            overrides["enable_self_refinement"] = bool(profile.enable_self_refinement)
+        if getattr(profile, "max_steps_extend_enabled", None) is not None:
+            overrides["max_steps_extend_enabled"] = bool(
+                profile.max_steps_extend_enabled
+            )
         if getattr(profile, "search", None):
             overrides["search"] = profile.search
         overrides["workspace_jail_enabled"] = bool(

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -59,6 +59,8 @@ def prepare_initial_state(
         "relevant_strategies": [],
         "step_count": 0,
         "max_steps": max_steps,
+        "base_max_steps": max_steps,
+        "step_budget_extensions": 0,
         "max_steps_per_plan_step": max_per_step,
         "execution_mode": execution_mode,
         "is_final": False,

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -69,6 +69,8 @@ def prepare_initial_state(
         "needs_refinement": False,
         "refinement_iterations": 0,
         "max_refinement_iterations": max_refinement,
+        "reflection_count": 0,
+        "reflection_log": [],
         "plan_steps": [],
         "current_plan_step": 0,
         "plan_status": "pending_review",
@@ -87,6 +89,11 @@ def prepare_initial_state(
         "pending_subagent": None,
         # Per user turn (must reset: checkpoint otherwise freezes honesty forever)
         "honesty_nudge_count": 0,
+        "supervisor_needs_rework": False,
+        "supervisor_rework_tasks": [],
+        "supervisor_rework_round": 0,
+        "supervisor_log": [],
+        "supervisor_last_diagnosis": None,
     }
 
 

--- a/core/graph/modes/hybrid.py
+++ b/core/graph/modes/hybrid.py
@@ -1,4 +1,4 @@
-"""Hybrid execution mode graph (plan + ReAct)."""
+"""Hybrid execution mode graph (plan + ReAct) with meta-agent + Reflexion."""
 
 from __future__ import annotations
 
@@ -9,15 +9,18 @@ from langgraph.graph import END, START, StateGraph
 from core.graph.modes._compile import compile_mode_graph
 from core.graph.nodes.finalize_node import finalize_node
 from core.graph.nodes.memory_retrieval_node import memory_retrieval_node
+from core.graph.nodes.meta_agent_node import meta_agent_node
 from core.graph.nodes.plan_clarify_node import plan_clarify_node
 from core.graph.nodes.plan_node import plan_node
 from core.graph.nodes.plan_review_node import plan_review_node
 from core.graph.nodes.react_node import react_node
+from core.graph.nodes.reflect_node import reflect_node
 from core.graph.nodes.tool_execution_node import tool_execution_node
 from core.graph.routers import (
     route_after_plan_clarify,
     route_after_plan_review_hybrid,
     route_after_react,
+    route_after_reflect,
 )
 from core.graph.state import HolixGraphState
 
@@ -29,15 +32,18 @@ def build_hybrid_graph(
 ):
     graph = StateGraph(HolixGraphState)
     graph.add_node("memory_retrieval", memory_retrieval_node)
+    graph.add_node("meta_agent", meta_agent_node)
     graph.add_node("plan", plan_node)
     graph.add_node("plan_clarify", plan_clarify_node)
     graph.add_node("plan_review", plan_review_node)
     graph.add_node("react", react_node)
     graph.add_node("tool_execution", tool_execution_node)
+    graph.add_node("reflect", reflect_node)
     graph.add_node("finalize", finalize_node)
 
     graph.add_edge(START, "memory_retrieval")
-    graph.add_edge("memory_retrieval", "plan")
+    graph.add_edge("memory_retrieval", "meta_agent")
+    graph.add_edge("meta_agent", "plan")
     graph.add_edge("plan", "plan_clarify")
     graph.add_conditional_edges(
         "plan_clarify",
@@ -52,9 +58,18 @@ def build_hybrid_graph(
     graph.add_conditional_edges(
         "react",
         route_after_react,
-        {"tool_execution": "tool_execution", "finalize": "finalize"},
+        {
+            "tool_execution": "tool_execution",
+            "reflect": "reflect",
+            "finalize": "finalize",
+        },
     )
     graph.add_edge("tool_execution", "react")
+    graph.add_conditional_edges(
+        "reflect",
+        route_after_reflect,
+        {"react": "react", "finalize": "finalize"},
+    )
     graph.add_edge("finalize", END)
 
     return compile_mode_graph(

--- a/core/graph/modes/plan_execute.py
+++ b/core/graph/modes/plan_execute.py
@@ -11,17 +11,22 @@ from core.graph.nodes.collect_subagent_node import collect_subagent_node
 from core.graph.nodes.delegate_subagent_node import delegate_subagent_node
 from core.graph.nodes.finalize_node import finalize_node
 from core.graph.nodes.memory_retrieval_node import memory_retrieval_node
+from core.graph.nodes.meta_agent_node import meta_agent_node
 from core.graph.nodes.plan_clarify_node import plan_clarify_node
 from core.graph.nodes.plan_node import plan_node
 from core.graph.nodes.plan_review_node import plan_review_node
 from core.graph.nodes.react_node import react_node
+from core.graph.nodes.reflect_node import reflect_node
 from core.graph.nodes.step_orchestrate_node import step_orchestrate_node
+from core.graph.nodes.supervisor_node import supervisor_node
 from core.graph.nodes.tool_execution_node import tool_execution_node
 from core.graph.routers import (
     route_after_plan_clarify,
     route_after_plan_review,
     route_after_react_plan,
+    route_after_reflect,
     route_after_step_orchestrate,
+    route_after_supervisor,
 )
 from core.graph.state import HolixGraphState
 
@@ -33,18 +38,22 @@ def build_plan_and_execute_graph(
 ):
     graph = StateGraph(HolixGraphState)
     graph.add_node("memory_retrieval", memory_retrieval_node)
+    graph.add_node("meta_agent", meta_agent_node)
     graph.add_node("plan", plan_node)
     graph.add_node("plan_clarify", plan_clarify_node)
     graph.add_node("plan_review", plan_review_node)
     graph.add_node("step_orchestrate", step_orchestrate_node)
     graph.add_node("delegate_subagent", delegate_subagent_node)
     graph.add_node("collect_subagent", collect_subagent_node)
+    graph.add_node("supervisor", supervisor_node)
     graph.add_node("react", react_node)
     graph.add_node("tool_execution", tool_execution_node)
+    graph.add_node("reflect", reflect_node)
     graph.add_node("finalize", finalize_node)
 
     graph.add_edge(START, "memory_retrieval")
-    graph.add_edge("memory_retrieval", "plan")
+    graph.add_edge("memory_retrieval", "meta_agent")
+    graph.add_edge("meta_agent", "plan")
     graph.add_edge("plan", "plan_clarify")
     graph.add_conditional_edges(
         "plan_clarify",
@@ -66,18 +75,34 @@ def build_plan_and_execute_graph(
         },
     )
     graph.add_edge("delegate_subagent", "collect_subagent")
-    graph.add_edge("collect_subagent", "react")
+    # Graph-native supervisor cycle: collect → diagnose → rework or synthesize
+    graph.add_edge("collect_subagent", "supervisor")
+    graph.add_conditional_edges(
+        "supervisor",
+        route_after_supervisor,
+        {
+            "delegate_subagent": "delegate_subagent",
+            "react": "react",
+            "finalize": "finalize",
+        },
+    )
     graph.add_conditional_edges(
         "react",
         route_after_react_plan,
         {
             "tool_execution": "tool_execution",
             "step_orchestrate": "step_orchestrate",
+            "reflect": "reflect",
             "finalize": "finalize",
             "react": "react",
         },
     )
     graph.add_edge("tool_execution", "react")
+    graph.add_conditional_edges(
+        "reflect",
+        route_after_reflect,
+        {"react": "react", "finalize": "finalize"},
+    )
     graph.add_edge("finalize", END)
 
     return compile_mode_graph(

--- a/core/graph/modes/react.py
+++ b/core/graph/modes/react.py
@@ -1,4 +1,4 @@
-"""ReAct execution mode graph."""
+"""ReAct execution mode graph with meta-agent + Reflexion cycle."""
 
 from __future__ import annotations
 
@@ -9,9 +9,11 @@ from langgraph.graph import END, START, StateGraph
 from core.graph.modes._compile import compile_mode_graph
 from core.graph.nodes.finalize_node import finalize_node
 from core.graph.nodes.memory_retrieval_node import memory_retrieval_node
+from core.graph.nodes.meta_agent_node import meta_agent_node
 from core.graph.nodes.react_node import react_node
+from core.graph.nodes.reflect_node import reflect_node
 from core.graph.nodes.tool_execution_node import tool_execution_node
-from core.graph.routers import route_after_react
+from core.graph.routers import route_after_react, route_after_reflect
 from core.graph.state import HolixGraphState
 
 
@@ -22,18 +24,30 @@ def build_react_graph(
 ):
     graph = StateGraph(HolixGraphState)
     graph.add_node("memory_retrieval", memory_retrieval_node)
+    graph.add_node("meta_agent", meta_agent_node)
     graph.add_node("react", react_node)
     graph.add_node("tool_execution", tool_execution_node)
+    graph.add_node("reflect", reflect_node)
     graph.add_node("finalize", finalize_node)
 
     graph.add_edge(START, "memory_retrieval")
-    graph.add_edge("memory_retrieval", "react")
+    graph.add_edge("memory_retrieval", "meta_agent")
+    graph.add_edge("meta_agent", "react")
     graph.add_conditional_edges(
         "react",
         route_after_react,
-        {"tool_execution": "tool_execution", "finalize": "finalize"},
+        {
+            "tool_execution": "tool_execution",
+            "reflect": "reflect",
+            "finalize": "finalize",
+        },
     )
     graph.add_edge("tool_execution", "react")
+    graph.add_conditional_edges(
+        "reflect",
+        route_after_reflect,
+        {"react": "react", "finalize": "finalize"},
+    )
     graph.add_edge("finalize", END)
 
     return compile_mode_graph(

--- a/core/graph/nodes/collect_subagent_node.py
+++ b/core/graph/nodes/collect_subagent_node.py
@@ -64,10 +64,34 @@ async def collect_subagent_node(
         )
         results = {job_id: payload for job_id, payload in zip(pending, payloads, strict=True)}
 
+        orch_raw = state.get("subagent_orchestration")
+        total_waves = 1
+        if orch_raw:
+            total_waves = len(OrchestrationPlan.from_dict(orch_raw).waves) or 1
+
+        sub_results = dict(state.get("sub_agent_results", {}))
+        for job_id, payload in results.items():
+            sub_results[job_id] = payload
+
+        # Merge into existing wave slot (supervisor rework must not drop prior successes).
+        # Rework jobs supersede their prior_job so failed attempts do not re-trigger forever.
+        wave_results = dict(state.get("subagent_wave_results", {}))
+        prior_wave = dict(wave_results.get(str(wave_idx)) or {})
+        merged_wave = dict(prior_wave)
+        for job_id, payload in results.items():
+            meta = task_meta_raw.get(job_id) or {}
+            prior_job = str(meta.get("prior_job") or "")
+            if prior_job and prior_job in merged_wave:
+                merged_wave.pop(prior_job, None)
+                sub_results.pop(prior_job, None)
+            merged_wave[job_id] = payload
+        wave_results[str(wave_idx)] = merged_wave
+
         task_meta: dict[str, SubagentTask] = {}
         step_indices: list[int] = []
-        for job_id, meta in task_meta_raw.items():
-            if job_id not in results:
+        for job_id in merged_wave:
+            meta = task_meta_raw.get(job_id) or {}
+            if not meta:
                 continue
             task_meta[job_id] = SubagentTask(
                 agent_type=str(meta.get("agent_type", "")),
@@ -77,38 +101,27 @@ async def collect_subagent_node(
             )
             step_indices.append(int(meta.get("step_index", 0)))
 
-        orch_raw = state.get("subagent_orchestration")
-        total_waves = 1
-        if orch_raw:
-            total_waves = len(OrchestrationPlan.from_dict(orch_raw).waves) or 1
-
         aggregate = format_wave_aggregate(
             wave_id=wave_idx,
             total_waves=total_waves,
-            results=results,
+            results=merged_wave,
             task_meta=task_meta,
         )
         user_summary = format_wave_user_summary(
             wave_id=wave_idx,
             total_waves=total_waves,
-            results=results,
+            results=merged_wave,
             task_meta=task_meta,
         )
-
-        sub_results = dict(state.get("sub_agent_results", {}))
-        for job_id, payload in results.items():
-            sub_results[job_id] = payload
-
-        wave_results = dict(state.get("subagent_wave_results", {}))
-        wave_results[str(wave_idx)] = results
 
         messages = list(state.get("messages", []))
         messages.append({"role": "user", "content": aggregate})
 
-        completed = sum(1 for p in results.values() if p.get("success"))
+        completed = sum(1 for p in merged_wave.values() if p.get("success"))
         log_subagent_event(
             "INFO",
-            f"wave {wave_idx + 1}/{total_waves} collected {completed}/{len(results)}",
+            f"wave {wave_idx + 1}/{total_waves} collected {completed}/{len(merged_wave)}"
+            f" (batch={len(results)})",
             subagent=",".join(pending),
         )
         if agent and hasattr(agent, "emit"):
@@ -119,7 +132,7 @@ async def collect_subagent_node(
                     wave_id=wave_idx,
                     total_waves=total_waves,
                     completed=completed,
-                    total=len(results),
+                    total=len(merged_wave),
                     summary=user_summary,
                     conversation_id=state.get("conversation_id", "default"),
                 )

--- a/core/graph/nodes/delegate_subagent_node.py
+++ b/core/graph/nodes/delegate_subagent_node.py
@@ -43,11 +43,73 @@ def _resolve_orchestration(
     return plan
 
 
+async def _spawn_task_list(
+    *,
+    agent: Any,
+    cfg: Any,
+    tasks: list[Any],
+    wave_id: int,
+    tasks_log: list[dict[str, Any]],
+    label: str,
+) -> tuple[list[str], dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    """Spawn a list of SubagentTask-like objects (or rework dicts)."""
+    manager = agent.subagents
+    pending: list[str] = []
+    task_meta: dict[str, dict[str, Any]] = {}
+
+    for task in tasks:
+        prior_job = ""
+        if isinstance(task, dict):
+            agent_type = str(task.get("agent_type") or "coder")
+            task_text = str(task.get("task") or "")
+            step_ref = int(task.get("step_ref") or 0)
+            step_index = int(task.get("step_index") or 0)
+            prior_job = str(task.get("prior_job") or "")
+        else:
+            agent_type = task.agent_type
+            task_text = task.task
+            step_ref = task.step_ref
+            step_index = task.step_index
+
+        instance = manager.allocate_name(agent_type)
+        sub_cfg = prepare_subagent_config(
+            agent_type,
+            cfg,
+            instance_name=instance,
+        )
+        handle = await manager.spawn_sub_agent(
+            sub_cfg,
+            task_text,
+            agent_type=agent_type,
+        )
+        pending.append(handle.name)
+        meta_entry: dict[str, Any] = {
+            "agent_type": agent_type,
+            "task": task_text,
+            "step_ref": step_ref,
+            "step_index": step_index,
+        }
+        if prior_job:
+            meta_entry["prior_job"] = prior_job
+        task_meta[handle.name] = meta_entry
+        tasks_log.append(
+            {
+                "type": agent_type,
+                "task": task_text[:500],
+                "handle": handle.name,
+                "process_mode": handle.config.process_mode.value,
+                "wave_id": wave_id,
+                "label": label,
+            }
+        )
+    return pending, task_meta, tasks_log
+
+
 async def delegate_subagent_node(
     state: HolixGraphState,
     config: RunnableConfig,
 ) -> dict[str, Any]:
-    """Spawn sub-agent(s) for the current orchestration wave."""
+    """Spawn sub-agent(s) for the current orchestration wave or supervisor rework."""
     agent = get_agent_from_config(config)
     if not agent:
         return {}
@@ -59,6 +121,56 @@ async def delegate_subagent_node(
         return {}
 
     from core.profile.soul import profile_name_from_agent
+
+    tasks_log = list(state.get("sub_agent_tasks", []))
+    rework = list(state.get("supervisor_rework_tasks") or [])
+
+    # --- Graph supervisor rework path (same agent types, guided tasks) ---
+    if rework and state.get("supervisor_needs_rework"):
+        try:
+            # Keep wave index stable for collect (collect will +1 again).
+            # Rework results land under current_subagent_wave before collect bumps.
+            wave_idx = max(0, int(state.get("current_subagent_wave", 1) or 1) - 1)
+            pending, new_meta, tasks_log = await _spawn_task_list(
+                agent=agent,
+                cfg=cfg,
+                tasks=rework,
+                wave_id=wave_idx,
+                tasks_log=tasks_log,
+                label="supervisor_rework",
+            )
+            # Preserve meta for successful jobs from the same wave (not re-run)
+            task_meta = dict(state.get("subagent_task_meta") or {})
+            for job_id, meta in new_meta.items():
+                prior = str(meta.get("prior_job") or "")
+                if prior:
+                    task_meta.pop(prior, None)
+                task_meta[job_id] = meta
+            log_subagent_event(
+                "INFO",
+                f"supervisor rework started ({len(pending)} job(s))",
+                subagent=",".join(pending),
+                task_count=len(pending),
+            )
+            return {
+                "pending_subagents": pending,
+                "pending_subagent": pending[0] if len(pending) == 1 else None,
+                "subagent_task_meta": task_meta,
+                "sub_agent_tasks": tasks_log,
+                "subagent_delegate_next": False,
+                "is_step_complete": False,
+                "supervisor_needs_rework": False,
+                "supervisor_rework_tasks": [],
+                # Roll wave index back so collect stores under the same wave slot
+                "current_subagent_wave": wave_idx,
+            }
+        except Exception as exc:
+            logger.warning("Supervisor rework delegation failed: %s", exc)
+            return {
+                "subagent_delegate_next": False,
+                "supervisor_needs_rework": False,
+                "supervisor_rework_tasks": [],
+            }
 
     orchestration = _resolve_orchestration(
         state,
@@ -74,40 +186,15 @@ async def delegate_subagent_node(
     if wave is None:
         return {"subagent_delegate_next": False}
 
-    manager = agent.subagents
-    pending: list[str] = []
-    task_meta: dict[str, dict[str, Any]] = {}
-    tasks_log = list(state.get("sub_agent_tasks", []))
-
     try:
-        for task in wave.tasks:
-            instance = manager.allocate_name(task.agent_type)
-            sub_cfg = prepare_subagent_config(
-                task.agent_type,
-                cfg,
-                instance_name=instance,
-            )
-            handle = await manager.spawn_sub_agent(
-                sub_cfg,
-                task.task,
-                agent_type=task.agent_type,
-            )
-            pending.append(handle.name)
-            task_meta[handle.name] = {
-                "agent_type": task.agent_type,
-                "task": task.task,
-                "step_ref": task.step_ref,
-                "step_index": task.step_index,
-            }
-            tasks_log.append(
-                {
-                    "type": task.agent_type,
-                    "task": task.task,
-                    "handle": handle.name,
-                    "process_mode": handle.config.process_mode.value,
-                    "wave_id": wave.wave_id,
-                }
-            )
+        pending, task_meta, tasks_log = await _spawn_task_list(
+            agent=agent,
+            cfg=cfg,
+            tasks=list(wave.tasks),
+            wave_id=wave.wave_id,
+            tasks_log=tasks_log,
+            label="wave",
+        )
 
         log_subagent_event(
             "INFO",
@@ -136,6 +223,8 @@ async def delegate_subagent_node(
             "sub_agent_tasks": tasks_log,
             "subagent_delegate_next": False,
             "is_step_complete": False,
+            "supervisor_needs_rework": False,
+            "supervisor_rework_tasks": [],
         }
     except Exception as exc:
         logger.warning("Sub-agent wave delegation failed: %s", exc)

--- a/core/graph/nodes/meta_agent_node.py
+++ b/core/graph/nodes/meta_agent_node.py
@@ -35,6 +35,12 @@ async def meta_agent_node(state: HolixGraphState, config: RunnableConfig) -> dic
     agent = get_agent_from_config(config)
     user_input = state.get("user_input", "")
 
+    from core.config_utils import is_meta_agent_enabled
+
+    cfg = getattr(agent, "config", None) if agent else None
+    if not is_meta_agent_enabled(cfg, default=True):
+        return {"meta_decision": None}
+
     if not agent or not hasattr(agent, "client"):
         logger.debug("Meta-agent: no agent/client available, skipping")
         return {"meta_decision": None}

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -474,6 +474,14 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
                 max_tokens=max_tokens,
                 tool_choice=tool_choice,
             )
+        from core.runtime.step_budget import maybe_extend_for_graph_result
+
+        result = maybe_extend_for_graph_result(
+            state,
+            result,
+            agent=agent,
+            task=str(state.get("user_input") or ""),
+        )
         return _merge_state_patch(result, messages_patch)
 
     except LLMStepTimeoutError as exc:

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -1302,6 +1302,26 @@ def _build_system_prompt_from_state(state: HolixGraphState, agent=None) -> str:
     if plan_context:
         combined_memories = f"{combined_memories}\n{plan_context}" if combined_memories else plan_context
 
+    # Meta-agent strategic hint (pre-thinking)
+    meta = state.get("meta_decision") or {}
+    if isinstance(meta, dict):
+        hint = str(meta.get("context_hint") or "").strip()
+        if hint:
+            block = f"\n\n## Meta-agent guidance\n{hint}\n"
+            combined_memories = f"{combined_memories}{block}" if combined_memories else block.strip()
+
+    # Prior Reflexion notes this turn (verbal self-reflection memory)
+    reflection_log = list(state.get("reflection_log") or [])
+    if reflection_log:
+        last = reflection_log[-1]
+        areas = ", ".join(last.get("improvement_areas") or []) or "quality"
+        refl = (
+            f"\n\n## Prior self-reflection (this turn)\n"
+            f"Last quality≈{last.get('quality_score', '?')}; focus on: {areas}.\n"
+            f"{(last.get('refinement_prompt') or last.get('reasoning') or '')[:400]}\n"
+        )
+        combined_memories = f"{combined_memories}{refl}" if combined_memories else refl.strip()
+
     profile_name = profile_name_from_agent(agent) if agent else "default"
     agent_config = getattr(agent, "config", None) if agent else None
     persona_name = getattr(agent, "studio_agent_type", None) if agent else None

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -23,7 +23,6 @@ from core.agent_events import (
     ToolCallStartEvent,
 )
 from core.graph.action_honesty import (
-    denies_visible_workspace,
     has_successful_workspace_listing,
     honesty_refusal_update,
     honesty_retry_update,

--- a/core/graph/nodes/reflect_node.py
+++ b/core/graph/nodes/reflect_node.py
@@ -93,7 +93,13 @@ async def _persist_reflection(
     will_retry: bool,
 ) -> None:
     memory = getattr(agent, "memory", None)
-    if not memory or not hasattr(memory, "episodic"):
+    if not memory:
+        return
+    # Memory facade properties raise RuntimeError when LTM is disabled —
+    # do not use hasattr() (it re-raises non-AttributeError from the property).
+    try:
+        episodic = memory.episodic
+    except Exception:
         return
     try:
         outcome = "retry" if will_retry else "accept"
@@ -102,7 +108,7 @@ async def _persist_reflection(
             f"needs_refinement={assessment.needs_refinement}, outcome={outcome}, "
             f"areas={', '.join(assessment.improvement_areas[:3])}"
         )
-        await memory.episodic.store_episode(
+        await episodic.store_episode(
             conversation_id=conversation_id,
             summary=summary,
             outcome=outcome,
@@ -115,18 +121,23 @@ async def _persist_reflection(
                 "will_retry": will_retry,
             },
         )
-        if will_retry and assessment.improvement_areas and hasattr(memory, "strategic"):
-            key = f"reflexion_{(assessment.improvement_areas[0] or 'general')[:40]}"
-            await memory.strategic.store_strategy(
-                key=key,
-                content=(
-                    f"When quality is low on '{assessment.improvement_areas[0]}', "
-                    f"apply: {(assessment.refinement_prompt or '')[:300]}"
-                ),
-                category="reflexion",
-                source="reflexion",
-                metadata={"quality_score": assessment.quality_score},
-            )
+        if will_retry and assessment.improvement_areas:
+            try:
+                strategic = memory.strategic
+            except Exception:
+                strategic = None
+            if strategic is not None:
+                key = f"reflexion_{(assessment.improvement_areas[0] or 'general')[:40]}"
+                await strategic.store_strategy(
+                    key=key,
+                    content=(
+                        f"When quality is low on '{assessment.improvement_areas[0]}', "
+                        f"apply: {(assessment.refinement_prompt or '')[:300]}"
+                    ),
+                    category="reflexion",
+                    source="reflexion",
+                    metadata={"quality_score": assessment.quality_score},
+                )
     except Exception:
         logger.debug("Failed to persist reflexion episode", exc_info=True)
 

--- a/core/graph/nodes/reflect_node.py
+++ b/core/graph/nodes/reflect_node.py
@@ -1,0 +1,285 @@
+"""Reflexion node — verbal self-reflection after a draft answer, then optional retry.
+
+Classic Reflexion loop (simplified for Holix):
+
+1. Agent produces a draft (``is_final`` / end of ReAct turn)
+2. MetaAgent evaluates answer (+ optional tool trajectory)
+3. If quality is low → append reflection to messages, clear final, route back to react
+4. Reflections are logged in state and stored to episodic LTM when available
+
+Disabled when ``enable_self_refinement`` is false (node becomes a pass-through).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langchain_core.runnables import RunnableConfig
+
+from core.config_utils import is_self_refinement_enabled
+from core.graph.state import HolixGraphState, get_agent_from_config
+from core.meta_agent import MetaAgent, QualityAssessment
+from core.presenters.final_content import is_aborted_final_response, is_placeholder_final
+
+logger = logging.getLogger(__name__)
+
+
+def _trajectory_summary(state: HolixGraphState, *, max_items: int = 8) -> str:
+    """Compact tool/assistant trajectory for the evaluator."""
+    lines: list[str] = []
+    messages = list(state.get("messages") or [])
+    for msg in messages[-40:]:
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls"):
+            for tc in msg.get("tool_calls") or []:
+                fn = tc.get("function") if isinstance(tc, dict) else None
+                if not isinstance(fn, dict):
+                    fn = {}
+                name = str(fn.get("name") or tc.get("name") or "?")
+                args = str(fn.get("arguments") or "")[:120]
+                lines.append(f"tool_call: {name}({args})")
+        elif role == "tool":
+            content = str(msg.get("content") or "")
+            preview = content.replace("\n", " ")[:160]
+            err = content.lower().startswith("error") or "traceback" in content.lower()
+            tag = "tool_error" if err else "tool_result"
+            lines.append(f"{tag}: {preview}")
+    if not lines:
+        # Fall back to last tool_results in state
+        for tr in list(state.get("tool_results") or [])[-max_items:]:
+            name = str(tr.get("name") or tr.get("tool_name") or "tool")
+            content = str(tr.get("content") or tr.get("result") or "")[:160]
+            lines.append(f"tool: {name} → {content}")
+    return "\n".join(lines[-max_items:])
+
+
+def _format_reflection_message(
+    assessment: QualityAssessment,
+    *,
+    iteration: int,
+    trajectory: str,
+) -> str:
+    areas = ", ".join(assessment.improvement_areas[:5]) if assessment.improvement_areas else "general quality"
+    traj_block = ""
+    if trajectory.strip():
+        traj_block = f"\n### Recent trajectory (tools)\n{trajectory}\n"
+
+    suggestion = (assessment.refinement_prompt or "").strip() or (
+        "Revise the answer to fully address the user task with correct, concrete results."
+    )
+    return (
+        f"## Reflexion (iteration {iteration})\n"
+        f"Your previous answer was evaluated and needs improvement "
+        f"(quality≈{assessment.quality_score:.2f}).\n\n"
+        f"**Issues:** {areas}\n"
+        f"**Reasoning:** {(assessment.reasoning or '')[:500]}\n"
+        f"{traj_block}\n"
+        f"### Self-reflection directive\n"
+        f"{suggestion}\n\n"
+        f"Produce an **improved final answer**. "
+        f"Do not repeat the same incomplete claim. "
+        f"Use tools if needed to verify or complete the work."
+    )
+
+
+async def _persist_reflection(
+    agent: Any,
+    *,
+    conversation_id: str,
+    user_input: str,
+    assessment: QualityAssessment,
+    iteration: int,
+    will_retry: bool,
+) -> None:
+    memory = getattr(agent, "memory", None)
+    if not memory or not hasattr(memory, "episodic"):
+        return
+    try:
+        outcome = "retry" if will_retry else "accept"
+        summary = (
+            f"Reflexion #{iteration}: quality={assessment.quality_score:.2f}, "
+            f"needs_refinement={assessment.needs_refinement}, outcome={outcome}, "
+            f"areas={', '.join(assessment.improvement_areas[:3])}"
+        )
+        await memory.episodic.store_episode(
+            conversation_id=conversation_id,
+            summary=summary,
+            outcome=outcome,
+            metadata={
+                "type": "reflexion",
+                "iteration": iteration,
+                "quality_score": assessment.quality_score,
+                "improvement_areas": assessment.improvement_areas[:5],
+                "original_task": (user_input or "")[:200],
+                "will_retry": will_retry,
+            },
+        )
+        if will_retry and assessment.improvement_areas and hasattr(memory, "strategic"):
+            key = f"reflexion_{(assessment.improvement_areas[0] or 'general')[:40]}"
+            await memory.strategic.store_strategy(
+                key=key,
+                content=(
+                    f"When quality is low on '{assessment.improvement_areas[0]}', "
+                    f"apply: {(assessment.refinement_prompt or '')[:300]}"
+                ),
+                category="reflexion",
+                source="reflexion",
+                metadata={"quality_score": assessment.quality_score},
+            )
+    except Exception:
+        logger.debug("Failed to persist reflexion episode", exc_info=True)
+
+
+async def reflect_node(state: HolixGraphState, config: RunnableConfig) -> dict[str, Any]:
+    """Evaluate draft final answer; request another ReAct pass when needed."""
+    agent = get_agent_from_config(config)
+    cfg = getattr(agent, "config", None) if agent else None
+
+    if not is_self_refinement_enabled(cfg, default=True):
+        return {"needs_refinement": False}
+
+    if str(state.get("plan_status") or "") == "rejected":
+        return {"needs_refinement": False}
+
+    final_response = str(state.get("final_response") or "").strip()
+    if not final_response or is_placeholder_final(final_response) or is_aborted_final_response(
+        final_response
+    ):
+        return {"needs_refinement": False}
+
+    reflection_count = int(state.get("reflection_count") or state.get("refinement_iterations") or 0)
+    max_iter = int(
+        state.get("max_refinement_iterations")
+        or getattr(cfg, "max_refinement_iterations", 2)
+        or 2
+    )
+    if reflection_count >= max_iter:
+        logger.info("Reflexion: max iterations (%s) reached", max_iter)
+        return {"needs_refinement": False}
+
+    if not agent or not hasattr(agent, "client"):
+        return {"needs_refinement": False}
+
+    user_input = str(state.get("user_input") or "")
+    trajectory = _trajectory_summary(state)
+    threshold = float(getattr(cfg, "refinement_quality_threshold", 0.7) or 0.7)
+
+    meta = MetaAgent(
+        client=agent.client,
+        model=getattr(agent, "model", None) or "",
+    )
+    try:
+        assessment = await meta.evaluate_response(
+            response=final_response,
+            original_task=user_input,
+            context={
+                "iteration": reflection_count,
+                "execution_mode": state.get("execution_mode", "react"),
+                "step_count": state.get("step_count", 0),
+                "trajectory": trajectory[:2000],
+                "prior_reflections": len(state.get("reflection_log") or []),
+            },
+        )
+    except Exception as exc:
+        logger.warning("Reflexion evaluate failed: %s", exc)
+        return {"needs_refinement": False}
+
+    needs = bool(assessment.needs_refinement) or float(assessment.quality_score) < threshold
+    # If score is high, trust it even if needs_refinement flag is noisy
+    if float(assessment.quality_score) >= max(threshold, 0.85):
+        needs = False
+
+    entry = {
+        "iteration": reflection_count + 1,
+        "quality_score": float(assessment.quality_score),
+        "needs_refinement": needs,
+        "improvement_areas": list(assessment.improvement_areas or [])[:5],
+        "reasoning": (assessment.reasoning or "")[:400],
+        "refinement_prompt": (assessment.refinement_prompt or "")[:400],
+    }
+    reflection_log = list(state.get("reflection_log") or [])
+    reflection_log.append(entry)
+
+    conversation_id = str(state.get("conversation_id") or "default")
+    await _persist_reflection(
+        agent,
+        conversation_id=conversation_id,
+        user_input=user_input,
+        assessment=assessment,
+        iteration=reflection_count + 1,
+        will_retry=needs,
+    )
+
+    if agent and hasattr(agent, "emit"):
+        try:
+            from core.agent_events import ThinkingEvent
+
+            if needs:
+                agent.emit(
+                    ThinkingEvent(
+                        message=(
+                            f"Reflexion: quality {assessment.quality_score:.2f} "
+                            f"< {threshold:.2f} — retrying with self-feedback "
+                            f"({reflection_count + 1}/{max_iter})"
+                        ),
+                        conversation_id=conversation_id,
+                    )
+                )
+            else:
+                agent.emit(
+                    ThinkingEvent(
+                        message=(
+                            f"Reflexion: quality {assessment.quality_score:.2f} OK — finalizing"
+                        ),
+                        conversation_id=conversation_id,
+                    )
+                )
+        except Exception:
+            pass
+
+    if not needs:
+        logger.info(
+            "Reflexion: accept answer quality=%.2f (iter=%s)",
+            assessment.quality_score,
+            reflection_count + 1,
+        )
+        return {
+            "needs_refinement": False,
+            "reflection_log": reflection_log,
+            "refinement_iterations": reflection_count + 1,
+            "reflection_count": reflection_count + 1,
+        }
+
+    reflection_msg = _format_reflection_message(
+        assessment,
+        iteration=reflection_count + 1,
+        trajectory=trajectory,
+    )
+    messages = list(state.get("messages") or [])
+    # Keep the draft visible as assistant content if not already last assistant
+    last = messages[-1] if messages else None
+    if not (
+        last
+        and last.get("role") == "assistant"
+        and (last.get("content") or "").strip() == final_response
+    ):
+        messages.append({"role": "assistant", "content": final_response})
+    messages.append({"role": "user", "content": reflection_msg})
+
+    logger.info(
+        "Reflexion: retry with feedback quality=%.2f areas=%s",
+        assessment.quality_score,
+        entry["improvement_areas"],
+    )
+
+    return {
+        "messages": messages,
+        "needs_refinement": True,
+        "is_final": False,
+        "final_response": "",
+        "tool_calls": [],
+        "reflection_log": reflection_log,
+        "reflection_count": reflection_count + 1,
+        "refinement_iterations": reflection_count + 1,
+    }

--- a/core/graph/nodes/supervisor_node.py
+++ b/core/graph/nodes/supervisor_node.py
@@ -1,0 +1,302 @@
+"""Graph-native supervisor node — post-wave diagnosis and rework cycle.
+
+Runs after ``collect_subagent`` in plan_and_execute. Looks at the wave just
+collected; if jobs failed or look thrashy, schedules **rework on the same
+agent types** with guidance (same orchestration cycle, not a new plan).
+
+Mid-run guidance still comes from the asyncio ``SubagentSupervisor`` sidecar;
+this node owns the **graph-level** rework loop:
+
+  collect → supervisor → (rework? delegate : react)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langchain_core.runnables import RunnableConfig
+
+from core.graph.state import HolixGraphState, get_agent_from_config
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_REWORK = 2
+
+
+def _max_rework_rounds(agent: Any) -> int:
+    cfg = getattr(agent, "config", None) if agent else None
+    if cfg is None:
+        return _DEFAULT_MAX_REWORK
+    raw = getattr(cfg, "subagent_supervisor_max_interventions", None)
+    if raw is None:
+        return _DEFAULT_MAX_REWORK
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_REWORK
+
+
+def _supervisor_enabled(agent: Any) -> bool:
+    cfg = getattr(agent, "config", None) if agent else None
+    if cfg is None:
+        return True
+    val = getattr(cfg, "subagent_supervisor_enabled", True)
+    return True if val is None else bool(val)
+
+
+def _error_looks_structural(error: str, response: str) -> bool:
+    text = f"{error}\n{response}".lower()
+    markers = (
+        "max steps",
+        "timed out",
+        "timeout",
+        "loop",
+        "permission denied",
+        "error:",
+        "traceback",
+        "failed",
+        "cancelled",
+    )
+    return any(m in text for m in markers)
+
+
+def _build_rework_task(
+    *,
+    agent_type: str,
+    original_task: str,
+    error: str,
+    response: str,
+    step_ref: int,
+    step_index: int,
+    prior_job: str,
+) -> dict[str, Any]:
+    err = (error or response or "unknown failure").strip()
+    if len(err) > 800:
+        err = err[:799] + "…"
+    guided = (
+        f"{original_task.strip()}\n\n"
+        f"### Supervisor rework (same sub-agent type)\n"
+        f"Previous attempt (`{prior_job}`) did not succeed.\n"
+        f"**Failure signal:** {err}\n\n"
+        f"**Instructions:**\n"
+        f"- Do not repeat the same failing tool sequence.\n"
+        f"- Fix the root cause or produce a clear partial deliverable.\n"
+        f"- Prefer smaller steps: verify paths, then write/test.\n"
+        f"- If blocked, state the exact blocker and what you already tried."
+    )
+    return {
+        "agent_type": agent_type,
+        "task": guided,
+        "step_ref": step_ref,
+        "step_index": step_index,
+        "prior_job": prior_job,
+        "failure": err[:400],
+    }
+
+
+async def supervisor_node(
+    state: HolixGraphState,
+    config: RunnableConfig,
+) -> dict[str, Any]:
+    """Diagnose last sub-agent wave; schedule rework or pass through to synthesis."""
+    agent = get_agent_from_config(config)
+    if not _supervisor_enabled(agent):
+        return {
+            "supervisor_needs_rework": False,
+            "supervisor_rework_tasks": [],
+        }
+
+    if not state.get("subagent_awaiting_synthesis"):
+        # No fresh wave to inspect
+        return {
+            "supervisor_needs_rework": False,
+            "supervisor_rework_tasks": [],
+        }
+
+    wave_idx_next = int(state.get("current_subagent_wave", 0) or 0)
+    completed_wave = max(0, wave_idx_next - 1)
+    wave_results = dict(state.get("subagent_wave_results") or {})
+    results = wave_results.get(str(completed_wave)) or {}
+    if not results:
+        return {
+            "supervisor_needs_rework": False,
+            "supervisor_rework_tasks": [],
+        }
+
+    rework_round = int(state.get("supervisor_rework_round", 0) or 0)
+    max_rounds = _max_rework_rounds(agent)
+    task_meta = dict(state.get("subagent_task_meta") or {})
+    log = list(state.get("supervisor_log") or [])
+
+    failed_jobs: list[tuple[str, dict[str, Any]]] = []
+    for job_id, payload in results.items():
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("success"):
+            continue
+        failed_jobs.append((job_id, payload))
+
+    if not failed_jobs:
+        return {
+            "supervisor_needs_rework": False,
+            "supervisor_rework_tasks": [],
+            "supervisor_last_diagnosis": {
+                "wave": completed_wave,
+                "kind": "ok",
+                "failed": 0,
+                "total": len(results),
+            },
+        }
+
+    if rework_round >= max_rounds:
+        summary = (
+            f"Supervisor: {len(failed_jobs)}/{len(results)} sub-agent job(s) failed "
+            f"on wave {completed_wave + 1}; rework limit ({max_rounds}) reached. "
+            "Synthesize best-effort from available results."
+        )
+        messages = list(state.get("messages") or [])
+        messages.append({"role": "user", "content": f"[Supervisor]\n{summary}"})
+        log.append(
+            {
+                "wave": completed_wave,
+                "kind": "exhausted",
+                "failed": len(failed_jobs),
+                "round": rework_round,
+            }
+        )
+        if agent and hasattr(agent, "emit"):
+            try:
+                from core.agent_events import SubAgentSupervisorEvent
+
+                agent.emit(
+                    SubAgentSupervisorEvent(
+                        name="wave",
+                        agent_type="supervisor",
+                        kind="exhausted",
+                        severity="warning",
+                        attempt=rework_round,
+                        max_interventions=max_rounds,
+                        summary=summary,
+                        message=summary,
+                        exhausted=True,
+                        conversation_id=str(state.get("conversation_id") or "default"),
+                    )
+                )
+            except Exception:
+                logger.debug("supervisor_node emit failed", exc_info=True)
+        return {
+            "messages": messages,
+            "supervisor_needs_rework": False,
+            "supervisor_rework_tasks": [],
+            "supervisor_log": log,
+            "supervisor_last_diagnosis": {
+                "wave": completed_wave,
+                "kind": "exhausted",
+                "failed": len(failed_jobs),
+                "total": len(results),
+            },
+        }
+
+    rework_tasks: list[dict[str, Any]] = []
+    for job_id, payload in failed_jobs:
+        err = str(payload.get("error") or "")
+        resp = str(payload.get("response") or "")
+        if not _error_looks_structural(err, resp) and not err:
+            # Soft failure with empty body — still rework once
+            pass
+        meta = task_meta.get(job_id) or {}
+        agent_type = str(meta.get("agent_type") or job_id.split("-")[0] or "coder")
+        original = str(meta.get("task") or "Continue the assigned work")
+        rework_tasks.append(
+            _build_rework_task(
+                agent_type=agent_type,
+                original_task=original,
+                error=err,
+                response=resp,
+                step_ref=int(meta.get("step_ref") or 0),
+                step_index=int(meta.get("step_index") or 0),
+                prior_job=job_id,
+            )
+        )
+
+    if not rework_tasks:
+        return {
+            "supervisor_needs_rework": False,
+            "supervisor_rework_tasks": [],
+        }
+
+    summary = (
+        f"Supervisor: scheduling rework for {len(rework_tasks)} failed job(s) "
+        f"(round {rework_round + 1}/{max_rounds}) on wave {completed_wave + 1}."
+    )
+    messages = list(state.get("messages") or [])
+    detail_lines = [
+        f"- `{t['prior_job']}` ({t['agent_type']}): {t.get('failure', '')[:200]}"
+        for t in rework_tasks
+    ]
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                f"[Supervisor rework]\n{summary}\n"
+                + "\n".join(detail_lines)
+                + "\n\nSub-agents will retry with corrected guidance before synthesis."
+            ),
+        }
+    )
+    log.append(
+        {
+            "wave": completed_wave,
+            "kind": "rework",
+            "failed": len(rework_tasks),
+            "round": rework_round + 1,
+            "jobs": [t["prior_job"] for t in rework_tasks],
+        }
+    )
+
+    if agent and hasattr(agent, "emit"):
+        try:
+            from core.agent_events import SubAgentSupervisorEvent, ThinkingEvent
+
+            agent.emit(
+                SubAgentSupervisorEvent(
+                    name="wave",
+                    agent_type="supervisor",
+                    kind="rework",
+                    severity="warning",
+                    attempt=rework_round + 1,
+                    max_interventions=max_rounds,
+                    summary=summary,
+                    message=summary,
+                    exhausted=False,
+                    conversation_id=str(state.get("conversation_id") or "default"),
+                )
+            )
+            agent.emit(
+                ThinkingEvent(
+                    message=summary,
+                    conversation_id=str(state.get("conversation_id") or "default"),
+                )
+            )
+        except Exception:
+            logger.debug("supervisor_node emit failed", exc_info=True)
+
+    logger.info(summary)
+
+    return {
+        "messages": messages,
+        "supervisor_needs_rework": True,
+        "supervisor_rework_tasks": rework_tasks,
+        "supervisor_rework_round": rework_round + 1,
+        # Keep synthesis flag false until rework collected
+        "subagent_awaiting_synthesis": False,
+        "supervisor_log": log,
+        "supervisor_last_diagnosis": {
+            "wave": completed_wave,
+            "kind": "rework",
+            "failed": len(rework_tasks),
+            "total": len(results),
+            "round": rework_round + 1,
+        },
+    }

--- a/core/graph/routers.py
+++ b/core/graph/routers.py
@@ -15,10 +15,25 @@ def route_after_react(state: HolixGraphState) -> str:
     step_count = state.get("step_count", 0)
     max_steps = state.get("max_steps", 90)
 
-    if is_final or step_count >= max_steps:
-        return "finalize"
-    if tool_calls:
+    if tool_calls and not is_final and step_count < max_steps:
         return "tool_execution"
+    # Draft answer or step budget exhausted → Reflexion evaluate (may loop to react)
+    if is_final or step_count >= max_steps or not tool_calls:
+        return "reflect"
+    return "reflect"
+
+
+def route_after_reflect(state: HolixGraphState) -> str:
+    """After Reflexion: retry ReAct with feedback, or finalize."""
+    if state.get("is_final", False) and not state.get("needs_refinement"):
+        return "finalize"
+    if state.get("needs_refinement"):
+        step_count = state.get("step_count", 0)
+        max_steps = state.get("max_steps", 90)
+        if step_count >= max_steps:
+            logger.info("Reflexion requested retry but max_steps reached — finalizing")
+            return "finalize"
+        return "react"
     return "finalize"
 
 
@@ -69,7 +84,7 @@ def route_after_react_plan(state: HolixGraphState) -> str:
     current_step_start_count = state.get("current_step_start_count", 0)
 
     if is_final or step_count >= max_steps:
-        return "finalize"
+        return "reflect"
     if tool_calls:
         return "tool_execution"
     if is_step_complete:
@@ -114,4 +129,18 @@ def route_after_step_orchestrate(state: HolixGraphState) -> str:
 
 def route_after_delegate_subagent(state: HolixGraphState) -> str:
     """After sub-agent delegation, continue to react for the step."""
+    return "react"
+
+
+def route_after_supervisor(state: HolixGraphState) -> str:
+    """After graph supervisor: rework failed jobs or synthesize via react."""
+    if state.get("is_final", False):
+        return "finalize"
+    if state.get("supervisor_needs_rework") and state.get("supervisor_rework_tasks"):
+        logger.info(
+            "Supervisor routing to rework (%d task(s), round=%s)",
+            len(state.get("supervisor_rework_tasks") or []),
+            state.get("supervisor_rework_round", 0),
+        )
+        return "delegate_subagent"
     return "react"

--- a/core/graph/state.py
+++ b/core/graph/state.py
@@ -38,6 +38,8 @@ class HolixGraphState(TypedDict, total=False):
     # Execution control
     step_count: int
     max_steps: int
+    base_max_steps: int                  # Original max_steps before auto-extensions
+    step_budget_extensions: int          # How many times max_steps was auto-extended
     max_steps_per_plan_step: int         # Max ReAct iterations per plan step
     execution_mode: str                  # "react" | "plan_and_execute" | "hybrid"
     is_final: bool                       # True when final response generated

--- a/core/graph/state.py
+++ b/core/graph/state.py
@@ -52,9 +52,11 @@ class HolixGraphState(TypedDict, total=False):
     meta_decision: dict[str, Any] | None  # Strategy adjustments from meta-agent
     needs_refinement: bool               # Set by meta-agent for self-refinement
 
-    # Self-refinement state (Phase 5)
+    # Self-refinement / Reflexion state
     refinement_iterations: int
     max_refinement_iterations: int
+    reflection_count: int                    # Reflexion retries this turn
+    reflection_log: list[dict[str, Any]]     # Verbal reflections + quality scores
 
     # Sub-agent state (Phase 4b)
     sub_agent_tasks: list[dict[str, Any]]    # Sub-tasks for sub-agents
@@ -68,6 +70,13 @@ class HolixGraphState(TypedDict, total=False):
     subagent_wave_step_indices: list[int] | None  # Plan indices finished in last wave
     subagent_awaiting_synthesis: bool     # True after collect, before react synthesis
     subagent_delegate_next: bool           # Router hint to spawn the next wave
+
+    # Graph-native supervisor (post-wave rework cycle)
+    supervisor_needs_rework: bool          # Router: supervisor → delegate again
+    supervisor_rework_tasks: list[dict[str, Any]]  # Tasks with guidance for same types
+    supervisor_rework_round: int           # How many graph rework rounds this turn
+    supervisor_log: list[dict[str, Any]]   # Audit trail of interventions
+    supervisor_last_diagnosis: dict[str, Any] | None
 
     # Plan state (for plan_and_execute and hybrid modes)
     plan_steps: list[dict[str, Any]]         # Ordered list of plan steps

--- a/core/meta_agent.py
+++ b/core/meta_agent.py
@@ -85,13 +85,17 @@ Based on the user's input and available context:
 Respond in JSON:
 {{"suggested_mode": "react|plan_and_execute|hybrid|", "context_hint": "brief hint", "confidence": 0.0-1.0, "reasoning": "why"}}"""
 
-META_EVALUATE_PROMPT = """You are a quality assessor for an AI agent. Evaluate the response quality.
+META_EVALUATE_PROMPT = """You are a Reflexion evaluator for an AI agent. Critique the draft answer.
 
 Rate the response on:
 - Completeness: Does it fully address the user's question?
-- Accuracy: Is the information correct?
+- Accuracy: Is the information correct and grounded in tools/results when relevant?
 - Clarity: Is it well-structured and easy to understand?
 - Actionability: Does it provide concrete, useful guidance?
+- Trajectory: If tool trajectory is provided, did tools succeed and support the claim?
+
+If quality is insufficient, set needs_refinement=true and write a specific refinement_prompt
+the agent should follow on the next attempt (verbal self-reflection).
 
 Respond in JSON:
 {{"quality_score": 0.0-1.0, "needs_refinement": true/false, "improvement_areas": ["area1", ...], "refinement_prompt": "what to improve", "reasoning": "why"}}"""
@@ -199,21 +203,32 @@ Context: {context_str}
             logger.debug("Meta-agent: no client, returning default assessment")
             return QualityAssessment()
 
+        ctx = context or {}
+        trajectory = str(ctx.get("trajectory") or "").strip()
+        traj_block = f"\nTool trajectory:\n{trajectory[:1500]}\n" if trajectory else ""
+        prior = ctx.get("prior_reflections")
+        prior_block = f"\nPrior reflection count this turn: {prior}\n" if prior else ""
+
         prompt = f"""Original task: {original_task[:300]}
 
 Agent response: {response[:1000]}
-
+{traj_block}{prior_block}
 {META_EVALUATE_PROMPT}"""
 
         try:
             response_obj = await self._client.chat.completions.create(
                 model=self._model,
                 messages=[
-                    {"role": "system", "content": "You are a quality assessor. Respond only with valid JSON."},
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a Reflexion evaluator. Respond only with valid JSON."
+                        ),
+                    },
                     {"role": "user", "content": prompt},
                 ],
                 temperature=0.1,
-                max_tokens=200,
+                max_tokens=280,
             )
 
             result_text = response_obj.choices[0].message.content or ""

--- a/core/models/client_factory.py
+++ b/core/models/client_factory.py
@@ -76,7 +76,13 @@ def create_openai_client(
     api_key: str,
     metadata: dict[str, Any] | None = None,
 ) -> AsyncOpenAI:
-    """Build AsyncOpenAI client with resolved key and provider headers."""
+    """Build AsyncOpenAI client with resolved key and provider headers.
+
+    Always inject a custom ``httpx.AsyncClient``. Older ``openai`` SDKs (e.g. 1.47)
+    still pass ``proxies=`` into httpx, which httpx>=0.28 rejects with::
+
+        TypeError: AsyncClient.__init__() got an unexpected keyword argument 'proxies'
+    """
     preset_id = (metadata or {}).get("preset_id")
     resolved_key = resolve_provider_api_key(api_key, preset_id=preset_id)
     headers = build_default_headers(metadata)
@@ -84,11 +90,15 @@ def create_openai_client(
     kwargs: dict[str, Any] = {
         "base_url": base_url,
         "api_key": resolved_key,
+        # Bypass OpenAI's AsyncHttpxClientWrapper which may still forward
+        # removed httpx kwargs (proxies) on httpx 0.28+.
+        "http_client": httpx.AsyncClient(
+            verify=resolve_verify_ssl(metadata),
+            follow_redirects=True,
+            timeout=httpx.Timeout(600.0, connect=30.0),
+        ),
     }
     if headers:
         kwargs["default_headers"] = headers
-
-    if not resolve_verify_ssl(metadata):
-        kwargs["http_client"] = httpx.AsyncClient(verify=False)
 
     return AsyncOpenAI(**kwargs)

--- a/core/profile/service.py
+++ b/core/profile/service.py
@@ -80,6 +80,15 @@ class ProfileConfig(BaseModel):
     enable_subagents: bool | None = None
     subagent_default_process_mode: str | None = None
     subagent_max_concurrent: int | None = None
+    # Runtime supervisor: watch stuck sub-agent jobs and inject guidance
+    subagent_supervisor_enabled: bool | None = None
+
+    # Meta-agent (pre-thinking) and Reflexion self-refinement
+    enable_meta_agent: bool | None = None
+    enable_self_refinement: bool | None = None
+
+    # When max_steps is hit, allow automatic budget extensions on progress
+    max_steps_extend_enabled: bool | None = None
 
     # Hub: optional background ClawHub version updates
     hub_auto_update: bool = False
@@ -105,6 +114,9 @@ class ProfileConfig(BaseModel):
 
     # Per-extension settings: { extension_name: { key: value, ... }, ... }
     extension_settings: dict[str, Any] = Field(default_factory=dict)
+
+    # Agent2Agent (A2A) protocol: server exposure + remote agents client registry
+    a2a: dict[str, Any] = Field(default_factory=dict)
 
 
 def _holix_env_name() -> str:

--- a/core/runtime/background_process.py
+++ b/core/runtime/background_process.py
@@ -83,6 +83,8 @@ class BackgroundProcessRegistry:
         """Stop profile processes that hold ports the new command needs."""
         from core.runtime.port_utils import force_free_ports, parse_listen_ports
 
+        # Include processes started by Telegram/other Holix OS processes.
+        self.hydrate_from_disk(profile)
         async with self._lock:
             candidates = list(self._records_for_profile(profile))
         candidates.sort(key=lambda r: r.started_at, reverse=True)
@@ -209,10 +211,19 @@ class BackgroundProcessRegistry:
             )
             self._records[process_id] = record
 
+        # Persist so Studio (separate OS process) sees Telegram/CLI starts.
+        try:
+            from core.runtime.background_process_store import upsert_record
+
+            await asyncio.to_thread(upsert_record, record)
+        except Exception as exc:
+            logger.warning("Failed to persist background process index: %s", exc)
+
         logger.info(
-            "Background process started id=%s pid=%s cmd=%s",
+            "Background process started id=%s pid=%s profile=%s cmd=%s",
             process_id,
             record.pid,
+            profile,
             command[:200],
         )
         return record
@@ -220,6 +231,9 @@ class BackgroundProcessRegistry:
     async def stop(self, process_id: str) -> BackgroundProcessRecord | None:
         async with self._lock:
             rec = self._records.get(process_id)
+        if rec is None:
+            # May only exist on disk (started by another Holix process).
+            rec = self.get(process_id)
         if rec is None:
             return None
         await self._stop_all_records([rec])
@@ -267,21 +281,6 @@ class BackgroundProcessRegistry:
         if all_ports:
             await asyncio.to_thread(force_free_ports, all_ports)
         return candidates[0]
-
-    def get(self, process_id: str) -> BackgroundProcessRecord | None:
-        return self._records.get(process_id)
-
-    def list_for_scope(self, *, profile: str, conversation_id: str) -> list[BackgroundProcessRecord]:
-        scope = self._scope_key(profile, conversation_id)
-        out: list[BackgroundProcessRecord] = []
-        for rec in self._records.values():
-            if self._scope_key(rec.profile, rec.conversation_id) == scope:
-                out.append(rec)
-        return sorted(out, key=lambda r: r.started_at, reverse=True)
-
-    def list_for_profile(self, *, profile: str) -> list[BackgroundProcessRecord]:
-        """All background processes for a profile (any conversation)."""
-        return sorted(self._records_for_profile(profile), key=lambda r: r.started_at, reverse=True)
 
     def active_for_scope(self, *, profile: str, conversation_id: str) -> BackgroundProcessRecord | None:
         for rec in self.list_for_scope(profile=profile, conversation_id=conversation_id):
@@ -389,6 +388,89 @@ class BackgroundProcessRegistry:
                 await asyncio.to_thread(rec._popen.wait, timeout=1)
             except Exception:
                 pass
+        try:
+            from core.runtime.background_process_store import remove_record
+
+            await asyncio.to_thread(remove_record, rec.profile, rec.process_id)
+        except Exception as exc:
+            logger.warning("Failed to remove background process from index: %s", exc)
+        async with self._lock:
+            self._records.pop(rec.process_id, None)
+
+    def hydrate_from_disk(self, profile: str | None = None) -> int:
+        """Load process rows started by other Holix processes (Telegram/Studio/CLI).
+
+        Returns number of records newly merged into memory.
+        """
+        from core.runtime.background_process_store import (
+            iter_profile_names_with_index,
+            load_index,
+            prune_dead_records,
+        )
+
+        profiles: set[str] = set()
+        if profile:
+            profiles.add((profile or "").strip() or "default")
+        else:
+            profiles.update(
+                (rec.profile or "default").strip() or "default"
+                for rec in self._records.values()
+            )
+            if not profiles:
+                profiles.update(iter_profile_names_with_index())
+
+        added = 0
+        for prof in profiles:
+            rows = prune_dead_records(prof, is_alive=is_process_alive)
+            if not rows:
+                rows = load_index(prof)
+            for row in rows:
+                pid_key = str(row.get("process_id") or "")
+                if not pid_key or pid_key in self._records:
+                    continue
+                try:
+                    pid = int(row.get("pid") or 0)
+                except (TypeError, ValueError):
+                    continue
+                if pid <= 0 or not is_process_alive(pid):
+                    continue
+                rec = BackgroundProcessRecord(
+                    process_id=pid_key,
+                    label=str(row.get("label") or pid_key)[:120],
+                    command=str(row.get("command") or ""),
+                    pid=pid,
+                    conversation_id=str(row.get("conversation_id") or ""),
+                    profile=str(row.get("profile") or prof),
+                    chat_id=(str(row["chat_id"]) if row.get("chat_id") else None),
+                    log_path=str(row.get("log_path") or ""),
+                    started_at=float(row.get("started_at") or time.time()),
+                    _popen=None,
+                )
+                self._records[pid_key] = rec
+                added += 1
+        return added
+
+    def get(self, process_id: str) -> BackgroundProcessRecord | None:
+        rec = self._records.get(process_id)
+        if rec is not None:
+            return rec
+        # Cross-process: scan profile indexes
+        self.hydrate_from_disk()
+        return self._records.get(process_id)
+
+    def list_for_profile(self, *, profile: str) -> list[BackgroundProcessRecord]:
+        """All background processes for a profile (any conversation + disk index)."""
+        self.hydrate_from_disk(profile)
+        return sorted(self._records_for_profile(profile), key=lambda r: r.started_at, reverse=True)
+
+    def list_for_scope(self, *, profile: str, conversation_id: str) -> list[BackgroundProcessRecord]:
+        self.hydrate_from_disk(profile)
+        scope = self._scope_key(profile, conversation_id)
+        out: list[BackgroundProcessRecord] = []
+        for rec in self._records.values():
+            if self._scope_key(rec.profile, rec.conversation_id) == scope:
+                out.append(rec)
+        return sorted(out, key=lambda r: r.started_at, reverse=True)
 
 
 _default_registry: BackgroundProcessRegistry | None = None
@@ -402,6 +484,10 @@ def bind_background_process_registry(
     """Associate a registry with a profile (set during agent initialize)."""
     key = (profile_name or "default").strip() or "default"
     _profile_registries[key] = registry
+    try:
+        registry.hydrate_from_disk(key)
+    except Exception:
+        pass
 
 
 def unbind_background_process_registry(profile_name: str) -> None:
@@ -410,14 +496,41 @@ def unbind_background_process_registry(profile_name: str) -> None:
 
 
 def get_background_process_registry(profile_name: str | None = None) -> BackgroundProcessRegistry:
-    """Return profile-bound registry when available, else process default."""
+    """Return the registry for a Holix profile (never share one bag across profiles).
+
+    Agent initialize binds its instance via :func:`bind_background_process_registry`.
+    When unbound, create/reuse a per-profile registry so Studio HTTP listing and
+    tools cannot mix process records between users.
+
+    Always hydrates from the shared on-disk index so Telegram-started processes
+    appear in Studio for the same profile.
+    """
     from core.tools.execution_context import get_profile_name
 
     key = (profile_name or get_profile_name() or "default").strip() or "default"
     bound = _profile_registries.get(key)
     if bound is not None:
+        try:
+            bound.hydrate_from_disk(key)
+        except Exception:
+            pass
         return bound
-    global _default_registry
-    if _default_registry is None:
-        _default_registry = BackgroundProcessRegistry()
-    return _default_registry
+    # Isolate by profile key. Keep a process-wide default only for the
+    # literal ``default`` key used by single-user / tests without a profile.
+    if key == "default":
+        global _default_registry
+        if _default_registry is None:
+            _default_registry = BackgroundProcessRegistry()
+        _profile_registries.setdefault("default", _default_registry)
+        try:
+            _default_registry.hydrate_from_disk("default")
+        except Exception:
+            pass
+        return _default_registry
+    reg = BackgroundProcessRegistry()
+    try:
+        reg.hydrate_from_disk(key)
+    except Exception:
+        pass
+    _profile_registries[key] = reg
+    return reg

--- a/core/runtime/background_process_store.py
+++ b/core/runtime/background_process_store.py
@@ -1,0 +1,167 @@
+"""Shared on-disk index of background processes for a Holix profile.
+
+Telegram, Studio, gateway workers, and CLI each have their own Python process and
+in-memory registry. This store makes starts from Telegram visible in Studio
+Processes / Browser (same profile workspace + index file).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_INDEX_NAME = "background_processes.json"
+_MAX_RECORDS = 200
+
+
+def _holix_home() -> Path:
+    raw = (os.environ.get("HOLIX_HOME") or "").strip()
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return (Path.home() / ".holix").resolve()
+
+
+def profile_process_index_path(profile: str) -> Path:
+    name = (profile or "default").strip() or "default"
+    return _holix_home() / "profiles" / name / "data" / _INDEX_NAME
+
+
+def iter_profile_names_with_index() -> list[str]:
+    """Profile directory names that have a background process index file."""
+    root = _holix_home() / "profiles"
+    if not root.is_dir():
+        return []
+    names: list[str] = []
+    try:
+        for entry in root.iterdir():
+            if entry.is_dir() and (entry / "data" / _INDEX_NAME).is_file():
+                names.append(entry.name)
+    except OSError:
+        return []
+    return names
+
+
+def record_to_dict(rec: Any) -> dict[str, Any]:
+    return {
+        "process_id": rec.process_id,
+        "label": rec.label,
+        "command": rec.command,
+        "pid": int(rec.pid),
+        "conversation_id": rec.conversation_id,
+        "profile": rec.profile,
+        "chat_id": rec.chat_id,
+        "log_path": rec.log_path or "",
+        "started_at": float(rec.started_at or time.time()),
+    }
+
+
+def load_index(profile: str) -> list[dict[str, Any]]:
+    path = profile_process_index_path(profile)
+    if not path.is_file():
+        return []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("background process index read failed %s: %s", path, exc)
+        return []
+    if not isinstance(raw, dict):
+        return []
+    items = raw.get("processes")
+    if not isinstance(items, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict) and item.get("process_id") and item.get("pid"):
+            out.append(item)
+    return out
+
+
+def _write_index(profile: str, processes: list[dict[str, Any]]) -> None:
+    path = profile_process_index_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Drop dead / oldest beyond cap
+    processes = sorted(
+        processes,
+        key=lambda r: float(r.get("started_at") or 0),
+        reverse=True,
+    )[:_MAX_RECORDS]
+    payload = {
+        "version": 1,
+        "profile": profile,
+        "updated_at": time.time(),
+        "processes": processes,
+    }
+    text = json.dumps(payload, ensure_ascii=False, indent=2)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=".bg-proc-",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def upsert_record(rec: Any) -> None:
+    """Insert or update a process row for its profile."""
+    profile = (getattr(rec, "profile", None) or "default").strip() or "default"
+    row = record_to_dict(rec)
+    try:
+        items = load_index(profile)
+        by_id = {str(i.get("process_id")): i for i in items}
+        by_id[row["process_id"]] = row
+        _write_index(profile, list(by_id.values()))
+    except OSError as exc:
+        logger.warning("background process index upsert failed profile=%s: %s", profile, exc)
+
+
+def remove_record(profile: str, process_id: str) -> None:
+    name = (profile or "default").strip() or "default"
+    pid = (process_id or "").strip()
+    if not pid:
+        return
+    try:
+        items = [i for i in load_index(name) if str(i.get("process_id")) != pid]
+        _write_index(name, items)
+    except OSError as exc:
+        logger.warning("background process index remove failed profile=%s: %s", name, exc)
+
+
+def prune_dead_records(profile: str, *, is_alive) -> list[dict[str, Any]]:
+    """Drop dead PIDs from the index; return surviving rows."""
+    name = (profile or "default").strip() or "default"
+    items = load_index(name)
+    alive: list[dict[str, Any]] = []
+    changed = False
+    for item in items:
+        try:
+            pid = int(item.get("pid") or 0)
+        except (TypeError, ValueError):
+            changed = True
+            continue
+        if pid > 0 and is_alive(pid):
+            alive.append(item)
+        else:
+            changed = True
+    if changed:
+        try:
+            _write_index(name, alive)
+        except OSError as exc:
+            logger.warning("background process index prune failed: %s", exc)
+    return alive

--- a/core/runtime/step_budget.py
+++ b/core/runtime/step_budget.py
@@ -1,0 +1,522 @@
+"""Step-budget health check and extension for main agent + sub-agents.
+
+When a run reaches ``max_steps``, Holix does **not** always stop. It evaluates
+whether the agent is still making relevant progress:
+
+* **working + relevant** → grant extra steps (bounded by extension count / hard cap)
+* **hung / looping / no signal** → stop (caller finalizes / fails the job)
+
+This mirrors wait-timeout extension for sub-agents (activity-based), but applies
+to the *reasoning step* budget.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Defaults (overridable via Settings / agent config)
+DEFAULT_EXTEND_BY = 30
+DEFAULT_MAX_EXTENSIONS = 3
+DEFAULT_HARD_CAP = 0  # 0 → derive from base max_steps + extend_by * max_extensions
+DEFAULT_LOOKBACK = 6
+
+_ERROR_MARKERS = (
+    "error",
+    "exception",
+    "traceback",
+    "failed",
+    "timeout",
+    "timed out",
+    "permission denied",
+    "not found",
+    "invalid",
+    "❌",
+    "⛔",
+)
+
+_PROGRESS_MARKERS = (
+    "ok",
+    "done",
+    "success",
+    "created",
+    "updated",
+    "written",
+    "saved",
+    "found",
+    "result",
+    "completed",
+    "✅",
+)
+
+
+@dataclass(slots=True)
+class StepBudgetPolicy:
+    """Tunable limits for step-budget extension."""
+
+    enabled: bool = True
+    extend_by: int = DEFAULT_EXTEND_BY
+    max_extensions: int = DEFAULT_MAX_EXTENSIONS
+    hard_cap: int = DEFAULT_HARD_CAP  # absolute max_steps after extensions
+    lookback: int = DEFAULT_LOOKBACK
+
+    @classmethod
+    def from_config(cls, cfg: Any | None = None) -> StepBudgetPolicy:
+        if cfg is None:
+            return cls()
+        enabled = getattr(cfg, "max_steps_extend_enabled", True)
+        if enabled is None:
+            enabled = True
+        return cls(
+            enabled=bool(enabled),
+            extend_by=max(1, int(getattr(cfg, "max_steps_extend_by", DEFAULT_EXTEND_BY) or DEFAULT_EXTEND_BY)),
+            max_extensions=max(
+                0,
+                int(
+                    getattr(cfg, "max_steps_max_extensions", DEFAULT_MAX_EXTENSIONS)
+                    or DEFAULT_MAX_EXTENSIONS
+                ),
+            ),
+            hard_cap=max(0, int(getattr(cfg, "max_steps_hard_cap", DEFAULT_HARD_CAP) or 0)),
+            lookback=max(3, int(getattr(cfg, "max_steps_lookback", DEFAULT_LOOKBACK) or DEFAULT_LOOKBACK)),
+        )
+
+
+@dataclass(slots=True)
+class StepBudgetDecision:
+    """Outcome of a max-steps health check."""
+
+    extend: bool
+    reason: str
+    status: str  # working | hung | stop | disabled | not_at_limit
+    extra_steps: int = 0
+    new_max_steps: int = 0
+    extensions_used: int = 0
+    signals: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def should_stop(self) -> bool:
+        return not self.extend
+
+
+def _norm_args(raw: Any) -> str:
+    if raw is None:
+        return ""
+    if isinstance(raw, (dict, list)):
+        try:
+            import json
+
+            return json.dumps(raw, sort_keys=True, ensure_ascii=False)[:400]
+        except Exception:
+            return str(raw)[:400]
+    text = str(raw).strip()
+    return text[:400]
+
+
+def _tool_signature(name: str, arguments: Any = None) -> str:
+    return f"{(name or '').strip().lower()}::{_norm_args(arguments)}"
+
+
+def _looks_like_error(text: str) -> bool:
+    low = (text or "").strip().lower()
+    if not low:
+        return True
+    if low.startswith("❌") or low.startswith("⛔"):
+        return True
+    return any(m in low for m in _ERROR_MARKERS)
+
+
+def _looks_like_progress(text: str) -> bool:
+    low = (text or "").strip().lower()
+    if len(low) < 8:
+        return False
+    if _looks_like_error(low):
+        return False
+    if any(m in low for m in _PROGRESS_MARKERS):
+        return True
+    # Non-trivial payload without error markers counts as progress
+    return len(low) >= 40
+
+
+def _token_overlap(a: str, b: str) -> float:
+    """Jaccard-ish overlap on alphanumeric tokens (relevance proxy)."""
+    def toks(s: str) -> set[str]:
+        return {t for t in re.findall(r"[a-zA-Zа-яА-Я0-9_]{3,}", (s or "").lower()) if t}
+
+    ta, tb = toks(a), toks(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / max(1, len(ta | tb))
+
+
+def collect_tool_traces(
+    messages: list[dict[str, Any]] | None = None,
+    *,
+    tool_calls_log: list[dict[str, Any]] | None = None,
+    tool_results: list[dict[str, Any]] | None = None,
+    lookback: int = DEFAULT_LOOKBACK,
+) -> list[dict[str, Any]]:
+    """Build recent tool traces from messages and/or explicit logs."""
+    traces: list[dict[str, Any]] = []
+
+    if tool_calls_log:
+        for item in tool_calls_log[-lookback:]:
+            name = str(item.get("name") or item.get("tool_name") or "")
+            args = item.get("arguments") or item.get("args") or ""
+            result = str(item.get("result") or item.get("content") or item.get("details") or "")
+            traces.append(
+                {
+                    "name": name,
+                    "arguments": args,
+                    "signature": _tool_signature(name, args),
+                    "result": result,
+                    "is_error": _looks_like_error(result) if result else False,
+                }
+            )
+
+    if tool_results:
+        for item in tool_results[-lookback:]:
+            name = str(item.get("name") or item.get("tool_name") or "")
+            content = str(item.get("content") or item.get("result") or "")
+            args = item.get("arguments") or ""
+            traces.append(
+                {
+                    "name": name,
+                    "arguments": args,
+                    "signature": _tool_signature(name, args),
+                    "result": content,
+                    "is_error": bool(item.get("is_error")) or _looks_like_error(content),
+                }
+            )
+
+    # Reconstruct from conversation messages (assistant tool_calls + tool results)
+    if messages and not traces:
+        pending: dict[str, dict[str, Any]] = {}
+        for msg in messages:
+            role = msg.get("role")
+            if role == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    fn = tc.get("function") if isinstance(tc, dict) else None
+                    if not isinstance(fn, dict):
+                        fn = {}
+                    tid = str(tc.get("id") or "")
+                    name = str(fn.get("name") or tc.get("name") or "")
+                    args = fn.get("arguments") if fn else tc.get("arguments")
+                    pending[tid] = {
+                        "name": name,
+                        "arguments": args,
+                        "signature": _tool_signature(name, args),
+                        "result": "",
+                        "is_error": False,
+                    }
+            elif role == "tool":
+                tid = str(msg.get("tool_call_id") or "")
+                content = str(msg.get("content") or "")
+                entry = pending.pop(tid, None) or {
+                    "name": str(msg.get("name") or ""),
+                    "arguments": "",
+                    "signature": _tool_signature(str(msg.get("name") or ""), ""),
+                }
+                entry["result"] = content
+                entry["is_error"] = _looks_like_error(content)
+                traces.append(entry)
+        # leftover unexecuted calls still count as intent to work
+        for entry in pending.values():
+            traces.append(entry)
+
+    return traces[-lookback:]
+
+
+def evaluate_step_budget(
+    *,
+    step_count: int,
+    max_steps: int,
+    extensions_used: int = 0,
+    pending_tool_calls: list[Any] | None = None,
+    messages: list[dict[str, Any]] | None = None,
+    tool_calls_log: list[dict[str, Any]] | None = None,
+    tool_results: list[dict[str, Any]] | None = None,
+    task: str = "",
+    policy: StepBudgetPolicy | None = None,
+    base_max_steps: int | None = None,
+) -> StepBudgetDecision:
+    """Decide whether to extend the step budget at/after the limit.
+
+    Call when ``step_count >= max_steps`` (or about to stop for that reason).
+    """
+    pol = policy or StepBudgetPolicy()
+    sc = int(step_count or 0)
+    ms = int(max_steps or 0)
+    ext_used = max(0, int(extensions_used or 0))
+    base = int(base_max_steps or ms)
+
+    if not pol.enabled:
+        return StepBudgetDecision(
+            extend=False,
+            reason="step budget extension disabled",
+            status="disabled",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+        )
+
+    if ms <= 0 or sc < ms:
+        return StepBudgetDecision(
+            extend=False,
+            reason="not at max_steps",
+            status="not_at_limit",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+        )
+
+    if ext_used >= pol.max_extensions:
+        return StepBudgetDecision(
+            extend=False,
+            reason=f"extension limit reached ({ext_used}/{pol.max_extensions})",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals={"extensions_used": ext_used},
+        )
+
+    hard = pol.hard_cap
+    if hard <= 0:
+        hard = base + pol.extend_by * pol.max_extensions
+    hard = max(ms, hard)
+
+    if ms >= hard:
+        return StepBudgetDecision(
+            extend=False,
+            reason=f"hard cap reached ({ms}>={hard})",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals={"hard_cap": hard},
+        )
+
+    pending = list(pending_tool_calls or [])
+    traces = collect_tool_traces(
+        messages,
+        tool_calls_log=tool_calls_log,
+        tool_results=tool_results,
+        lookback=pol.lookback,
+    )
+
+    sigs = [t.get("signature") or "" for t in traces if t.get("signature")]
+    unique_sigs = {s for s in sigs if s}
+    error_count = sum(1 for t in traces if t.get("is_error"))
+    progress_count = sum(
+        1 for t in traces if _looks_like_progress(str(t.get("result") or ""))
+    )
+    recent_names = " ".join(str(t.get("name") or "") for t in traces)
+    recent_results = " ".join(str(t.get("result") or "")[:200] for t in traces)
+    relevance = max(
+        _token_overlap(task, recent_names),
+        _token_overlap(task, recent_results),
+    ) if task else 0.0
+
+    # Detect tight loops: same signature thrice in a row (or 3+ of last 4)
+    loop_hit = False
+    if len(sigs) >= 3:
+        if sigs[-1] and sigs[-1] == sigs[-2] == sigs[-3]:
+            loop_hit = True
+        elif len(sigs) >= 4:
+            last4 = sigs[-4:]
+            if last4 and last4.count(last4[-1]) >= 3:
+                loop_hit = True
+
+    signals = {
+        "pending_tools": len(pending),
+        "traces": len(traces),
+        "unique_sigs": len(unique_sigs),
+        "error_count": error_count,
+        "progress_count": progress_count,
+        "loop_hit": loop_hit,
+        "relevance": round(relevance, 3),
+        "extensions_used": ext_used,
+        "hard_cap": hard,
+    }
+
+    # --- Hung: repeated identical work or pure error thrash ---
+    if loop_hit:
+        return StepBudgetDecision(
+            extend=False,
+            reason="hung: repeated identical tool calls (loop)",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    if len(traces) >= 3 and error_count == len(traces) and progress_count == 0:
+        return StepBudgetDecision(
+            extend=False,
+            reason="hung: recent tools failed without progress",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    # --- Working: still has tools to run or recent successful relevant work ---
+    working = False
+    if pending:
+        working = True
+    elif progress_count > 0 and (len(unique_sigs) >= 2 or progress_count >= 2):
+        working = True
+    elif traces and progress_count > 0 and error_count < len(traces):
+        working = True
+
+    if not working:
+        return StepBudgetDecision(
+            extend=False,
+            reason="no active work signal at max_steps (stop)",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    # Relevance: require weak signal when we have a task string and tool names
+    if task and recent_names and relevance < 0.02 and progress_count == 0:
+        return StepBudgetDecision(
+            extend=False,
+            reason="work not relevant to the task",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    extra = min(pol.extend_by, hard - ms)
+    if extra <= 0:
+        return StepBudgetDecision(
+            extend=False,
+            reason=f"no room under hard cap ({ms}/{hard})",
+            status="stop",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    new_max = ms + extra
+    return StepBudgetDecision(
+        extend=True,
+        reason=(
+            f"working with relevant progress; +{extra} steps "
+            f"({sc}/{ms} → max {new_max})"
+        ),
+        status="working",
+        extra_steps=extra,
+        new_max_steps=new_max,
+        extensions_used=ext_used + 1,
+        signals=signals,
+    )
+
+
+def policy_from_agent(agent: Any | None) -> StepBudgetPolicy:
+    cfg = getattr(agent, "config", None) if agent is not None else None
+    return StepBudgetPolicy.from_config(cfg)
+
+
+def apply_decision_to_state(
+    state: dict[str, Any],
+    decision: StepBudgetDecision,
+) -> dict[str, Any]:
+    """Return partial graph state updates when extending."""
+    if not decision.extend:
+        return {}
+    return {
+        "max_steps": int(decision.new_max_steps),
+        "step_budget_extensions": int(decision.extensions_used),
+    }
+
+
+def maybe_extend_for_graph_result(
+    state: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    agent: Any | None = None,
+    task: str = "",
+) -> dict[str, Any]:
+    """If result is at max_steps with pending tools, maybe bump max_steps on result."""
+    step_count = int(result.get("step_count", state.get("step_count", 0)) or 0)
+    max_steps = int(result.get("max_steps", state.get("max_steps", 0)) or 0)
+    if max_steps <= 0:
+        max_steps = int(state.get("max_steps", 0) or 0)
+    if step_count < max_steps:
+        return result
+    if result.get("is_final"):
+        return result
+
+    pending = result.get("tool_calls") or state.get("tool_calls") or []
+    messages = result.get("messages") or state.get("messages") or []
+    tool_results = result.get("tool_results") or state.get("tool_results") or []
+    extensions_used = int(
+        result.get("step_budget_extensions", state.get("step_budget_extensions", 0)) or 0
+    )
+    base_max = int(state.get("base_max_steps") or state.get("max_steps") or max_steps)
+    policy = policy_from_agent(agent)
+    decision = evaluate_step_budget(
+        step_count=step_count,
+        max_steps=max_steps,
+        extensions_used=extensions_used,
+        pending_tool_calls=pending,
+        messages=messages if isinstance(messages, list) else None,
+        tool_results=tool_results if isinstance(tool_results, list) else None,
+        task=task or str(state.get("user_input") or ""),
+        policy=policy,
+        base_max_steps=base_max,
+    )
+    if not decision.extend:
+        logger.info(
+            "step budget stop at %s/%s: %s (%s)",
+            step_count,
+            max_steps,
+            decision.status,
+            decision.reason,
+        )
+        return result
+
+    logger.info(
+        "step budget extended: %s → %s (ext=%s) %s",
+        max_steps,
+        decision.new_max_steps,
+        decision.extensions_used,
+        decision.reason,
+    )
+    out = dict(result)
+    out["max_steps"] = decision.new_max_steps
+    out["step_budget_extensions"] = decision.extensions_used
+    if "base_max_steps" not in state and "base_max_steps" not in out:
+        out["base_max_steps"] = base_max
+    # Notify UIs
+    if agent is not None and hasattr(agent, "emit"):
+        try:
+            from core.agent_events import MaxStepsExtendedEvent, ThinkingEvent
+
+            agent.emit(
+                MaxStepsExtendedEvent(
+                    max_steps=decision.new_max_steps,
+                    previous_max_steps=max_steps,
+                    extra_steps=decision.extra_steps,
+                    extensions=decision.extensions_used,
+                    reason=decision.reason,
+                    conversation_id=str(state.get("conversation_id") or ""),
+                )
+            )
+            agent.emit(
+                ThinkingEvent(
+                    message=(
+                        f"Step budget extended by {decision.extra_steps} "
+                        f"(now max {decision.new_max_steps}): still working"
+                    ),
+                    conversation_id=str(state.get("conversation_id") or ""),
+                )
+            )
+        except Exception:
+            logger.debug("failed to emit step budget events", exc_info=True)
+    return out

--- a/core/sdd/merge.py
+++ b/core/sdd/merge.py
@@ -48,62 +48,82 @@ def _preamble_and_reqs(content: str) -> tuple[str, list[_Requirement]]:
     return preamble, _split_requirements(content)
 
 
-def _parse_delta_sections(delta: str) -> dict[str, list[_Requirement]]:
-    """Return {ADDED|MODIFIED|REMOVED: [requirements]} from a delta spec."""
-    sections: dict[str, list[_Requirement]] = {
-        "ADDED": [],
-        "MODIFIED": [],
-        "REMOVED": [],
-    }
+def _parse_delta_sections(delta: str) -> list[tuple[str, list[_Requirement]]]:
+    """Return ordered [(ADDED|MODIFIED|REMOVED, requirements), ...] from a delta.
+
+    Sections are applied in document order so a later REMOVED wins over an
+    earlier MODIFIED of the same title (and vice versa).
+    """
     matches = list(_SECTION_RE.finditer(delta))
     if not matches:
         # Whole file treated as ADDED if it has requirements
-        sections["ADDED"] = _split_requirements(delta)
-        return sections
+        return [("ADDED", _split_requirements(delta))]
 
+    ordered: list[tuple[str, list[_Requirement]]] = []
     for i, m in enumerate(matches):
         kind = m.group(1).upper()
         start = m.end()
         end = matches[i + 1].start() if i + 1 < len(matches) else len(delta)
         body = delta[start:end]
-        sections[kind] = _split_requirements(body)
-    return sections
+        ordered.append((kind, _split_requirements(body)))
+    return ordered
+
+
+def _apply_section(
+    *,
+    kind: str,
+    reqs: list[_Requirement],
+    by_title: dict[str, _Requirement],
+    order: list[str],
+) -> list[str]:
+    """Mutate by_title; return updated order of normalized titles."""
+    if kind == "REMOVED":
+        for r in reqs:
+            key = _normalize_title(r.title)
+            by_title.pop(key, None)
+            order = [t for t in order if t != key]
+        return order
+
+    if kind == "MODIFIED":
+        for r in reqs:
+            key = _normalize_title(r.title)
+            by_title[key] = r
+            if key not in order:
+                order.append(key)
+        return order
+
+    # ADDED (and unknown kinds treated as ADDED)
+    for r in reqs:
+        key = _normalize_title(r.title)
+        if key in by_title:
+            # Already present → replace body (safe re-archive / re-add)
+            by_title[key] = r
+        else:
+            by_title[key] = r
+            order.append(key)
+    return order
 
 
 def merge_delta_into_main(main_content: str, delta_content: str) -> str:
     """Apply delta requirement sections onto main spec markdown.
 
-    - ADDED: append requirements not already present (by title)
-    - MODIFIED: replace body of matching title
+    - ADDED: append requirements not already present (by title); if title exists, replace body
+    - MODIFIED: replace body of matching title (append if missing)
     - REMOVED: drop matching titles
+    - Sections are applied **in document order** (later section wins for the same title)
+    - Duplicate titles in main are collapsed to a single requirement
     """
     preamble, main_reqs = _preamble_and_reqs(main_content)
-    by_title: dict[str, _Requirement] = {
-        _normalize_title(r.title): r for r in main_reqs
-    }
-    order = [_normalize_title(r.title) for r in main_reqs]
-
-    sections = _parse_delta_sections(delta_content)
-
-    for r in sections["REMOVED"]:
-        key = _normalize_title(r.title)
-        by_title.pop(key, None)
-        order = [t for t in order if t != key]
-
-    for r in sections["MODIFIED"]:
+    by_title: dict[str, _Requirement] = {}
+    order: list[str] = []
+    for r in main_reqs:
         key = _normalize_title(r.title)
         by_title[key] = r
         if key not in order:
             order.append(key)
 
-    for r in sections["ADDED"]:
-        key = _normalize_title(r.title)
-        if key in by_title:
-            # treat as modify if already exists
-            by_title[key] = r
-        else:
-            by_title[key] = r
-            order.append(key)
+    for kind, reqs in _parse_delta_sections(delta_content):
+        order = _apply_section(kind=kind, reqs=reqs, by_title=by_title, order=order)
 
     parts: list[str] = []
     if preamble.strip():

--- a/core/sdd/store.py
+++ b/core/sdd/store.py
@@ -685,26 +685,101 @@ class SpecStore:
             ),
         }
 
-    def archive(self, change_id: str) -> dict:
+    @staticmethod
+    def _delta_domain_for_spec(specs_delta: Path, delta_spec: Path) -> str | None:
+        """Map ``changes/<id>/specs/<domain>/…/spec.md`` → top-level domain name.
+
+        OpenSpec layout is ``specs/<domain>/spec.md``. Nested files under a domain
+        (e.g. ``specs/auth/notes/spec.md``) still merge into **auth**, not a
+        bogus domain named after the nested folder.
+        Only files named ``spec.md`` under ``specs/<domain>/`` (any depth) are used;
+        the domain is the first path segment relative to ``specs/``.
+        """
+        try:
+            rel = delta_spec.parent.resolve().relative_to(specs_delta.resolve())
+        except ValueError:
+            return None
+        parts = rel.parts
+        if not parts:
+            return None
+        domain = parts[0]
+        try:
+            validate_domain(domain)
+        except ValueError:
+            return None
+        return domain
+
+    def archive(self, change_id: str, *, force: bool = False) -> dict:
         cid = validate_change_id(change_id)
         cdir = change_dir(self.workspace, cid)
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
+
+        st = self.change_status(cid)
+        warnings: list[str] = []
+        if not st.apply_ready:
+            warnings.append(
+                "Change is not apply_ready (proposal/specs/tasks incomplete)."
+            )
+        open_tasks = [
+            t
+            for t in parse_tasks_markdown(
+                (cdir / "tasks.md").read_text(encoding="utf-8")
+                if (cdir / "tasks.md").is_file()
+                else ""
+            )
+            if not t.done
+        ]
+        if open_tasks:
+            warnings.append(
+                f"{len(open_tasks)} open task(s) remain; archive will still merge deltas."
+            )
+        if warnings and not force:
+            # Soft gate: still allow archive (historical behavior) but surface warnings
+            # so agents/UI do not assume a clean merge of finished work.
+            pass
+
         merged: list[str] = []
+        merge_errors: list[str] = []
         specs_delta = cdir / "specs"
+        # One merge pass per domain (later nested/duplicate delta files merge in sort order)
+        domain_deltas: dict[str, list[Path]] = {}
         if specs_delta.is_dir():
             for delta_spec in sorted(specs_delta.rglob(SPEC_FILENAME)):
-                domain = delta_spec.parent.name
-                main_path = domain_spec_path(self.workspace, domain)
-                delta_text = delta_spec.read_text(encoding="utf-8")
-                if main_path.is_file():
-                    main_text = main_path.read_text(encoding="utf-8")
-                else:
-                    main_path.parent.mkdir(parents=True, exist_ok=True)
-                    main_text = f"# {domain}\n\n"
-                new_main = merge_delta_into_main(main_text, delta_text)
-                main_path.write_text(new_main, encoding="utf-8")
-                merged.append(self.tool_relpath(main_path))
+                domain = self._delta_domain_for_spec(specs_delta, delta_spec)
+                if not domain:
+                    merge_errors.append(
+                        f"skipped non-domain delta path: {self.tool_relpath(delta_spec)}"
+                    )
+                    continue
+                domain_deltas.setdefault(domain, []).append(delta_spec)
+
+        for domain, paths in sorted(domain_deltas.items()):
+            main_path = domain_spec_path(self.workspace, domain)
+            if main_path.is_file():
+                main_text = main_path.read_text(encoding="utf-8")
+            else:
+                main_path.parent.mkdir(parents=True, exist_ok=True)
+                main_text = f"# {domain}\n\n"
+            for delta_spec in paths:
+                try:
+                    delta_text = delta_spec.read_text(encoding="utf-8")
+                    main_text = merge_delta_into_main(main_text, delta_text)
+                except Exception as exc:
+                    merge_errors.append(
+                        f"{self.tool_relpath(delta_spec)}: {exc}"
+                    )
+            main_path.write_text(main_text, encoding="utf-8")
+            merged.append(self.tool_relpath(main_path))
+
+        if merge_errors and not merged and not force:
+            return {
+                "ok": False,
+                "change_id": cid,
+                "error": "No specs merged",
+                "merge_errors": merge_errors,
+                "warnings": warnings,
+            }
 
         arch = archive_root(self.workspace)
         arch.mkdir(parents=True, exist_ok=True)
@@ -713,12 +788,17 @@ class SpecStore:
         if dest.exists():
             dest = arch / f"{stamp}-{cid}-{_unique_suffix()}"
         shutil.move(str(cdir), str(dest))
-        return {
+        result: dict = {
             "ok": True,
             "change_id": cid,
             "archived_to": self.tool_relpath(dest),
             "merged_specs": merged,
         }
+        if warnings:
+            result["warnings"] = warnings
+        if merge_errors:
+            result["merge_errors"] = merge_errors
+        return result
 
     def status_overview(self) -> dict:
         changes = self.list_changes() if self.is_initialized() else []

--- a/core/self_refinement/loop.py
+++ b/core/self_refinement/loop.py
@@ -243,7 +243,12 @@ Your improved response:"""
             output: RefinedOutput from the refinement process.
             original_task: The original user task.
         """
-        if not memory or not hasattr(memory, "episodic"):
+        if not memory:
+            return
+        # Facade properties raise when LTM is off (not AttributeError).
+        try:
+            episodic = memory.episodic
+        except Exception:
             return
 
         try:
@@ -256,7 +261,7 @@ Your improved response:"""
                 f"improvements: {', '.join(output.improvements[:3])}"
             )
 
-            await memory.episodic.store_episode(
+            await episodic.store_episode(
                 conversation_id=conversation_id,
                 summary=summary,
                 outcome=outcome,

--- a/core/skills/bundled.py
+++ b/core/skills/bundled.py
@@ -6,9 +6,35 @@ from pathlib import Path
 
 _BUNDLED_ROOT = Path(__file__).resolve().parent / "bundled"
 
+# Always (re)seed + assign on profile create/refresh — platform workflow skills.
+# Frontmatter ``required: true`` / ``platform: true`` also forces overwrite on seed.
+_REQUIRED_BUNDLED_FALLBACK = frozenset(
+    {
+        "holix-studio-frontend-backend",
+    }
+)
+
 
 def bundled_skills_root() -> Path:
     return _BUNDLED_ROOT
+
+
+def _skill_is_required(parsed: dict | None, *, entry_name: str) -> bool:
+    if not parsed:
+        return entry_name in _REQUIRED_BUNDLED_FALLBACK
+    name = str(parsed.get("name") or entry_name).strip()
+    if name in _REQUIRED_BUNDLED_FALLBACK:
+        return True
+    for key in ("required", "platform"):
+        val = parsed.get(key)
+        if val is True or str(val).strip().lower() in {"1", "true", "yes"}:
+            return True
+    tags = parsed.get("tags") or []
+    if isinstance(tags, str):
+        tags = [tags]
+    if any(str(t).strip().lower() in {"required", "platform"} for t in tags):
+        return True
+    return False
 
 
 def bundled_skill_names() -> list[str]:
@@ -30,6 +56,27 @@ def bundled_skill_names() -> list[str]:
     return names
 
 
+def required_bundled_skill_names() -> list[str]:
+    """Bundled skills that must exist on every profile and stay assigned to main."""
+    from core.hub.normalize import parse_skill_file
+
+    root = bundled_skills_root()
+    if not root.is_dir():
+        return sorted(_REQUIRED_BUNDLED_FALLBACK)
+    names: list[str] = []
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        skill_md = entry / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        parsed = parse_skill_file(skill_md)
+        name = (parsed.get("name") if parsed else None) or entry.name
+        if _skill_is_required(parsed, entry_name=entry.name):
+            names.append(name)
+    return names or sorted(_REQUIRED_BUNDLED_FALLBACK)
+
+
 def ensure_bundled_assigned_to_main(
     assignments: dict[str, list[str]] | None,
     skill_names: list[str] | None = None,
@@ -48,14 +95,23 @@ def ensure_bundled_assigned_to_main(
     before = set(out.get("main", []))
     for name in names:
         out = assign_skill_to_agents(out, name, ["main"])
+    # Required platform skills must always appear on main even if allowlist was empty.
+    for name in required_bundled_skill_names():
+        out = assign_skill_to_agents(out, name, ["main"])
     added = [n for n in names if n not in before and n in out.get("main", [])]
+    for name in required_bundled_skill_names():
+        if name not in before and name in out.get("main", []) and name not in added:
+            added.append(name)
     return out, added
 
 
 def seed_bundled_skills(skills_dir: Path, *, overwrite: bool = False) -> list[str]:
     """Copy packaged bundled skills into ``<profile>/data/skills/`` as flat ``{name}.md``.
 
-    Returns names of skills that were installed.
+    Skills marked ``required`` / ``platform`` are always rewritten so Studio
+    workflow updates reach existing profiles on next create/seed.
+
+    Returns names of skills that were installed or refreshed.
     """
     from core.hub.normalize import parse_skill_file, write_flat_skill
     from core.hub.slash_registry import rebuild_slash_registry
@@ -79,7 +135,8 @@ def seed_bundled_skills(skills_dir: Path, *, overwrite: bool = False) -> list[st
             continue
         name = parsed.get("name") or entry.name
         flat = dest_dir / f"{name}.md"
-        if flat.exists() and not overwrite:
+        force = overwrite or _skill_is_required(parsed, entry_name=entry.name)
+        if flat.exists() and not force:
             continue
         write_flat_skill(flat, parsed)
         installed.append(name)

--- a/core/skills/bundled/holix-sdd-archive/SKILL.md
+++ b/core/skills/bundled/holix-sdd-archive/SKILL.md
@@ -18,14 +18,28 @@ Change is implemented (tasks checked) and user wants to close it / merge require
 1. `sdd_status` with `change_id` — review remaining open tasks
 2. Confirm with user if any tasks incomplete
 3. `sdd_archive` with `change_id`
-4. Report merged main specs paths and archive folder under `openspec/changes/archive/`
+4. Report `merged_specs`, any `warnings` (open tasks / not apply_ready), and archive path under `openspec/changes/archive/`
 
 ## Effects
 
 - Delta `## ADDED|MODIFIED|REMOVED Requirements` merged into `openspec/specs/<domain>/spec.md`
+- Nested `specs/<domain>/**/spec.md` still merges into **that domain** (not a nested folder name as a new domain)
+- Sections apply in **document order** (later REMOVED of the same title wins over earlier MODIFIED)
+- Duplicate requirement titles in main collapse to one block
 - Change directory moved to `openspec/changes/archive/YYYY-MM-DD-<change-id>/`
+- Open tasks do **not** block archive; tool returns `warnings` — surface them to the user
+
+## Merge gotchas
+
+| Issue | Behavior |
+| --- | --- |
+| Same title ADDED when already in main | Body replaced (treated as modify) |
+| REMOVED then MODIFIED same title | **Last section in the delta file wins** |
+| Nested `specs/auth/notes/spec.md` | Merges into **auth**, not domain `notes` |
+| Incomplete tasks | Archive still runs; check `warnings` |
 
 ## Do NOT
 
 - Do not archive without user intent for incomplete work
 - Do not delete main specs; archive only moves the change folder after merge
+- Do not invent main specs by hand after archive — trust `merged_specs` paths

--- a/core/skills/bundled/holix-studio-frontend-backend/SKILL.md
+++ b/core/skills/bundled/holix-studio-frontend-backend/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: holix-studio-frontend-backend
 description: >
-  Wire frontend API base to the real Holix Studio backend public origin when both
-  apps run in Studio. Use when building or fixing SPA/API monorepos, Vite/Next/React
-  + FastAPI/Express, or any FE that calls a BE on another Studio preview port.
+  Run frontend (and FE+BE) apps in Holix Studio: always bind 0.0.0.0, always open
+  Studio preview links in chat, always prefer docker-compose with an nginx reverse
+  proxy that joins frontend and backend. Use when starting Vite/Next/Nuxt/React,
+  SPA+API monorepos, or any web app the user should open in Studio Browser.
   Invoke via /holix-studio-frontend-backend.
 tags:
   - holix
@@ -11,169 +12,235 @@ tags:
   - frontend
   - backend
   - preview
+  - docker
+  - nginx
   - vite
-  - api
-  - cors
+  - compose
+  - required
 user-invocable: true
+required: true
+platform: true
 ---
 
-## When to use
+## When to use (always in Studio)
 
-You are in **Holix Studio** and the project has (or will have) **both**:
+Apply this skill **whenever** you start, fix, or demo a **web** frontend (or FE+API) in Holix Studio:
 
-- a **frontend** (Vite, Next, CRA, static SPA, etc.) on one listen port
-- a **backend** API (FastAPI, Express, Django, …) on another listen port
+- User asks to run the app, open the UI, “подними фронт”, “запусти preview”, “открой в браузере”
+- Project has Vite / Next / Nuxt / CRA / static SPA ± API
+- You are about to say the app is ready
 
-Apply this skill **before** telling the user the app is ready, and whenever the frontend still points at `localhost` after both services are up.
+This skill is **platform / required**: do not ignore it for Studio web work.
 
-## Goal
+## Non‑negotiable rules
 
-The browser loads the frontend from Studio’s **public** preview URL (H2 subdomain or path proxy). From that browser context, `http://localhost:8000` is **the user’s machine**, not the Studio host. API calls must use the backend’s **real Studio public origin**.
+1. **Listen on `0.0.0.0` (never only `127.0.0.1`)** for any process that Studio Preview must reach  
+   (Vite/Nuxt `host: '0.0.0.0'`, uvicorn `--host 0.0.0.0`, nginx published port, etc.).
+2. **Always form real preview links in chat** after the app listens:
+   - Call MCP **`open_preview_url(port=…)`** (and for FE+BE, for **every** public port users need).
+   - Paste into the chat reply: `frame_url` / public origin from the tool result (Markdown link).
+   - Never tell the user to open `localhost` / bare `host:port` as the main URL.
+3. **Prefer docker-compose + nginx** for “run the app” demos:
+   - One **published** port on the host (nginx).
+   - Frontend and backend only on the **compose network** (expose, not host-publish unless needed).
+   - Nginx routes UI + API on the **same origin** (`/` → FE, `/api/` → BE) so the browser does not need a separate API host when possible.
+4. **Do not use Desktop / noVNC** for web apps — only **Studio → Browser** via `open_preview_url`.
+5. **Do not claim** “preview is ready” without a successful tool result that includes the public URL.
 
-## Mandatory workflow
-
-1. Start backend and frontend under the **profile workspace** (`start_background_process` / project scripts). Keep the **project’s configured ports** (do not invent random ports).
-2. Wait until both are healthy (listen + health check).
-3. Resolve public origins via built-in MCP **`holix_studio`** (tools appear as `mcp_holix_studio_*`):
-   - `open_preview_url(port=…)` for each service (user Browser + registers H2 when enabled)
-   - `preview_origins` — map `port → origin` for the whole profile
-   - `resolve_preview_origin_tool(port=BACKEND_PORT)` — single backend origin + siblings
-4. Set the **frontend** API base to the **backend** `origin` from that response (not localhost).
-5. If the backend enforces CORS, allow the **frontend** public origin (from `origins` / `open_preview_url` for the FE port).
-6. Restart the frontend dev server if env files changed, re-check health, open both previews again if needed.
-7. Tell the user to open **Studio → Browser** (or the returned `frame_url`) — never `localhost`.
-
-## What to put in frontend config
-
-Prefer the project’s existing env convention. Examples (use the real backend origin string from MCP):
-
-| Stack | Typical keys |
-| --- | --- |
-| Vite | `VITE_API_URL`, `VITE_API_BASE`, `VITE_BACKEND_URL` |
-| Next.js | `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_BACKEND_URL` |
-| CRA | `REACT_APP_API_URL` |
-| Code | `axios.defaults.baseURL`, `fetch` base, OpenAPI client `basePath` |
-
-Rules:
-
-- Value = **backend** public origin from MCP, e.g. `https://p8000-<id>.preview.example.com` or path-proxy `https://studio.example.com/studio/preview/8000`
-- No trailing slash unless the project already expects one (match existing style).
-- Do **not** use `http://127.0.0.1:PORT` or `http://localhost:PORT` for browser-facing API base.
-- Server-side only code that runs **on the Studio host** (SSR, build scripts talking to loopback) may still use `http://127.0.0.1:PORT` for same-machine calls — never for client-bundled env.
-
-## Backend CORS / cookies
-
-- Allow origin = frontend public origin (from MCP for the FE port).
-- If cookies/auth cross FE↔BE hosts (especially H2 subdomains), configure CORS credentials and cookie `SameSite` appropriately; prefer Studio ticket/bootstrap for preview auth rather than inventing hostnames.
-- In **path** mode both services may share the Studio host under different `/studio/preview/{port}/` prefixes — still use those public bases, not raw loopback.
-
-## Vite / Nuxt HMR WebSocket (not the API)
-
-Console errors like:
+## Preferred architecture (FE + BE)
 
 ```text
-[vite] failed to connect to websocket
-WebSocket connection to 'wss://p3000-….preview…/_nuxt/?token=…' failed
-WebSocket connection to 'wss://localhost:5173/_nuxt/?token=…' failed
+Browser → Studio preview (public HTTPS) → host:PORT → nginx container
+                                              ├─ /        → frontend:3000
+                                              └─ /api/    → backend:8000
 ```
 
-are **Hot Module Replacement**, not REST/GraphQL frontend↔backend wiring.
+Single public port → **one** `open_preview_url` → **one** link in chat.
 
-- The browser loads the app from the Studio **public** preview host.
-- Vite then opens a **WebSocket** for live reload. That path often fails behind Studio H2 / reverse proxy.
-- Fallback to `wss://localhost:5173` always fails for remote users (localhost is their laptop).
-- **The SPA can still work** without HMR (no hot reload until you refresh). Do not treat this as a broken API unless `fetch`/XHR to the backend also fails.
+### docker-compose.yml (template — adapt ports/paths)
 
-### Port must match
+Write under the project (e.g. `docker-compose.yml` or `deploy/docker-compose.studio.yml`):
 
-If the preview host is `p3000-…` but Vite prints `localhost:5173` as the server, ports are inconsistent:
+```yaml
+services:
+  frontend:
+    build: ./frontend   # or image + command for node
+    # CRITICAL: app inside container must listen 0.0.0.0
+    environment:
+      - HOST=0.0.0.0
+      - PORT=3000
+      # Prefer same-origin /api via nginx — no absolute localhost API
+      - VITE_API_URL=/api
+      - NEXT_PUBLIC_API_URL=/api
+    expose:
+      - "3000"
+    # no ports: on host — only nginx publishes
 
-1. Run the dev server on **one** port (prefer the project’s Nuxt/Vite port).
-2. Call `open_preview_url` with **that same** listen port.
-3. Do not open preview for 3000 while only Vite listens on 5173 (or vice versa).
+  backend:
+    build: ./backend
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8000
+    expose:
+      - "8000"
 
-### Preferred fix (keep HMR when possible)
-
-**Nuxt** (`nuxt.config.ts`):
-
-```ts
-export default defineNuxtConfig({
-  devServer: { host: '127.0.0.1', port: 3000 },
-  vite: {
-    server: {
-      allowedHosts: true,
-      hmr: {
-        protocol: 'wss',
-        clientPort: 443, // public HTTPS edge; avoids empty :port in wss URL
-      },
-    },
-  },
-})
+  nginx:
+    image: nginx:alpine
+    depends_on:
+      - frontend
+      - backend
+    ports:
+      # Published port = Studio preview port (pick free project port)
+      - "8080:80"
+    volumes:
+      - ./deploy/nginx.studio.conf:/etc/nginx/conf.d/default.conf:ro
 ```
 
-**Vite** (`vite.config.ts`):
+### nginx.studio.conf (template)
 
-```ts
-export default defineConfig({
-  server: {
-    host: '127.0.0.1',
-    port: 5173,
-    strictPort: true,
-    allowedHosts: true,
-    hmr: {
-      protocol: 'wss',
-      clientPort: 443,
-    },
-  },
-})
+```nginx
+server {
+    listen 80;
+    server_name _;
+    client_max_body_size 50m;
+
+    # Frontend (Vite/Next/Nuxt/static)
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    # Backend API (adjust prefix to match the app)
+    location /api/ {
+        proxy_pass http://backend:8000/;   # trailing slash strips /api prefix if BE has no /api
+        # use proxy_pass http://backend:8000;  # if BE routes already start with /api
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Optional OpenAPI / health
+    location /docs {
+        proxy_pass http://backend:8000/docs;
+        proxy_set_header Host $host;
+    }
+    location /health {
+        proxy_pass http://backend:8000/health;
+        proxy_set_header Host $host;
+    }
+}
 ```
 
-Then `open_preview_url(port=5173)` (or 3000 for Nuxt) — same port the process listens on.
+### Frontend API base when nginx fronts both
 
-### Reliable Studio fallback (no hot reload)
-
-If HMR still fails after the config above, **disable HMR** so the client does not spam errors or throw:
-
-```ts
-// when process.env.HOLIX_STUDIO is set, or always for Studio-targeted projects
-vite: {
-  server: {
-    hmr: false,
-    allowedHosts: true,
-  },
-},
-```
-
-Or start with a flag if the toolchain supports it. Hard-refresh the Browser panel after restart.
-
-### Do not confuse with API base
-
-| Concern | Fix |
+| Stack | Prefer |
 | --- | --- |
-| REST/API `fetch` to backend | Backend **public origin** via MCP (`VITE_API_URL` / …) |
-| `[vite] failed to connect to websocket` | HMR config / same listen port / `hmr: false` |
-| User open URL | `frame_url` / Studio Browser — never localhost |
+| Vite | `VITE_API_URL=/api` (or empty + relative `/api/...`) |
+| Next | `NEXT_PUBLIC_API_URL=/api` |
+| CRA | `REACT_APP_API_URL=/api` |
+| Axios/fetch | relative `/api/...` |
+
+Only if the user **must** call a **separate** public BE port (no nginx): set API base from MCP backend **public origin** (not localhost) — see “Split ports” below.
+
+## Mandatory agent workflow
+
+### A. Default: compose + nginx (propose this first)
+
+1. Inspect project (package.json, existing Dockerfile/compose, ports).
+2. **Propose** (and implement if user agrees / task implies run):
+   - `docker-compose` with **frontend**, **backend** (if any), **nginx**
+   - nginx joins FE+BE as above
+   - host bind **0.0.0.0** inside services; **one** published host port on nginx
+3. Start stack from workspace:
+   - Studio Docker tools / `docker compose up -d --build` in the project dir
+   - Or background process if user forbids Docker — still **0.0.0.0** + preview
+4. Wait until nginx port accepts HTTP (health / log / `check_background_process` / docker ps).
+5. **`open_preview_url(port=NGINX_HOST_PORT)`** (e.g. 8080).
+6. In the **same** assistant message after tools succeed, include Markdown links, e.g.:
+
+   ```markdown
+   **Приложение:** [открыть preview](<frame_url or public origin from tool>)
+   Порт: 8080 · nginx → frontend + `/api` → backend
+   ```
+
+7. If FE-only (no BE), still use nginx (or the FE process on `0.0.0.0`) and still call `open_preview_url` + link in chat.
+
+### B. Dev servers without Docker (fallback)
+
+Only if Docker is unavailable or user forbids it:
+
+1. Start processes with **host `0.0.0.0`**:
+   - Vite: `server: { host: '0.0.0.0', port, strictPort: true, allowedHosts: true }`
+   - Nuxt: `devServer: { host: '0.0.0.0', port }`
+   - uvicorn: `--host 0.0.0.0 --port …`
+2. Prefer a small **local nginx** (compose one-service nginx + upstream host network) still if possible.
+3. `open_preview_url` for each user-facing port; put **all** links in chat.
+4. If FE and BE are separate public ports (no shared nginx origin):
+   - `open_preview_url` for FE **and** BE
+   - Set FE env to **backend public origin** from `resolve_preview_origin_tool` / `preview_origins`
+   - CORS on BE must allow **frontend public origin**
+
+### C. Split ports (no nginx) — API base
+
+Same as before, but secondary to nginx:
+
+1. `resolve_preview_origin_tool(port=BACKEND)` or `preview_origins`
+2. FE env = backend **origin** (H2 or path proxy) — never `http://localhost:PORT` for the browser
+3. Restart FE after env change; re-open previews; link both URLs in chat
+
+## Vite / Nuxt HMR (secondary)
+
+HMR WebSocket may fail behind Studio preview. SPA can still work without hot reload.
+
+- Keep listen port consistent with `open_preview_url`
+- Prefer `allowedHosts: true`, host `0.0.0.0`
+- If HMR spam: `hmr: false` or `clientPort: 443` for wss edge — see stack docs
+- Do **not** confuse HMR errors with broken REST API
 
 ## Do NOT
 
-- Advertise `localhost` / bare host:port as the user-facing API or app URL.
-- Invent H2 hostnames or endpoint ids — always call `open_preview_url` / `resolve_preview_origin_tool`.
-- Leave a committed `.env` with `localhost` as the only API URL when the app is meant to run in Studio (use Studio-resolved origin or document both local vs Studio).
-- Point the frontend at the **frontend** origin by mistake — API base must be the **backend** port’s origin.
-- Open the app via **Desktop** (`desktop_start` / `desktop_exec` / firefox in noVNC). Web apps go to **Studio → Browser** via `open_preview_url`. Desktop is only for native GUI apps or when the user asks for Desktop.
+- Start web servers only on `127.0.0.1` when Studio preview is required
+- Advertise localhost as the user URL
+- Invent H2 hostnames — only MCP `open_preview_url` / `preview_origins`
+- Open web apps via Desktop/noVNC
+- Install random host nginx/yadisk/rclone for “preview” when Studio Browser + compose is available
+- Say “я открыл preview” without a tool result containing the URL
+- Skip proposing **docker-compose + nginx** for FE+BE run tasks
 
 ## Checklist before “done”
 
-- [ ] Backend healthy on its port
-- [ ] Frontend healthy on its port
-- [ ] `resolve_preview_origin_tool` (or `preview_origins`) used for backend
-- [ ] Frontend env / client baseURL = backend public origin
-- [ ] CORS allows frontend public origin if needed
-- [ ] Frontend restarted after env change
-- [ ] User told to open Studio Browser / `frame_url`, not localhost
+- [ ] Services listen on **0.0.0.0** (or via nginx published port)
+- [ ] **docker-compose + nginx** proposed (and used when possible) for FE+BE
+- [ ] Nginx routes `/` → FE and `/api/` (or project prefix) → BE
+- [ ] FE uses **same-origin `/api`** or backend **public** origin (not laptop localhost)
+- [ ] `open_preview_url` called for the public port(s)
+- [ ] Chat message includes clickable **preview link(s)** from tool output
+- [ ] User told: Studio Browser / the link — not localhost
 
-## Related
+## Related tools (Studio)
 
-- System prompt block: Holix Studio browser preview
-- MCP: `list_preview_targets`, `preview_origins`, `resolve_preview_origin_tool`, `open_preview_url`
-- Skill: holix-cron / holix-subagents are unrelated; this skill is only FE↔BE wiring in Studio
+- MCP `holix_studio`: `open_preview_url`, `list_preview_targets`, `preview_origins`, `resolve_preview_origin_tool`
+- Docker panel / compose tools for workspace stacks
+- `start_background_process` / terminal only as fallback when compose is impossible
+
+## Telegram + Studio (same Holix profile)
+
+Processes started from **Telegram** for a user profile must appear in **Studio** for that
+same profile (Processes panel + Browser targets):
+
+- Holix persists a shared index: `HOLIX_HOME/profiles/<profile>/data/background_processes.json`
+- Always use `start_background_process` (not detached raw nohup outside Holix)
+- Bind **0.0.0.0** and call `open_preview_url` so Studio Browser can attach
+- Workspace cwd must stay under the profile workspace so Studio can list the app
+
+## Slash
+
+`/holix-studio-frontend-backend` — re-apply this workflow (ports, compose+nginx, preview links).

--- a/core/subagents/async_runner.py
+++ b/core/subagents/async_runner.py
@@ -180,6 +180,32 @@ class AsyncSubAgentRunner:
                     )
                     self._notify_progress(config.name)
 
+                    # Runtime supervisor guidance (same job course-correction)
+                    try:
+                        from core.subagents.supervisor import (
+                            drain_guidance_messages,
+                            format_guidance_system_message,
+                        )
+
+                        if self._comm_bus is not None:
+                            guidance_texts = await drain_guidance_messages(
+                                self._comm_bus.receive,
+                                config.name,
+                            )
+                            gmsg = format_guidance_system_message(guidance_texts)
+                            if gmsg:
+                                messages.append({"role": "system", "content": gmsg})
+                                handle.record_activity(
+                                    "status",
+                                    "Applied supervisor guidance",
+                                    steps_taken=steps_taken,
+                                )
+                    except Exception:
+                        logger.debug(
+                            "sub-agent guidance drain failed",
+                            exc_info=True,
+                        )
+
                     # Set up timeout
                     try:
                         response = await asyncio.wait_for(

--- a/core/subagents/async_runner.py
+++ b/core/subagents/async_runner.py
@@ -94,7 +94,9 @@ class AsyncSubAgentRunner:
         start_time = time.monotonic()
         tool_calls_made: list[dict[str, Any]] = []
         steps_taken = 0
-        max_steps = config.max_steps
+        max_steps = int(config.max_steps or 0)
+        base_max_steps = max_steps
+        step_budget_extensions = 0
 
         # Build client (inherit from parent or use config override)
         model = config.model or self._parent.model
@@ -163,164 +165,207 @@ class AsyncSubAgentRunner:
         # ReAct loop
         tokens_used = 0
         try:
-            while steps_taken < max_steps:
-                steps_taken += 1
+            from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
+
+            step_policy = StepBudgetPolicy.from_config(parent_cfg)
+
+            while True:
+                while steps_taken < max_steps:
+                    steps_taken += 1
+                    handle.max_steps = max_steps
+                    handle.record_activity(
+                        "step",
+                        f"Reasoning step {steps_taken}/{max_steps}",
+                        steps_taken=steps_taken,
+                    )
+                    self._notify_progress(config.name)
+
+                    # Set up timeout
+                    try:
+                        response = await asyncio.wait_for(
+                            client.chat.completions.create(
+                                model=model,
+                                messages=messages,
+                                tools=tools_schemas if tools_schemas else None,
+                                tool_choice="auto" if tools_schemas else None,
+                                temperature=config.temperature,
+                            ),
+                            timeout=config.timeout,
+                        )
+                    except TimeoutError:
+                        handle.status = SubAgentStatus.TIMED_OUT
+                        handle.record_activity(
+                            "status",
+                            f"Timed out after {config.timeout}s",
+                            steps_taken=steps_taken,
+                        )
+                        handle.result = SubAgentResult(
+                            name=config.name,
+                            success=False,
+                            error=f"Sub-agent timed out after {config.timeout}s",
+                            duration_ms=(time.monotonic() - start_time) * 1000,
+                            steps_taken=steps_taken,
+                            tool_calls=tool_calls_made,
+                            tokens_used=tokens_used,
+                        )
+                        return handle.result
+
+                    message = response.choices[0].message
+                    try:
+                        from core.llm.usage import (
+                            completion_text_from_message,
+                            resolve_usage,
+                        )
+
+                        usage = resolve_usage(
+                            response,
+                            messages=messages,
+                            completion_text=completion_text_from_message(message),
+                            model=model,
+                        )
+                        tokens_used += int(usage.get("total_tokens") or 0)
+                    except Exception:
+                        logger.debug("Sub-agent token accounting failed", exc_info=True)
+
+                    if message.tool_calls:
+                        # Execute tool calls
+                        msg_dict = {
+                            "role": "assistant",
+                            "content": message.content or "",
+                            "tool_calls": [
+                                {
+                                    "id": tc.id,
+                                    "type": tc.type,
+                                    "function": {
+                                        "name": tc.function.name,
+                                        "arguments": tc.function.arguments,
+                                    },
+                                }
+                                for tc in message.tool_calls
+                            ],
+                        }
+                        messages.append(msg_dict)
+
+                        for tc in message.tool_calls:
+                            tool_name = tc.function.name
+                            tool_calls_made.append({
+                                "name": tool_name,
+                                "arguments": tc.function.arguments,
+                            })
+                            handle.record_activity(
+                                "tool_start",
+                                f"Calling {tool_name}",
+                                tool_name=tool_name,
+                                details=(tc.function.arguments or "")[:300],
+                                steps_taken=steps_taken,
+                            )
+                            self._notify_progress(config.name)
+                            result = await self._execute_tool(tc, config)
+                            preview = (result or "").strip()
+                            if len(preview) > 240:
+                                preview = preview[:239] + "…"
+                            tool_calls_made[-1]["result"] = result
+                            handle.record_activity(
+                                "tool_result",
+                                f"{tool_name} finished",
+                                tool_name=tool_name,
+                                details=preview,
+                                steps_taken=steps_taken,
+                            )
+                            self._notify_progress(config.name)
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tc.id,
+                                "content": result,
+                            })
+                    else:
+                        # Final response
+                        final_response = message.content or "No response"
+                        messages.append({"role": "assistant", "content": final_response})
+
+                        duration_ms = (time.monotonic() - start_time) * 1000
+                        handle.status = SubAgentStatus.COMPLETED
+                        handle.record_activity(
+                            "status",
+                            "Completed",
+                            steps_taken=steps_taken,
+                        )
+                        handle.result = SubAgentResult(
+                            name=config.name,
+                            success=True,
+                            response=final_response,
+                            duration_ms=duration_ms,
+                            steps_taken=steps_taken,
+                            tool_calls=tool_calls_made,
+                            tokens_used=tokens_used,
+                        )
+                        logger.info(
+                            "Sub-agent '%s' completed (steps=%d, tools=%d, %.0fms)",
+                            config.name,
+                            steps_taken,
+                            len(tool_calls_made),
+                            duration_ms,
+                        )
+                        return handle.result
+
+                # Max steps: health-check — extend if still working with relevant progress
+                decision = evaluate_step_budget(
+                    step_count=steps_taken,
+                    max_steps=max_steps,
+                    extensions_used=step_budget_extensions,
+                    messages=messages,
+                    tool_calls_log=tool_calls_made,
+                    task=task,
+                    policy=step_policy,
+                    base_max_steps=base_max_steps,
+                )
+                if decision.extend:
+                    prev = max_steps
+                    max_steps = decision.new_max_steps
+                    step_budget_extensions = decision.extensions_used
+                    handle.max_steps = max_steps
+                    handle.record_activity(
+                        "step_budget_extended",
+                        (
+                            f"Step budget +{decision.extra_steps} "
+                            f"({prev} → {max_steps}): {decision.reason}"
+                        ),
+                        steps_taken=steps_taken,
+                    )
+                    self._notify_progress(config.name)
+                    logger.info(
+                        "Sub-agent '%s' step budget extended %s → %s (ext=%s)",
+                        config.name,
+                        prev,
+                        max_steps,
+                        step_budget_extensions,
+                    )
+                    continue
+
+                duration_ms = (time.monotonic() - start_time) * 1000
+                handle.status = SubAgentStatus.FAILED
                 handle.record_activity(
-                    "step",
-                    f"Reasoning step {steps_taken}/{max_steps}",
+                    "status",
+                    f"Max steps ({max_steps}) reached: {decision.reason}",
                     steps_taken=steps_taken,
                 )
-                self._notify_progress(config.name)
-
-                # Set up timeout
-                try:
-                    response = await asyncio.wait_for(
-                        client.chat.completions.create(
-                            model=model,
-                            messages=messages,
-                            tools=tools_schemas if tools_schemas else None,
-                            tool_choice="auto" if tools_schemas else None,
-                            temperature=config.temperature,
-                        ),
-                        timeout=config.timeout,
-                    )
-                except TimeoutError:
-                    handle.status = SubAgentStatus.TIMED_OUT
-                    handle.record_activity(
-                        "status",
-                        f"Timed out after {config.timeout}s",
-                        steps_taken=steps_taken,
-                    )
-                    handle.result = SubAgentResult(
-                        name=config.name,
-                        success=False,
-                        error=f"Sub-agent timed out after {config.timeout}s",
-                        duration_ms=(time.monotonic() - start_time) * 1000,
-                        steps_taken=steps_taken,
-                        tool_calls=tool_calls_made,
-                        tokens_used=tokens_used,
-                    )
-                    return handle.result
-
-                message = response.choices[0].message
-                try:
-                    from core.llm.usage import (
-                        completion_text_from_message,
-                        resolve_usage,
-                    )
-
-                    usage = resolve_usage(
-                        response,
-                        messages=messages,
-                        completion_text=completion_text_from_message(message),
-                        model=model,
-                    )
-                    tokens_used += int(usage.get("total_tokens") or 0)
-                except Exception:
-                    logger.debug("Sub-agent token accounting failed", exc_info=True)
-
-                if message.tool_calls:
-                    # Execute tool calls
-                    msg_dict = {
-                        "role": "assistant",
-                        "content": message.content or "",
-                        "tool_calls": [
-                            {
-                                "id": tc.id,
-                                "type": tc.type,
-                                "function": {
-                                    "name": tc.function.name,
-                                    "arguments": tc.function.arguments,
-                                },
-                            }
-                            for tc in message.tool_calls
-                        ],
-                    }
-                    messages.append(msg_dict)
-
-                    for tc in message.tool_calls:
-                        tool_name = tc.function.name
-                        tool_calls_made.append({
-                            "name": tool_name,
-                            "arguments": tc.function.arguments,
-                        })
-                        handle.record_activity(
-                            "tool_start",
-                            f"Calling {tool_name}",
-                            tool_name=tool_name,
-                            details=(tc.function.arguments or "")[:300],
-                            steps_taken=steps_taken,
-                        )
-                        self._notify_progress(config.name)
-                        result = await self._execute_tool(tc, config)
-                        preview = (result or "").strip()
-                        if len(preview) > 240:
-                            preview = preview[:239] + "…"
-                        handle.record_activity(
-                            "tool_result",
-                            f"{tool_name} finished",
-                            tool_name=tool_name,
-                            details=preview,
-                            steps_taken=steps_taken,
-                        )
-                        self._notify_progress(config.name)
-                        messages.append({
-                            "role": "tool",
-                            "tool_call_id": tc.id,
-                            "content": result,
-                        })
-                else:
-                    # Final response
-                    final_response = message.content or "No response"
-                    messages.append({"role": "assistant", "content": final_response})
-
-                    duration_ms = (time.monotonic() - start_time) * 1000
-                    handle.status = SubAgentStatus.COMPLETED
-                    handle.record_activity(
-                        "status",
-                        "Completed",
-                        steps_taken=steps_taken,
-                    )
-                    handle.result = SubAgentResult(
-                        name=config.name,
-                        success=True,
-                        response=final_response,
-                        duration_ms=duration_ms,
-                        steps_taken=steps_taken,
-                        tool_calls=tool_calls_made,
-                        tokens_used=tokens_used,
-                    )
-                    logger.info(
-                        "Sub-agent '%s' completed (steps=%d, tools=%d, %.0fms)",
-                        config.name,
-                        steps_taken,
-                        len(tool_calls_made),
-                        duration_ms,
-                    )
-                    return handle.result
-
-            # Max steps reached
-            duration_ms = (time.monotonic() - start_time) * 1000
-            handle.status = SubAgentStatus.FAILED
-            handle.record_activity(
-                "status",
-                f"Max steps ({max_steps}) reached",
-                steps_taken=steps_taken,
-            )
-            handle.result = SubAgentResult(
-                name=config.name,
-                success=False,
-                response="Sub-agent reached maximum steps",
-                error=f"Max steps ({max_steps}) reached",
-                duration_ms=duration_ms,
-                steps_taken=steps_taken,
-                tool_calls=tool_calls_made,
-                        tokens_used=tokens_used,
-            )
-            logger.warning(
-                "Sub-agent '%s' hit max steps (%d)", config.name, max_steps
-            )
-            return handle.result
+                handle.result = SubAgentResult(
+                    name=config.name,
+                    success=False,
+                    response="Sub-agent reached maximum steps",
+                    error=f"Max steps ({max_steps}) reached: {decision.reason}",
+                    duration_ms=duration_ms,
+                    steps_taken=steps_taken,
+                    tool_calls=tool_calls_made,
+                    tokens_used=tokens_used,
+                )
+                logger.warning(
+                    "Sub-agent '%s' hit max steps (%d): %s",
+                    config.name,
+                    max_steps,
+                    decision.reason,
+                )
+                return handle.result
 
         except asyncio.CancelledError:
             handle.status = SubAgentStatus.CANCELLED

--- a/core/subagents/manager.py
+++ b/core/subagents/manager.py
@@ -82,6 +82,7 @@ class SubAgentManager:
         self._progress_min_interval = 1.25
         self._runtime_owner: str | None = None
         self._runtime_source: str | None = None
+        self._supervisor: Any = None
 
     def _max_concurrent(self) -> int:
         cfg = getattr(self._parent, "config", None)
@@ -258,7 +259,26 @@ class SubAgentManager:
         self._register_handle(config.name, handle)
         self._emit_started(handle)
         self._publish_runtime(handle)
+        self._ensure_supervisor().ensure_running()
+        if self._supervisor is not None:
+            try:
+                self._supervisor.reset_job(config.name)
+            except Exception:
+                pass
         return handle
+
+    def _ensure_supervisor(self) -> Any:
+        """Lazy-create the runtime supervisor (watches jobs, injects guidance)."""
+        if self._supervisor is not None:
+            return self._supervisor
+        from core.subagents.supervisor import SubagentSupervisor, SupervisorPolicy
+
+        cfg = getattr(self._parent, "config", None)
+        self._supervisor = SubagentSupervisor(
+            self,
+            policy=SupervisorPolicy.from_config(cfg),
+        )
+        return self._supervisor
 
     def _register_handle(self, name: str, handle: SubAgentHandle) -> None:
         """Track a handle and reconcile completion notifications."""

--- a/core/subagents/process.py
+++ b/core/subagents/process.py
@@ -363,6 +363,49 @@ def run_sub_agent_in_process(
                     steps_taken=steps_taken,
                 )
 
+                # Drain supervisor guidance / cancel from parent
+                try:
+                    while True:
+                        try:
+                            data = input_queue.get_nowait()
+                        except Exception:
+                            break
+                        msg = AgentMessage.deserialize(data)
+                        if msg.msg_type == "cancel":
+                            result = SubAgentResult(
+                                name=config.name,
+                                success=False,
+                                error="Cancelled by parent",
+                                duration_ms=(time.monotonic() - start_time) * 1000,
+                                steps_taken=steps_taken,
+                                tool_calls=tool_calls_made,
+                                tokens_used=tokens_used,
+                            )
+                            _send_result(output_queue, config.name, result)
+                            heartbeat_stop.set()
+                            return
+                        if msg.msg_type in {"guidance", "revise"} and (msg.content or "").strip():
+                            messages.append(
+                                {
+                                    "role": "system",
+                                    "content": (
+                                        "### Runtime supervisor intervention\n"
+                                        "The parent runtime detected a problem and sent guidance. "
+                                        "Follow it on this step:\n\n"
+                                        f"{msg.content.strip()}"
+                                    ),
+                                }
+                            )
+                            _send_progress(
+                                output_queue,
+                                config.name,
+                                kind="status",
+                                message="Applied supervisor guidance",
+                                steps_taken=steps_taken,
+                            )
+                except Exception:
+                    pass
+
                 # LLM call with timeout
                 try:
                     response = loop.run_until_complete(

--- a/core/subagents/process.py
+++ b/core/subagents/process.py
@@ -294,10 +294,22 @@ def run_sub_agent_in_process(
     tool_calls_made: list[dict[str, Any]] = []
     steps_taken = 0
     tokens_used = 0
-    max_steps = config.max_steps
+    max_steps = int(config.max_steps or 0)
+    base_max_steps = max_steps
+    step_budget_extensions = 0
     result = None
 
     try:
+        from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
+
+        # Process workers may not have full parent Settings; use env-backed defaults.
+        try:
+            from config import settings as _settings
+
+            step_policy = StepBudgetPolicy.from_config(_settings)
+        except Exception:
+            step_policy = StepBudgetPolicy()
+
         # Start heartbeat in background
         heartbeat_stop = multiprocessing.Event()
 
@@ -319,179 +331,208 @@ def run_sub_agent_in_process(
         hb_thread = threading.Thread(target=heartbeat_worker, daemon=True)
         hb_thread.start()
 
-        while steps_taken < max_steps:
-            # Check for cancel signal
-            try:
-                while not input_queue.empty():
-                    data = input_queue.get_nowait()
-                    msg = AgentMessage.deserialize(data)
-                    if msg.msg_type == "cancel":
-                        result = SubAgentResult(
-                            name=config.name,
-                            success=False,
-                            error="Cancelled by parent",
-                            duration_ms=(time.monotonic() - start_time) * 1000,
+        while True:
+            while steps_taken < max_steps:
+                # Check for cancel signal
+                try:
+                    while not input_queue.empty():
+                        data = input_queue.get_nowait()
+                        msg = AgentMessage.deserialize(data)
+                        if msg.msg_type == "cancel":
+                            result = SubAgentResult(
+                                name=config.name,
+                                success=False,
+                                error="Cancelled by parent",
+                                duration_ms=(time.monotonic() - start_time) * 1000,
+                                steps_taken=steps_taken,
+                                tool_calls=tool_calls_made,
+                                tokens_used=tokens_used,
+                            )
+                            _send_result(output_queue, config.name, result)
+                            heartbeat_stop.set()
+                            return
+                except Exception:
+                    pass
+
+                steps_taken += 1
+                _send_progress(
+                    output_queue,
+                    config.name,
+                    kind="step",
+                    message=f"Reasoning step {steps_taken}/{max_steps}",
+                    steps_taken=steps_taken,
+                )
+
+                # LLM call with timeout
+                try:
+                    response = loop.run_until_complete(
+                        _asyncio.wait_for(
+                            client.chat.completions.create(
+                                model=model,
+                                messages=messages,
+                                tools=tools_schemas if tools_schemas else None,
+                                tool_choice="auto" if tools_schemas else None,
+                                temperature=config.temperature,
+                            ),
+                            timeout=config.timeout,
+                        )
+                    )
+                except TimeoutError:
+                    result = SubAgentResult(
+                        name=config.name,
+                        success=False,
+                        error=f"Timed out after {config.timeout}s",
+                        duration_ms=(time.monotonic() - start_time) * 1000,
+                        steps_taken=steps_taken,
+                        tool_calls=tool_calls_made,
+                        tokens_used=tokens_used,
+                    )
+                    _send_result(output_queue, config.name, result)
+                    heartbeat_stop.set()
+                    return
+
+                message = response.choices[0].message
+                try:
+                    from core.llm.usage import (
+                        completion_text_from_message,
+                        resolve_usage,
+                    )
+
+                    usage = resolve_usage(
+                        response,
+                        messages=messages,
+                        completion_text=completion_text_from_message(message),
+                        model=model,
+                    )
+                    tokens_used += int(usage.get("total_tokens") or 0)
+                except Exception:
+                    pass
+
+                if message.tool_calls:
+                    msg_dict = {
+                        "role": "assistant",
+                        "content": message.content or "",
+                        "tool_calls": [
+                            {
+                                "id": tc.id,
+                                "type": tc.type,
+                                "function": {
+                                    "name": tc.function.name,
+                                    "arguments": tc.function.arguments,
+                                },
+                            }
+                            for tc in message.tool_calls
+                        ],
+                    }
+                    messages.append(msg_dict)
+
+                    for tc in message.tool_calls:
+                        tool_name = tc.function.name
+                        tool_calls_made.append({
+                            "name": tool_name,
+                            "arguments": tc.function.arguments,
+                        })
+                        _send_progress(
+                            output_queue,
+                            config.name,
+                            kind="tool_start",
+                            message=f"Calling {tool_name}",
                             steps_taken=steps_taken,
-                            tool_calls=tool_calls_made,
-                            tokens_used=tokens_used,
+                            tool_name=tool_name,
+                            details=(tc.function.arguments or "")[:300],
                         )
-                        _send_result(output_queue, config.name, result)
-                        heartbeat_stop.set()
-                        return
-            except Exception:
-                pass
 
-            steps_taken += 1
-            _send_progress(
-                output_queue,
-                config.name,
-                kind="step",
-                message=f"Reasoning step {steps_taken}/{max_steps}",
-                steps_taken=steps_taken,
+                        try:
+                            tool_result = _execute_tool_guarded(
+                                registry,
+                                tc,
+                                config=config,
+                                profile_name=profile_name,
+                                output_queue=output_queue,
+                                input_queue=input_queue,
+                                auto_allow_threshold=auto_allow_threshold,
+                                confirmation_timeout=confirmation_timeout,
+                                interactive=interactive,
+                                data_dir=data_dir,
+                                loop=loop,
+                            )
+                        except Exception as e:
+                            tool_result = f"Error: {e}"
+
+                        preview = (tool_result or "").strip()
+                        if len(preview) > 240:
+                            preview = preview[:239] + "…"
+                        tool_calls_made[-1]["result"] = tool_result
+                        _send_progress(
+                            output_queue,
+                            config.name,
+                            kind="tool_result",
+                            message=f"{tool_name} finished",
+                            steps_taken=steps_taken,
+                            tool_name=tool_name,
+                            details=preview,
+                        )
+
+                        messages.append({
+                            "role": "tool",
+                            "tool_call_id": tc.id,
+                            "content": tool_result,
+                        })
+                else:
+                    # Final answer
+                    final_response = message.content or "No response"
+                    result = SubAgentResult(
+                        name=config.name,
+                        success=True,
+                        response=final_response,
+                        duration_ms=(time.monotonic() - start_time) * 1000,
+                        steps_taken=steps_taken,
+                        tool_calls=tool_calls_made,
+                        tokens_used=tokens_used,
+                    )
+                    _send_result(output_queue, config.name, result)
+                    heartbeat_stop.set()
+                    return
+
+            # Max steps: health-check — extend if still working
+            decision = evaluate_step_budget(
+                step_count=steps_taken,
+                max_steps=max_steps,
+                extensions_used=step_budget_extensions,
+                messages=messages,
+                tool_calls_log=tool_calls_made,
+                task=str(task or ""),
+                policy=step_policy,
+                base_max_steps=base_max_steps,
             )
-
-            # LLM call with timeout
-            try:
-                response = loop.run_until_complete(
-                    _asyncio.wait_for(
-                        client.chat.completions.create(
-                            model=model,
-                            messages=messages,
-                            tools=tools_schemas if tools_schemas else None,
-                            tool_choice="auto" if tools_schemas else None,
-                            temperature=config.temperature,
-                        ),
-                        timeout=config.timeout,
-                    )
-                )
-            except TimeoutError:
-                result = SubAgentResult(
-                    name=config.name,
-                    success=False,
-                    error=f"Timed out after {config.timeout}s",
-                    duration_ms=(time.monotonic() - start_time) * 1000,
+            if decision.extend:
+                prev = max_steps
+                max_steps = decision.new_max_steps
+                step_budget_extensions = decision.extensions_used
+                _send_progress(
+                    output_queue,
+                    config.name,
+                    kind="step_budget_extended",
+                    message=(
+                        f"Step budget +{decision.extra_steps} "
+                        f"({prev} → {max_steps}): {decision.reason}"
+                    ),
                     steps_taken=steps_taken,
-                    tool_calls=tool_calls_made,
-                    tokens_used=tokens_used,
                 )
-                _send_result(output_queue, config.name, result)
-                heartbeat_stop.set()
-                return
+                continue
 
-            message = response.choices[0].message
-            try:
-                from core.llm.usage import (
-                    completion_text_from_message,
-                    resolve_usage,
-                )
-
-                usage = resolve_usage(
-                    response,
-                    messages=messages,
-                    completion_text=completion_text_from_message(message),
-                    model=model,
-                )
-                tokens_used += int(usage.get("total_tokens") or 0)
-            except Exception:
-                pass
-
-            if message.tool_calls:
-                msg_dict = {
-                    "role": "assistant",
-                    "content": message.content or "",
-                    "tool_calls": [
-                        {
-                            "id": tc.id,
-                            "type": tc.type,
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            },
-                        }
-                        for tc in message.tool_calls
-                    ],
-                }
-                messages.append(msg_dict)
-
-                for tc in message.tool_calls:
-                    tool_name = tc.function.name
-                    tool_calls_made.append({
-                        "name": tool_name,
-                        "arguments": tc.function.arguments,
-                    })
-                    _send_progress(
-                        output_queue,
-                        config.name,
-                        kind="tool_start",
-                        message=f"Calling {tool_name}",
-                        steps_taken=steps_taken,
-                        tool_name=tool_name,
-                        details=(tc.function.arguments or "")[:300],
-                    )
-
-                    try:
-                        tool_result = _execute_tool_guarded(
-                            registry,
-                            tc,
-                            config=config,
-                            profile_name=profile_name,
-                            output_queue=output_queue,
-                            input_queue=input_queue,
-                            auto_allow_threshold=auto_allow_threshold,
-                            confirmation_timeout=confirmation_timeout,
-                            interactive=interactive,
-                            data_dir=data_dir,
-                            loop=loop,
-                        )
-                    except Exception as e:
-                        tool_result = f"Error: {e}"
-
-                    preview = (tool_result or "").strip()
-                    if len(preview) > 240:
-                        preview = preview[:239] + "…"
-                    _send_progress(
-                        output_queue,
-                        config.name,
-                        kind="tool_result",
-                        message=f"{tool_name} finished",
-                        steps_taken=steps_taken,
-                        tool_name=tool_name,
-                        details=preview,
-                    )
-
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": tool_result,
-                    })
-            else:
-                # Final answer
-                final_response = message.content or "No response"
-                result = SubAgentResult(
-                    name=config.name,
-                    success=True,
-                    response=final_response,
-                    duration_ms=(time.monotonic() - start_time) * 1000,
-                    steps_taken=steps_taken,
-                    tool_calls=tool_calls_made,
-                    tokens_used=tokens_used,
-                )
-                _send_result(output_queue, config.name, result)
-                heartbeat_stop.set()
-                return
-
-        # Max steps
-        result = SubAgentResult(
-            name=config.name,
-            success=False,
-            error=f"Max steps ({max_steps}) reached",
-            duration_ms=(time.monotonic() - start_time) * 1000,
-            steps_taken=steps_taken,
-            tool_calls=tool_calls_made,
-            tokens_used=tokens_used,
-        )
-        _send_result(output_queue, config.name, result)
-        heartbeat_stop.set()
+            result = SubAgentResult(
+                name=config.name,
+                success=False,
+                error=f"Max steps ({max_steps}) reached: {decision.reason}",
+                duration_ms=(time.monotonic() - start_time) * 1000,
+                steps_taken=steps_taken,
+                tool_calls=tool_calls_made,
+                tokens_used=tokens_used,
+            )
+            _send_result(output_queue, config.name, result)
+            heartbeat_stop.set()
+            return
 
     except Exception as e:
         result = SubAgentResult(

--- a/core/subagents/supervisor.py
+++ b/core/subagents/supervisor.py
@@ -1,0 +1,557 @@
+"""Runtime Subagent Supervisor — watch jobs, diagnose stalls, inject guidance.
+
+MVP: asyncio background loop attached to ``SubAgentManager``. Detects loop /
+thrash / hang / stall using activity logs and step-budget heuristics, then
+sends a ``guidance`` message to the **same** sub-agent so its next reasoning
+step can course-correct.
+
+See ``docs/plans/SUBAGENT_SUPERVISOR_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.runtime.step_budget import (
+    _looks_like_error,
+    _looks_like_progress,
+    _tool_signature,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_POLL_S = 4.0
+DEFAULT_IDLE_S = 90.0
+DEFAULT_MAX_INTERVENTIONS = 3
+DEFAULT_COOLDOWN_S = 45.0
+DEFAULT_MIN_STEPS_BEFORE_STALL = 4
+
+
+@dataclass(slots=True)
+class SupervisorPolicy:
+    enabled: bool = True
+    poll_s: float = DEFAULT_POLL_S
+    idle_s: float = DEFAULT_IDLE_S
+    max_interventions: int = DEFAULT_MAX_INTERVENTIONS
+    cooldown_s: float = DEFAULT_COOLDOWN_S
+    min_steps_before_stall: int = DEFAULT_MIN_STEPS_BEFORE_STALL
+
+    @classmethod
+    def from_config(cls, cfg: Any | None) -> SupervisorPolicy:
+        if cfg is None:
+            return cls()
+        enabled = getattr(cfg, "subagent_supervisor_enabled", True)
+        if enabled is None:
+            enabled = True
+        return cls(
+            enabled=bool(enabled),
+            poll_s=max(
+                1.0,
+                float(
+                    getattr(cfg, "subagent_supervisor_poll_s", DEFAULT_POLL_S)
+                    or DEFAULT_POLL_S
+                ),
+            ),
+            idle_s=max(
+                5.0,
+                float(
+                    getattr(cfg, "subagent_supervisor_idle_s", DEFAULT_IDLE_S)
+                    or DEFAULT_IDLE_S
+                ),
+            ),
+            max_interventions=max(
+                0,
+                int(
+                    getattr(
+                        cfg,
+                        "subagent_supervisor_max_interventions",
+                        DEFAULT_MAX_INTERVENTIONS,
+                    )
+                    or DEFAULT_MAX_INTERVENTIONS
+                ),
+            ),
+            cooldown_s=max(
+                0.0,
+                float(
+                    getattr(cfg, "subagent_supervisor_cooldown_s", DEFAULT_COOLDOWN_S)
+                    or DEFAULT_COOLDOWN_S
+                ),
+            ),
+            min_steps_before_stall=max(
+                2,
+                int(
+                    getattr(
+                        cfg,
+                        "subagent_supervisor_min_steps_before_stall",
+                        DEFAULT_MIN_STEPS_BEFORE_STALL,
+                    )
+                    or DEFAULT_MIN_STEPS_BEFORE_STALL
+                ),
+            ),
+        )
+
+
+@dataclass(slots=True)
+class Diagnosis:
+    kind: str  # ok | loop | thrash | hung | stall
+    severity: str  # info | warning | critical
+    summary: str
+    guidance: str
+    signals: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def needs_intervention(self) -> bool:
+        return self.kind in {"loop", "thrash", "hung", "stall"}
+
+
+def _activity_tool_traces(handle: Any, *, lookback: int = 8) -> list[dict[str, Any]]:
+    """Build tool-like traces from handle.activity_log."""
+    log = list(getattr(handle, "activity_log", None) or [])
+    traces: list[dict[str, Any]] = []
+    for entry in log[-lookback * 2 :]:
+        kind = str(entry.get("kind") or "")
+        tool = str(entry.get("tool_name") or "")
+        details = str(entry.get("details") or "")
+        if kind == "tool_start" and tool:
+            traces.append(
+                {
+                    "name": tool,
+                    "arguments": details,
+                    "signature": _tool_signature(tool, details),
+                    "result": "",
+                    "is_error": False,
+                }
+            )
+        elif kind == "tool_result" and traces:
+            # Attach result to last matching tool if empty
+            for t in reversed(traces):
+                if t.get("name") == tool or not t.get("result"):
+                    t["result"] = details
+                    t["is_error"] = _looks_like_error(details)
+                    if not t.get("signature"):
+                        t["signature"] = _tool_signature(tool, t.get("arguments"))
+                    break
+            else:
+                traces.append(
+                    {
+                        "name": tool,
+                        "arguments": "",
+                        "signature": _tool_signature(tool, ""),
+                        "result": details,
+                        "is_error": _looks_like_error(details),
+                    }
+                )
+    return traces[-lookback:]
+
+
+def assess_handle(
+    handle: Any,
+    *,
+    policy: SupervisorPolicy | None = None,
+    now: float | None = None,
+) -> Diagnosis:
+    """Classify sub-agent health from live handle state."""
+    pol = policy or SupervisorPolicy()
+    status = getattr(handle, "status", None)
+    status_val = (
+        status.value if hasattr(status, "value") else str(status or "")
+    ).lower()
+    is_running = bool(getattr(handle, "is_running", False)) or status_val == "running"
+    if not is_running:
+        return Diagnosis(
+            kind="ok",
+            severity="info",
+            summary="not running",
+            guidance="",
+            signals={"status": status_val},
+        )
+
+    traces = _activity_tool_traces(handle)
+    sigs = [str(t.get("signature") or "") for t in traces if t.get("signature")]
+    error_count = sum(1 for t in traces if t.get("is_error"))
+    progress_count = sum(
+        1 for t in traces if _looks_like_progress(str(t.get("result") or ""))
+    )
+    steps = int(getattr(handle, "steps_taken", 0) or 0)
+    last_tool = str(getattr(handle, "last_tool", "") or "")
+    activity = str(getattr(handle, "current_activity", "") or "")
+
+    loop_hit = False
+    if len(sigs) >= 3 and sigs[-1] and sigs[-1] == sigs[-2] == sigs[-3]:
+        loop_hit = True
+    elif len(sigs) >= 4 and sigs[-1] and sigs[-4:].count(sigs[-1]) >= 3:
+        loop_hit = True
+
+    actively = True
+    if hasattr(handle, "is_actively_working"):
+        try:
+            actively = bool(handle.is_actively_working(max_idle_s=pol.idle_s))
+        except Exception:
+            actively = True
+
+    signals = {
+        "steps": steps,
+        "traces": len(traces),
+        "error_count": error_count,
+        "progress_count": progress_count,
+        "loop_hit": loop_hit,
+        "actively_working": actively,
+        "last_tool": last_tool,
+        "activity": activity[:120],
+    }
+
+    if loop_hit:
+        tool = last_tool or (traces[-1].get("name") if traces else "tool")
+        return Diagnosis(
+            kind="loop",
+            severity="critical",
+            summary=f"repeated identical tool calls ({tool})",
+            guidance=(
+                f"SUPERVISOR GUIDANCE: You are looping on the same tool call "
+                f"({tool}). Stop repeating it. Change approach: try a different "
+                f"tool, different arguments, read a related file, or summarize "
+                f"what you already know and produce a partial result. Do not "
+                f"call the same tool with the same arguments again."
+            ),
+            signals=signals,
+        )
+
+    if len(traces) >= 3 and error_count == len(traces) and progress_count == 0:
+        return Diagnosis(
+            kind="thrash",
+            severity="critical",
+            summary="recent tools only return errors",
+            guidance=(
+                "SUPERVISOR GUIDANCE: Your last tool calls all failed. "
+                "Diagnose the root error (permissions, missing path, bad args). "
+                "Fix the underlying issue (correct path, create dir, simpler command) "
+                "or report a clear blocker with the exact error — do not retry the "
+                "same failing call."
+            ),
+            signals=signals,
+        )
+
+    if not actively:
+        return Diagnosis(
+            kind="hung",
+            severity="critical",
+            summary=f"no activity for >{pol.idle_s:.0f}s",
+            guidance=(
+                "SUPERVISOR GUIDANCE: You appear stalled (no recent progress). "
+                "Either complete the current step with a concrete result or "
+                "switch strategy. Avoid long silent waits; call a tool or write "
+                "your final answer for the assigned task."
+            ),
+            signals=signals,
+        )
+
+    if (
+        steps >= pol.min_steps_before_stall
+        and progress_count == 0
+        and len(traces) >= 2
+        and error_count >= 1
+    ):
+        return Diagnosis(
+            kind="stall",
+            severity="warning",
+            summary="steps advancing without useful progress",
+            guidance=(
+                "SUPERVISOR GUIDANCE: You are spending steps without useful progress. "
+                "Narrow the task: pick one concrete deliverable, use a smaller "
+                "tool sequence, and avoid exploratory retries. Prefer write/fix "
+                "over re-reading the same inputs."
+            ),
+            signals=signals,
+        )
+
+    return Diagnosis(
+        kind="ok",
+        severity="info",
+        summary="healthy / progressing",
+        guidance="",
+        signals=signals,
+    )
+
+
+class SubagentSupervisor:
+    """Background watcher that nudges stuck sub-agents with guidance."""
+
+    def __init__(
+        self,
+        manager: Any,
+        *,
+        policy: SupervisorPolicy | None = None,
+    ) -> None:
+        self._manager = manager
+        self._policy = policy or SupervisorPolicy()
+        self._task: asyncio.Task[None] | None = None
+        self._stop = asyncio.Event()
+        # job name -> stats
+        self._interventions: dict[str, int] = {}
+        self._last_intervene_at: dict[str, float] = {}
+        self._last_kind: dict[str, str] = {}
+
+    @property
+    def policy(self) -> SupervisorPolicy:
+        return self._policy
+
+    @property
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    def ensure_running(self) -> None:
+        if not self._policy.enabled:
+            return
+        if self.is_running:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug("supervisor: no running event loop")
+            return
+        self._stop = asyncio.Event()
+        self._task = loop.create_task(self._watch_loop(), name="subagent-supervisor")
+        logger.info(
+            "SubagentSupervisor started (poll=%.1fs idle=%.0fs max_iv=%d)",
+            self._policy.poll_s,
+            self._policy.idle_s,
+            self._policy.max_interventions,
+        )
+
+    async def stop(self) -> None:
+        self._stop.set()
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug("supervisor stop error", exc_info=True)
+
+    def reset_job(self, name: str) -> None:
+        self._interventions.pop(name, None)
+        self._last_intervene_at.pop(name, None)
+        self._last_kind.pop(name, None)
+
+    async def _watch_loop(self) -> None:
+        try:
+            while not self._stop.is_set():
+                try:
+                    await self._tick()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("SubagentSupervisor tick failed")
+                try:
+                    await asyncio.wait_for(self._stop.wait(), timeout=self._policy.poll_s)
+                    break
+                except TimeoutError:
+                    continue
+        except asyncio.CancelledError:
+            logger.debug("SubagentSupervisor cancelled")
+        finally:
+            logger.info("SubagentSupervisor stopped")
+
+    async def _tick(self) -> None:
+        handles = getattr(self._manager, "_handles", None) or {}
+        running = [
+            h
+            for h in handles.values()
+            if getattr(h, "is_running", False)
+            or str(getattr(getattr(h, "status", None), "value", "")).lower() == "running"
+        ]
+        if not running:
+            return
+        for handle in running:
+            await self._maybe_intervene(handle)
+
+    async def _maybe_intervene(self, handle: Any) -> None:
+        name = str(getattr(handle, "name", "") or "")
+        if not name:
+            return
+        diagnosis = assess_handle(handle, policy=self._policy)
+        if not diagnosis.needs_intervention:
+            return
+
+        count = int(self._interventions.get(name, 0))
+        if count >= self._policy.max_interventions:
+            # Emit once per "exhausted" transition
+            if self._last_kind.get(name) != "exhausted":
+                self._last_kind[name] = "exhausted"
+                self._emit(
+                    handle,
+                    diagnosis,
+                    attempt=count,
+                    message=(
+                        f"Supervisor: max interventions ({count}) reached for "
+                        f"`{name}` ({diagnosis.kind}); waiting for natural stop"
+                    ),
+                    exhausted=True,
+                )
+            return
+
+        now = time.monotonic()
+        last = float(self._last_intervene_at.get(name, 0.0))
+        if last and (now - last) < self._policy.cooldown_s:
+            return
+
+        # Don't spam same kind every poll without cooldown already covered
+        ok = await self._send_guidance(handle, diagnosis, attempt=count + 1)
+        if not ok:
+            return
+
+        self._interventions[name] = count + 1
+        self._last_intervene_at[name] = now
+        self._last_kind[name] = diagnosis.kind
+        self._emit(
+            handle,
+            diagnosis,
+            attempt=count + 1,
+            message=diagnosis.guidance,
+            exhausted=False,
+        )
+        # Surface in activity log for Studio
+        try:
+            handle.record_activity(
+                "supervisor_guidance",
+                f"Supervisor ({diagnosis.kind}): {diagnosis.summary}",
+                details=diagnosis.guidance[:300],
+                steps_taken=int(getattr(handle, "steps_taken", 0) or 0),
+            )
+        except Exception:
+            pass
+        notify = getattr(self._manager, "notify_progress", None)
+        if callable(notify):
+            try:
+                notify(name, force=True)
+            except Exception:
+                pass
+
+    async def _send_guidance(
+        self,
+        handle: Any,
+        diagnosis: Diagnosis,
+        *,
+        attempt: int,
+    ) -> bool:
+        from core.subagents.communication import AgentMessage
+
+        name = handle.name
+        msg = AgentMessage(
+            from_agent="supervisor",
+            to_agent=name,
+            msg_type="guidance",
+            content=diagnosis.guidance,
+            metadata={
+                "kind": diagnosis.kind,
+                "severity": diagnosis.severity,
+                "summary": diagnosis.summary,
+                "attempt": attempt,
+                "signals": diagnosis.signals,
+            },
+        )
+        bus = getattr(self._manager, "_comm_bus", None)
+        if bus is None:
+            logger.warning("supervisor: no communication bus")
+            return False
+
+        mode = getattr(handle.config, "process_mode", None)
+        mode_val = mode.value if hasattr(mode, "value") else str(mode or "async")
+        try:
+            if str(mode_val).lower() == "process":
+                bus.process_bus.send_to_sub_agent(msg)
+            else:
+                await bus.async_bus.send(msg)
+        except Exception:
+            logger.exception("supervisor: failed to send guidance to %s", name)
+            return False
+
+        logger.info(
+            "Supervisor guidance → %s kind=%s attempt=%d: %s",
+            name,
+            diagnosis.kind,
+            attempt,
+            diagnosis.summary,
+        )
+        return True
+
+    def _emit(
+        self,
+        handle: Any,
+        diagnosis: Diagnosis,
+        *,
+        attempt: int,
+        message: str,
+        exhausted: bool,
+    ) -> None:
+        try:
+            from core.agent_events import SubAgentSupervisorEvent
+
+            emit = getattr(self._manager, "_emit_agent_event", None)
+            if not callable(emit):
+                parent = getattr(self._manager, "_parent", None)
+                emit_fn = getattr(parent, "emit", None) if parent else None
+                if callable(emit_fn):
+                    emit = lambda e: emit_fn(e)  # noqa: E731
+                else:
+                    return
+            emit(
+                SubAgentSupervisorEvent(
+                    name=str(handle.name),
+                    agent_type=str(
+                        getattr(handle, "agent_type", "")
+                        or getattr(handle.config, "agent_type", "")
+                        or ""
+                    ),
+                    kind=diagnosis.kind,
+                    severity=diagnosis.severity,
+                    attempt=attempt,
+                    max_interventions=self._policy.max_interventions,
+                    summary=diagnosis.summary,
+                    message=(message or "")[:2000],
+                    exhausted=exhausted,
+                )
+            )
+        except Exception:
+            logger.debug("supervisor emit failed", exc_info=True)
+
+
+async def drain_guidance_messages(
+    bus_receive,
+    agent_name: str,
+    *,
+    max_messages: int = 8,
+) -> list[str]:
+    """Drain guidance messages for a sub-agent (async bus receive coroutine).
+
+    ``bus_receive`` is ``async_bus.receive`` bound method.
+    """
+    texts: list[str] = []
+    for _ in range(max_messages):
+        msg = await bus_receive(agent_name, timeout=0.001)
+        if msg is None:
+            break
+        if getattr(msg, "msg_type", "") in {"guidance", "revise"}:
+            content = str(getattr(msg, "content", "") or "").strip()
+            if content:
+                texts.append(content)
+    return texts
+
+
+def format_guidance_system_message(texts: list[str]) -> str:
+    if not texts:
+        return ""
+    body = "\n\n".join(texts)
+    return (
+        "### Runtime supervisor intervention\n"
+        "The parent runtime detected a problem with your recent work and sent "
+        "the following guidance. Follow it on this step:\n\n"
+        f"{body}"
+    )

--- a/core/tools/a2a.py
+++ b/core/tools/a2a.py
@@ -1,0 +1,248 @@
+"""Tools so Holix can call remote A2A agents (client role)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.a2a.client import A2AClient, A2AClientError, extract_task_text
+from core.a2a.config import load_a2a_config
+from core.tools.base import BaseTool
+
+
+def _profile(agent: Any) -> str:
+    cfg = getattr(agent, "config", None)
+    return str(getattr(cfg, "profile_name", None) or "default")
+
+
+def _resolve_remote(agent: Any, name_or_url: str) -> tuple[str, dict[str, str], float]:
+    """Return (url, headers, timeout) for a configured remote or raw URL."""
+    raw = (name_or_url or "").strip()
+    if not raw:
+        raise ValueError("agent name or url is required")
+    cfg = load_a2a_config(_profile(agent))
+    if not cfg.client_enabled:
+        raise RuntimeError(
+            "A2A is disabled. Set a2a.enabled: true in profile config.yaml "
+            "or HOLIX_A2A_ENABLED=true"
+        )
+    # URL form
+    if raw.startswith("http://") or raw.startswith("https://"):
+        return raw.rstrip("/"), {}, cfg.request_timeout_s
+    # Named remote
+    for remote in cfg.remote_agents:
+        if remote.name == raw or remote.name.lower() == raw.lower():
+            return remote.url, dict(remote.headers), cfg.request_timeout_s
+    known = ", ".join(r.name for r in cfg.remote_agents) or "(none configured)"
+    raise ValueError(
+        f"Unknown A2A agent '{raw}'. Use a full URL or configure remote_agents: {known}"
+    )
+
+
+class A2AListAgentsTool(BaseTool):
+    def __init__(self, parent_agent: Any):
+        super().__init__()
+        self._parent = parent_agent
+        self.name = "a2a_list_agents"
+        self.description = (
+            "List configured remote A2A (Agent2Agent) agents this Holix profile can call. "
+            "Use before a2a_send_message when you need the agent name."
+        )
+        self.risk_level = "no"
+        self.parameters = {"type": "object", "properties": {}, "required": []}
+
+    async def execute(self) -> str:
+        cfg = load_a2a_config(_profile(self._parent))
+        if not cfg.client_enabled:
+            return json.dumps({"enabled": False, "agents": []})
+        agents = [
+            {
+                "name": r.name,
+                "url": r.url,
+                "description": r.description,
+            }
+            for r in cfg.remote_agents
+        ]
+        return json.dumps(
+            {
+                "enabled": True,
+                "agents": agents,
+                "hint": "Pass name or full URL to a2a_discover / a2a_send_message",
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
+
+class A2ADiscoverTool(BaseTool):
+    def __init__(self, parent_agent: Any):
+        super().__init__()
+        self._parent = parent_agent
+        self.name = "a2a_discover"
+        self.description = (
+            "Fetch an A2A Agent Card from a remote agent (by configured name or base URL). "
+            "Returns name, skills, capabilities, and service URL."
+        )
+        self.risk_level = "low"
+        self.parameters = {
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "description": "Configured remote name or https://… base URL",
+                },
+            },
+            "required": ["agent"],
+        }
+
+    async def execute(self, agent: str) -> str:
+        try:
+            url, headers, timeout = _resolve_remote(self._parent, agent)
+            client = A2AClient(url, headers=headers, timeout_s=timeout)
+            card = await client.fetch_agent_card()
+            return json.dumps(
+                {
+                    "ok": True,
+                    "url": client.base_url,
+                    "card": {
+                        "name": card.get("name"),
+                        "description": card.get("description"),
+                        "version": card.get("version"),
+                        "protocolVersion": card.get("protocolVersion"),
+                        "url": card.get("url"),
+                        "capabilities": card.get("capabilities"),
+                        "skills": card.get("skills"),
+                        "defaultInputModes": card.get("defaultInputModes"),
+                        "defaultOutputModes": card.get("defaultOutputModes"),
+                    },
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        except (A2AClientError, ValueError, RuntimeError) as exc:
+            return json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+
+
+class A2ASendMessageTool(BaseTool):
+    def __init__(self, parent_agent: Any):
+        super().__init__()
+        self._parent = parent_agent
+        self.name = "a2a_send_message"
+        self.description = (
+            "Send a task/message to a remote A2A agent and wait for the result (blocking). "
+            "Use for cross-agent collaboration when another system exposes Agent2Agent. "
+            "Prefer a2a_list_agents / a2a_discover first."
+        )
+        self.risk_level = "medium"
+        self.parameters = {
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "description": "Configured remote name or https://… A2A endpoint",
+                },
+                "message": {
+                    "type": "string",
+                    "description": "User message / task for the remote agent",
+                },
+                "context_id": {
+                    "type": "string",
+                    "description": "Optional multi-turn contextId to continue a dialogue",
+                },
+            },
+            "required": ["agent", "message"],
+        }
+
+    async def execute(
+        self,
+        agent: str,
+        message: str,
+        context_id: str | None = None,
+    ) -> str:
+        text = (message or "").strip()
+        if not text:
+            return json.dumps({"ok": False, "error": "message is empty"})
+        try:
+            url, headers, timeout = _resolve_remote(self._parent, agent)
+            client = A2AClient(url, headers=headers, timeout_s=timeout)
+            task = await client.send_message(
+                text,
+                context_id=(context_id or "").strip() or None,
+                configuration={"returnImmediately": False},
+            )
+            reply = extract_task_text(task)
+            return json.dumps(
+                {
+                    "ok": True,
+                    "task_id": task.get("id"),
+                    "context_id": task.get("contextId"),
+                    "state": (task.get("status") or {}).get("state")
+                    if isinstance(task.get("status"), dict)
+                    else None,
+                    "text": reply,
+                    "task": task,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        except (A2AClientError, ValueError, RuntimeError) as exc:
+            return json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+
+
+class A2AGetTaskTool(BaseTool):
+    def __init__(self, parent_agent: Any):
+        super().__init__()
+        self._parent = parent_agent
+        self.name = "a2a_get_task"
+        self.description = (
+            "Fetch status/result of a remote A2A task by id (after a2a_send_message)."
+        )
+        self.risk_level = "low"
+        self.parameters = {
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "description": "Configured remote name or https://… endpoint",
+                },
+                "task_id": {"type": "string", "description": "A2A task id"},
+            },
+            "required": ["agent", "task_id"],
+        }
+
+    async def execute(self, agent: str, task_id: str) -> str:
+        tid = (task_id or "").strip()
+        if not tid:
+            return json.dumps({"ok": False, "error": "task_id is required"})
+        try:
+            url, headers, timeout = _resolve_remote(self._parent, agent)
+            client = A2AClient(url, headers=headers, timeout_s=timeout)
+            task = await client.get_task(tid)
+            return json.dumps(
+                {
+                    "ok": True,
+                    "text": extract_task_text(task),
+                    "task": task,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        except (A2AClientError, ValueError, RuntimeError) as exc:
+            return json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+
+
+def register_a2a_tools(registry: Any, parent_agent: Any) -> None:
+    """Register A2A client tools when enabled for the profile."""
+    try:
+        cfg = load_a2a_config(_profile(parent_agent))
+        if not cfg.client_enabled:
+            return
+    except Exception:
+        return
+    for tool in (
+        A2AListAgentsTool(parent_agent),
+        A2ADiscoverTool(parent_agent),
+        A2ASendMessageTool(parent_agent),
+        A2AGetTaskTool(parent_agent),
+    ):
+        registry.register(tool)

--- a/core/tools/sdd.py
+++ b/core/tools/sdd.py
@@ -666,8 +666,11 @@ class SddArchiveTool(BaseTool):
         super().__init__()
         self.name = "sdd_archive"
         self.description = (
-            "Merge change delta specs into main openspec/specs/, "
-            "then move the change folder to changes/archive/YYYY-MM-DD-<id>/."
+            "Merge change delta specs (ADDED/MODIFIED/REMOVED Requirements) into "
+            "main openspec/specs/<domain>/spec.md, then move the change folder to "
+            "changes/archive/YYYY-MM-DD-<id>/. Nested delta files under "
+            "specs/<domain>/… still merge into that domain. Returns warnings if "
+            "tasks are still open (merge still proceeds)."
         )
         self.risk_level = "no"
         self.parameters = {
@@ -675,13 +678,20 @@ class SddArchiveTool(BaseTool):
             "properties": {
                 "project": _PROJECT_PROP,
                 "change_id": {"type": "string"},
+                "force": {
+                    "type": "boolean",
+                    "description": "Reserved for stricter gates; archive currently always merges when change exists.",
+                    "default": False,
+                },
             },
             "required": ["change_id"],
         }
 
-    async def execute(self, change_id: str, project: str = "", **_: Any) -> str:
+    async def execute(
+        self, change_id: str, project: str = "", force: bool = False, **_: Any
+    ) -> str:
         try:
-            return result_json(_store(project).archive(change_id))
+            return result_json(_store(project).archive(change_id, force=bool(force)))
         except Exception as exc:
             return _err(exc)
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,49 @@
+# Production overlay — always-restart, log rotation, production defaults.
+#
+# Bind-mount storage is controlled by env (no second volume list — avoids
+# double-mount merge with docker-compose.yml):
+#
+#   HOLIX_DATA_DIR=./data/holix          # host path → /data/.holix
+#   HOLIX_EXTENSIONS_DIR=./extensions    # → /data/.holix/extensions
+#   HOLIX_FILES_DIR=./data/files         # → /data/files
+#
+# Usage:
+#   cp docker/env.example .env
+#   # set HOLIX_DATA_DIR, secrets, MODEL, TELEGRAM_BOT_TOKEN, …
+#   mkdir -p "${HOLIX_DATA_DIR:-./data/holix}" \
+#            "${HOLIX_EXTENSIONS_DIR:-./extensions}" \
+#            "${HOLIX_FILES_DIR:-./data/files}"
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Multi-user:
+#   1. Start with TELEGRAM_BOT_TOKEN + MODEL/BASE_URL/API_KEY
+#   2. Users /start → approve --create-profile <name>
+#   3. Profiles live under $HOLIX_DATA_DIR/profiles/
+#   4. Drop extensions into $HOLIX_EXTENSIONS_DIR; restart
+
+x-prod-logging: &prod-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
+
+services:
+  holix:
+    restart: always
+    environment:
+      HOLIX_ENV: production
+      HOLIX_REQUIRE_AUTH: "true"
+      HOLIX_WORKSPACE_JAIL: ${HOLIX_WORKSPACE_JAIL:-true}
+      HOLIX_ENABLE_CODE_EXECUTOR: ${HOLIX_ENABLE_CODE_EXECUTOR:-false}
+      HOLIX_TERMINAL_COMMAND_WHITELIST: ${HOLIX_TERMINAL_COMMAND_WHITELIST:-true}
+      HOLIX_CORS_ORIGINS: ${HOLIX_CORS_ORIGINS:-}
+    logging: *prod-logging
+
+  holix-gateway:
+    restart: always
+    environment:
+      HOLIX_ENV: production
+      HOLIX_REQUIRE_AUTH: "true"
+      HOLIX_TELEGRAM_AUTOSTART: "false"
+      HOLIX_MAX_AUTOSTART: "false"
+    logging: *prod-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,52 +1,140 @@
-# Holix agent — minimal start: set TELEGRAM_BOT_TOKEN and run `docker compose up -d`
+# Holix agent — Docker Compose
 #
-# Quick start:
-#   export TELEGRAM_BOT_TOKEN="123456:ABC..."
+# ── Quick start (Telegram bot + gateway + cloud/local LLM) ──────────────────
+#   cp docker/env.example .env
+#   # edit: TELEGRAM_BOT_TOKEN, MODEL, BASE_URL, API_KEY
 #   docker compose up -d
 #
-# Approve Telegram users:
-#   docker compose exec holix holix telegram requests list
-#   docker compose exec holix holix telegram requests approve USER_ID --profile default
+# ── With local Ollama ───────────────────────────────────────────────────────
+#   docker compose --profile ollama up -d
 #
-# CLI / admin:
+# ── Gateway only (API, no Telegram/MAX companions) ──────────────────────────
+#   docker compose --profile gateway-only up -d holix-gateway
+#
+# ── Production multi-user (bind-mount storage + extensions) ─────────────────
+#   mkdir -p ./data/holix ./extensions ./data/files
+#   # in .env: HOLIX_DATA_DIR=./data/holix  HOLIX_EXTENSIONS_DIR=./extensions
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Approve Telegram users:
+#   docker compose exec holix holix -p shared telegram requests list
+#   docker compose exec holix holix -p shared telegram requests approve USER_ID --create-profile alice
+#
+# Extensions:
+#   # drop-in: put package under ./extensions/<name>/  (mounted → HOLIX_HOME/extensions)
+#   docker compose exec holix holix extensions list
+#   # pip into the running image:
+#   #   HOLIX_EXTENSIONS_PIP=./extensions/my-pkg  or  holix-sdk-package-name
+#
+# CLI:
 #   docker compose exec holix holix --help
-#   docker compose exec holix holix profile create alice
+#   docker compose exec holix holix -p shared profile create alice
+
+x-holix-common: &holix-common
+  image: ${HOLIX_IMAGE:-holix-agent:latest}
+  build:
+    context: .
+    dockerfile: Dockerfile
+  restart: unless-stopped
+  environment: &holix-env
+    HOLIX_HOME: /data/.holix
+    HOLIX_PROFILE: ${HOLIX_PROFILE:-shared}
+    HOLIX_ENV: ${HOLIX_ENV:-production}
+    HOLIX_REQUIRE_AUTH: ${HOLIX_REQUIRE_AUTH:-true}
+    HOLIX_API_KEY_PEPPER: ${HOLIX_API_KEY_PEPPER:-change-me-in-production}
+    HOLIX_GATEWAY_HOST: 0.0.0.0
+    HOLIX_GATEWAY_PORT: "8000"
+    # LLM
+    MODEL: ${MODEL:-}
+    BASE_URL: ${BASE_URL:-}
+    API_KEY: ${API_KEY:-}
+    TEMPERATURE: ${TEMPERATURE:-0.7}
+    OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+    OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+    DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+    LITELLM_API_BASE: ${LITELLM_API_BASE:-}
+    LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+    OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
+    # Telegram
+    TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
+    HOLIX_TELEGRAM_BOT_TOKEN: ${HOLIX_TELEGRAM_BOT_TOKEN:-}
+    HOLIX_TELEGRAM_ACCESS_REQUESTS: ${HOLIX_TELEGRAM_ACCESS_REQUESTS:-true}
+    HOLIX_TELEGRAM_ALLOWED_USERS: ${HOLIX_TELEGRAM_ALLOWED_USERS:-}
+    HOLIX_TELEGRAM_ALLOW_ALL: ${HOLIX_TELEGRAM_ALLOW_ALL:-}
+    HOLIX_TELEGRAM_ADMIN_USER_ID: ${HOLIX_TELEGRAM_ADMIN_USER_ID:-}
+    HOLIX_TELEGRAM_VOICE_ENABLED: ${HOLIX_TELEGRAM_VOICE_ENABLED:-true}
+    HOLIX_TELEGRAM_FILES_ENABLED: ${HOLIX_TELEGRAM_FILES_ENABLED:-true}
+    HOLIX_TELEGRAM_AUTOSTART: ${HOLIX_TELEGRAM_AUTOSTART:-true}
+    # MAX messenger (optional)
+    MAX_ACCESS_TOKEN: ${MAX_ACCESS_TOKEN:-}
+    HOLIX_MAX_ACCESS_TOKEN: ${HOLIX_MAX_ACCESS_TOKEN:-}
+    HOLIX_MAX_AUTOSTART: ${HOLIX_MAX_AUTOSTART:-true}
+    # Tools / browser
+    ENABLE_BROWSER_TOOLS: ${ENABLE_BROWSER_TOOLS:-true}
+    BROWSER_HEADLESS: "true"
+    HOLIX_ENABLE_TERMINAL_TOOL: ${HOLIX_ENABLE_TERMINAL_TOOL:-true}
+    HOLIX_ENABLE_CODE_EXECUTOR: ${HOLIX_ENABLE_CODE_EXECUTOR:-false}
+    HOLIX_TERMINAL_COMMAND_WHITELIST: ${HOLIX_TERMINAL_COMMAND_WHITELIST:-true}
+    # Multi-user workspace jail
+    HOLIX_WORKSPACE_JAIL: ${HOLIX_WORKSPACE_JAIL:-true}
+    # Extensions: comma-separated pip specs or local paths inside container
+    HOLIX_EXTENSIONS_PIP: ${HOLIX_EXTENSIONS_PIP:-}
+    HOLIX_EXTENSIONS_SYNC: ${HOLIX_EXTENSIONS_SYNC:-true}
+    # CORS (comma-separated; empty = default)
+    HOLIX_CORS_ORIGINS: ${HOLIX_CORS_ORIGINS:-}
+    # Unlock encrypted profiles (optional)
+    HOLIX_UNLOCK_KEY: ${HOLIX_UNLOCK_KEY:-}
+  volumes: &holix-volumes
+    # Persistent Holix home (profiles, memory, gateway state, telegram.env)
+    - ${HOLIX_DATA_DIR:-holix-data}:/data/.holix
+    # Drop-in / git-clone extensions (no rebuild)
+    - ${HOLIX_EXTENSIONS_DIR:-./extensions}:/data/.holix/extensions
+    # Optional shared file store for multi-user deployments
+    - ${HOLIX_FILES_DIR:-./data/files}:/data/files
+  networks:
+    - holix-network
+  healthcheck:
+    test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8000/health"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 45s
 
 services:
+  # ── Full agent: gateway + Telegram/MAX companions + cron ──────────────────
   holix:
-    build: .
-    image: holix-agent:latest
+    <<: *holix-common
+    container_name: holix
     ports:
       - "${HOLIX_GATEWAY_PORT:-8000}:8000"
-    environment:
-      HOLIX_HOME: /data/.holix
-      HOLIX_PROFILE: ${HOLIX_PROFILE:-default}
-      HOLIX_ENV: production
-      HOLIX_REQUIRE_AUTH: "true"
-      HOLIX_API_KEY_PEPPER: ${HOLIX_API_KEY_PEPPER:-change-me-in-production}
-      HOLIX_GATEWAY_HOST: 0.0.0.0
-      HOLIX_GATEWAY_PORT: "8000"
-      HOLIX_TELEGRAM_ACCESS_REQUESTS: "true"
-      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:?Set TELEGRAM_BOT_TOKEN in .env or environment}
-      MODEL: ${MODEL:-qwen2.5-coder:32b}
-      BASE_URL: ${BASE_URL:-http://ollama:11434/v1}
-      API_KEY: ${API_KEY:-ollama}
-      OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
-      HOLIX_TELEGRAM_VOICE_ENABLED: ${HOLIX_TELEGRAM_VOICE_ENABLED:-true}
-      HOLIX_TELEGRAM_FILES_ENABLED: ${HOLIX_TELEGRAM_FILES_ENABLED:-true}
-      ENABLE_BROWSER_TOOLS: ${ENABLE_BROWSER_TOOLS:-true}
-      BROWSER_HEADLESS: "true"
-    volumes:
-      - holix-data:/data/.holix
+    command: ["agent"]
+    # Ollama is optional; start with --profile ollama when using local models
     depends_on:
       ollama:
         condition: service_started
-    restart: unless-stopped
-    networks:
-      - holix-network
+        required: false
 
+  # ── Gateway only: OpenAI-compatible API + management, no messengers ───────
+  holix-gateway:
+    <<: *holix-common
+    profiles: ["gateway-only"]
+    container_name: holix-gateway
+    ports:
+      - "${HOLIX_GATEWAY_PORT:-8000}:8000"
+    environment:
+      <<: *holix-env
+      HOLIX_TELEGRAM_AUTOSTART: "false"
+      HOLIX_MAX_AUTOSTART: "false"
+      # Keep tokens out of this service unless you intentionally enable companions
+      TELEGRAM_BOT_TOKEN: ""
+      HOLIX_TELEGRAM_BOT_TOKEN: ""
+    command: ["gateway"]
+
+  # ── Optional local LLM ────────────────────────────────────────────────────
   ollama:
+    profiles: ["ollama"]
     image: ollama/ollama:latest
+    container_name: holix-ollama
     ports:
       - "${OLLAMA_PORT:-11434}:11434"
     volumes:
@@ -54,9 +142,10 @@ services:
     restart: unless-stopped
     networks:
       - holix-network
+
 volumes:
-  ollama-data:
   holix-data:
+  ollama-data:
 
 networks:
   holix-network:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,9 @@
+# Holix Docker
+
+| File | Role |
+|------|------|
+| [`../docker-compose.yml`](../docker-compose.yml) | Full agent, gateway-only profile, optional Ollama |
+| [`../docker-compose.prod.yml`](../docker-compose.prod.yml) | Restart policy, logging, production defaults |
+| [`env.example`](env.example) | Copy to project root as `.env` |
+
+Full guide: [docs/en/INSTALLATION.md § Path B](../docs/en/INSTALLATION.md#path-b--docker) · [RU](../docs/ru/INSTALLATION.md#путь-b--docker)

--- a/docker/env.example
+++ b/docker/env.example
@@ -1,0 +1,126 @@
+# Holix Docker environment — copy to project root:
+#   cp docker/env.example .env
+#
+# Minimal (Telegram + cloud LLM):
+#   TELEGRAM_BOT_TOKEN=...
+#   MODEL=gpt-4o-mini
+#   BASE_URL=https://api.openai.com/v1
+#   API_KEY=sk-...
+#   HOLIX_API_KEY_PEPPER=<openssl rand -hex 32>
+#   docker compose up -d
+
+# =============================================================================
+# Image / ports
+# =============================================================================
+HOLIX_IMAGE=holix-agent:latest
+HOLIX_GATEWAY_PORT=8000
+# OLLAMA_PORT=11434
+
+# =============================================================================
+# Runtime identity
+# =============================================================================
+# production forbids profile "default" — use a named bot host profile
+HOLIX_PROFILE=shared
+HOLIX_ENV=production
+HOLIX_REQUIRE_AUTH=true
+# REQUIRED in production (hashing for gateway API keys)
+HOLIX_API_KEY_PEPPER=change-me-to-a-long-random-secret
+
+# Optional: unlock encrypted profiles at startup
+# HOLIX_UNLOCK_KEY=
+
+# CORS for browser clients (comma-separated). Empty = framework default.
+# HOLIX_CORS_ORIGINS=https://app.example.com
+
+# =============================================================================
+# LLM (required for a useful agent — pick one path)
+# =============================================================================
+
+# Path A — OpenAI-compatible cloud / proxy
+MODEL=gpt-4o-mini
+BASE_URL=https://api.openai.com/v1
+API_KEY=sk-...
+TEMPERATURE=0.7
+
+# Path B — OpenRouter / DeepSeek / LiteLLM (also written into profile .env)
+# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+# DEEPSEEK_API_KEY=
+# LITELLM_API_BASE=http://litellm:4000/v1
+# LITELLM_API_KEY=
+
+# Path C — Ollama (docker compose --profile ollama up -d)
+# MODEL=qwen2.5-coder:32b
+# BASE_URL=http://ollama:11434/v1
+# API_KEY=ollama
+# OLLAMA_HOST=http://ollama:11434
+
+# =============================================================================
+# Telegram (full agent service "holix")
+# =============================================================================
+TELEGRAM_BOT_TOKEN=
+# HOLIX_TELEGRAM_BOT_TOKEN=   # alias
+
+# Multi-user: users /start → admin approves (recommended for prod)
+HOLIX_TELEGRAM_ACCESS_REQUESTS=true
+# Optional allowlist (comma-separated Telegram user ids)
+# HOLIX_TELEGRAM_ALLOWED_USERS=123456789,987654321
+# HOLIX_TELEGRAM_ADMIN_USER_ID=123456789
+# Dev only — never in production multi-tenant:
+# HOLIX_TELEGRAM_ALLOW_ALL=true
+
+HOLIX_TELEGRAM_VOICE_ENABLED=true
+HOLIX_TELEGRAM_FILES_ENABLED=true
+# Set false for gateway-only (also set by compose profile gateway-only)
+HOLIX_TELEGRAM_AUTOSTART=true
+
+# =============================================================================
+# MAX messenger (optional)
+# =============================================================================
+# MAX_ACCESS_TOKEN=
+# HOLIX_MAX_ACCESS_TOKEN=
+HOLIX_MAX_AUTOSTART=true
+
+# =============================================================================
+# Storage (multi-user production)
+# =============================================================================
+# Named Docker volume by default in base compose.
+# For prod bind mounts use docker-compose.prod.yml and set absolute paths:
+# HOLIX_DATA_DIR=./data/holix
+# HOLIX_EXTENSIONS_DIR=./extensions
+# HOLIX_FILES_DIR=./data/files
+#
+# Layout after start:
+#   $HOLIX_DATA_DIR/profiles/shared/     — bot host profile
+#   $HOLIX_DATA_DIR/profiles/<user>/     — per-user profiles (after approve)
+#   $HOLIX_DATA_DIR/profiles/<user>/workspace/  — file workspace (jail)
+#   $HOLIX_DATA_DIR/extensions/          — drop-in extensions
+#   $HOLIX_FILES_DIR/                    — optional shared host files
+
+# Enable workspace jail for multi-user isolation (default true in compose)
+HOLIX_WORKSPACE_JAIL=true
+
+# =============================================================================
+# Tools / security
+# =============================================================================
+ENABLE_BROWSER_TOOLS=true
+HOLIX_ENABLE_TERMINAL_TOOL=true
+HOLIX_ENABLE_CODE_EXECUTOR=false
+HOLIX_TERMINAL_COMMAND_WHITELIST=true
+
+# =============================================================================
+# Extensions
+# =============================================================================
+# Drop-in (preferred): place packages under ./extensions/<name>/
+#   ./extensions/my-billing/
+#     extension.py | agent.py | holix.plugin.json
+#   or git clone a repo into ./extensions/holix-telegram-billing
+#
+# Pip install on container start (comma-separated specs; paths must exist in container):
+# HOLIX_EXTENSIONS_PIP=holix-sdk,./extensions/my-pkg
+# Re-run pip each start when true (default); set false after first install for faster boot
+HOLIX_EXTENSIONS_SYNC=true
+
+# After start:
+#   docker compose exec holix holix extensions list
+#   docker compose exec holix holix extensions agent-list

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+## 1.0.2 — 2026-07-31
+
+Runtime orchestration, Reflexion, A2A, production Docker, and multi-user deploy ergonomics.
+
+### Added
+
+- **A2A (Agent2Agent)** — Holix as A2A **server** (Agent Card + JSON-RPC `/a2a` + REST + **SSE streaming** via `message/stream` / `/a2a/message:stream`) and **client** (`a2a_list_agents`, `a2a_discover`, `a2a_send_message`, `a2a_get_task`). Profile `a2a:` config / `HOLIX_A2A_*`. Docs: [A2A.md](en/A2A.md).
+- **Reflexion (main agent)** — after a draft answer, meta evaluator scores quality (+ tool trajectory); low scores inject verbal self-feedback and retry ReAct (`reflect` node). Defaults: `enable_meta_agent` / `enable_self_refinement` **on**. Docs: [EXECUTION_MODES.md](en/EXECUTION_MODES.md#reflexion-self-critique).
+- **Step budget extension** — at `max_steps`, health-check may grant more steps when the agent is still progressing (`HOLIX_MAX_STEPS_EXTEND_*`). Applies to main graph/legacy loop and sub-agents.
+- **Subagent supervisor (runtime)** — background watcher detects loop / thrash / hang / stall and injects **guidance** into the same job (async + process). Events: `SubAgentSupervisorEvent`.
+- **Subagent supervisor (graph)** — in `plan_and_execute`, after `collect`: rework failed wave jobs with repair instructions; merge keeps successes (`prior_job` supersede). Design: [SUBAGENT_SUPERVISOR.md](en/SUBAGENT_SUPERVISOR.md).
+- **Docker production stack** — `docker-compose.yml` (full agent / gateway-only / Ollama profiles), `docker-compose.prod.yml`, `docker/env.example`, entrypoint modes (`agent`, `gateway`, extensions pip/drop-in), bootstrap for profile `shared` + workspace jail. Docs: [INSTALLATION.md](en/INSTALLATION.md#path-b--docker).
+
+### Changed
+
+- Default `subagent_default_process_mode` documented as **`async`** (process still available with spawn fallback).
+- Mode graphs wire `meta_agent` and `reflect` into `react`, `hybrid`, and `plan_and_execute`.
+- Companion autostart flags: `HOLIX_TELEGRAM_AUTOSTART` / `HOLIX_MAX_AUTOSTART` for gateway-only containers.
+- Docker default profile is **`shared`** (production-safe; `default` remains dev-only).
+
+### Docs
+
+- Updated EN/RU: EXECUTION_MODES, SUBAGENTS, CONFIGURATION, ARCHITECTURE, MEMORY, INSTALLATION, DEPLOYMENT; supervisor design plan under `docs/plans/`.
+
 ## 1.0.1 — 2026-07-29
 
 Patch release focused on **tool isolation**, **gateway security**, and **cooperative cancel** so Studio/agent runs fail closed on secrets and stay killable.

--- a/docs/en/A2A.md
+++ b/docs/en/A2A.md
@@ -1,0 +1,177 @@
+# Agent2Agent (A2A) protocol
+
+Holix can participate in the open **[Agent2Agent (A2A)](https://a2a-protocol.org)** ecosystem:
+
+| Role | What Holix does |
+|------|-----------------|
+| **A2A Server** | Exposes the profile agent via gateway: Agent Card + JSON-RPC / REST + **SSE streaming** |
+| **A2A Client** | Tools to discover remote agents and send them tasks |
+
+Internal Holix **sub-agents** stay process-local. A2A is for **interop with other systems** (other frameworks, vendors, gateways).
+
+## Enable / configure
+
+Profile `config.yaml` (or env):
+
+```yaml
+a2a:
+  enabled: true
+  # Optional public URL advertised in the Agent Card
+  public_url: https://agent.example.com/a2a
+  name: Holix Coding Agent
+  description: Workspace agent with skills, MCP, SDD
+  request_timeout_s: 300
+  # Remotes Holix may call as a client
+  remote_agents:
+    - name: research
+      url: https://other.example.com/a2a
+      description: Research specialist
+      headers:
+        Authorization: Bearer ${REMOTE_A2A_TOKEN}
+```
+
+Environment overrides:
+
+| Variable | Meaning |
+|----------|---------|
+| `HOLIX_A2A_ENABLED` | `true` / `false` (default on) |
+| `HOLIX_A2A_PUBLIC_URL` | Public base URL for the Agent Card |
+| `HOLIX_A2A_TIMEOUT_S` | Client timeout seconds |
+
+## Server endpoints (gateway)
+
+Requires a Holix gateway API key (`hx_…`) like other `/v1` routes.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/.well-known/agent.json` | Agent Card discovery |
+| `GET` | `/a2a/.well-known/agent.json` | Same under `/a2a` |
+| `POST` | `/a2a` | JSON-RPC 2.0 (send, **stream**, tasks, card) |
+| `POST` | `/a2a/message:send` | REST send (JSON or SSE if `Accept: text/event-stream`) |
+| `POST` | `/a2a/message:stream` | REST send — always SSE |
+| `GET` | `/a2a/tasks/{id}` | REST get task |
+| `GET` | `/a2a/tasks/{id}/subscribe` | SSE snapshot of task state |
+
+Optional headers: `X-Holix-Profile` (multi-profile gateway).
+
+Agent Card advertises:
+
+```json
+"capabilities": {
+  "streaming": true,
+  "pushNotifications": false
+}
+```
+
+### JSON-RPC — blocking send
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/a2a" \
+  -H "Authorization: Bearer $HOLIX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Summarize the workspace README"}]
+      },
+      "configuration": {"returnImmediately": false}
+    }
+  }'
+```
+
+`contextId` on the message is mapped to a Holix conversation (`a2a:<contextId>`) for multi-turn.
+
+### JSON-RPC — streaming (SSE)
+
+```bash
+curl -sSN -X POST "http://127.0.0.1:8000/a2a" \
+  -H "Authorization: Bearer $HOLIX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "stream-1",
+    "method": "message/stream",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Write a short haiku about code"}]
+      }
+    }
+  }'
+```
+
+Each SSE event is a JSON-RPC response with a StreamResponse `result`:
+
+```
+data: {"jsonrpc":"2.0","id":"stream-1","result":{"task":{...}}}
+
+data: {"jsonrpc":"2.0","id":"stream-1","result":{"statusUpdate":{"taskId":"...","status":{"state":"working"},"final":false}}}
+
+data: {"jsonrpc":"2.0","id":"stream-1","result":{"artifactUpdate":{"taskId":"...","artifact":{...},"append":true}}}
+
+data: {"jsonrpc":"2.0","id":"stream-1","result":{"statusUpdate":{"status":{"state":"completed"},"final":true}}}
+```
+
+Aliases for the stream method: `message/stream`, `message/sendStreamingMessage`, `message/sendSubscribe`.
+
+You can also call `message/send` with `Accept: text/event-stream` to force SSE.
+
+### REST streaming
+
+```bash
+curl -sSN -X POST "http://127.0.0.1:8000/a2a/message:stream" \
+  -H "Authorization: Bearer $HOLIX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": {
+      "role": "user",
+      "parts": [{"kind": "text", "text": "Hello from A2A REST stream"}]
+    }
+  }'
+```
+
+SSE payloads are bare StreamResponse objects (`{"task":…}`, `{"statusUpdate":…}`, `{"artifactUpdate":…}`) without a JSON-RPC envelope.
+
+## Client tools (Holix agent)
+
+When A2A is enabled, the agent gets:
+
+| Tool | Role |
+|------|------|
+| `a2a_list_agents` | Configured remotes |
+| `a2a_discover` | Fetch remote Agent Card |
+| `a2a_send_message` | Send a task and wait for completion (blocking) |
+| `a2a_get_task` | Poll a remote task id |
+
+Example skill-style usage:
+
+1. `a2a_list_agents` → pick `research`
+2. `a2a_discover(agent="research")` → check skills / `capabilities.streaming`
+3. `a2a_send_message(agent="research", message="…")` → use returned `text`
+
+## Relation to MCP and sub-agents
+
+| Mechanism | Scope |
+|-----------|--------|
+| **MCP** | Tools/resources from servers |
+| **Sub-agents** | Holix-internal specialized workers |
+| **A2A** | Opaque remote agents over HTTP (standard protocol) |
+
+## Streaming behaviour (implementation notes)
+
+- Holix runs the agent with `run_holix(..., stream=True)` and maps events:
+  - thinking / tool start-result → `statusUpdate` (`working`)
+  - assistant token deltas → `artifactUpdate` (append chunks)
+  - final answer → completed `statusUpdate` (`final: true`) + full artifact
+- Task store is process-local (gateway lifetime); subscribe on an old task returns a snapshot, not live mid-run progress (use `message/stream` for live runs).
+- Push notifications remain off in the Agent Card (webhook delivery not implemented).
+
+## Spec
+
+- https://a2a-protocol.org  
+- Protocol versions referenced: **0.3** / **1.0** (JSON-RPC + REST + Agent Card + SSE)

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -6,10 +6,26 @@ Holix is a Python agent platform with a single execution path for reasoning, eve
 
 ```
 HolixAgent (core/agent.py)
-    → run_agent_loop() / LangGraph (core/agent_execution.py)
+    → LangGraph mode graph (core/graph/)  [preferred when use_langgraph=true]
+    → or legacy loop (core/agent_execution.py)
     → yields AgentEvent (core/agent_events.py)
-    → ToolRegistry, MemoryManager, SkillManager
+    → ToolRegistry, MemoryManager, SkillManager, SubAgentManager
 ```
+
+### LangGraph modes (cyclic orchestration)
+
+| Mode | Graph sketch |
+|------|----------------|
+| `react` | `memory → meta → react ⇄ tools → reflect ⇄ react → finalize` |
+| `hybrid` | `memory → meta → plan → review → react ⇄ tools → reflect → finalize` |
+| `plan_and_execute` | plan/review + `step_orchestrate` + optional `delegate → collect → supervisor → rework/react` + `reflect` |
+
+- **Meta-agent** — short pre-thinking hint (`core/graph/nodes/meta_agent_node.py`).  
+- **Reflexion** — post-draft quality critique + verbal retry (`reflect_node.py`).  
+- **Step budget** — at `max_steps`, health-check and optional extension (`core/runtime/step_budget.py`).  
+- **Subagents** — async/process workers; **runtime supervisor** (mid-job guidance) + **graph supervisor** (wave rework).  
+
+Product docs: [EXECUTION_MODES.md](EXECUTION_MODES.md), [SUBAGENTS.md](SUBAGENTS.md).
 
 | Adapter | Role |
 |---------|------|
@@ -22,8 +38,11 @@ HolixAgent (core/agent.py)
 | Component | Path | Role |
 |-----------|------|------|
 | Agent | `core/agent.py` | Orchestrates memory, skills, tools, loop |
-| Execution | `core/agent_execution.py` | Unified agent loop |
+| Graph | `core/graph/` | LangGraph modes, nodes, routers, state |
+| Execution | `core/agent_execution.py` | Legacy / non-graph agent loop |
 | Events | `core/agent_events.py` | Pub/sub `AgentEventBus` |
+| Subagents | `core/subagents/` | Manager, spawn, supervisor, process/async runners |
+| Meta / refine | `core/meta_agent.py`, `core/self_refinement/` | Advisory + quality evaluate |
 | Tools | `core/tools/` | `BaseTool`, registry, browser, terminal |
 | Memory | `core/memory/` | SQLite + ChromaDB |
 | Skills | `core/skills/` | Markdown skills, generator, hub |
@@ -106,6 +125,8 @@ never imports `cli` / `api` / `integrations` (enforced by tests).
 
 ## See also
 
+- [EXECUTION_MODES.md](EXECUTION_MODES.md) — modes, Reflexion, step budget
+- [SUBAGENTS.md](SUBAGENTS.md) — workers and supervisor
 - [CLI.md](CLI.md)
 - [GATEWAY.md](GATEWAY.md)
 - [SECURITY.md](SECURITY.md)

--- a/docs/en/CONFIGURATION.md
+++ b/docs/en/CONFIGURATION.md
@@ -299,7 +299,45 @@ Profile `.env` / `config.yaml` (see also [EXECUTION_MODES.md](EXECUTION_MODES.md
 | `plan_generation_max_tokens` | `12000` | Max tokens for plan JSON (large development reports) |
 | `plan_generation_retries` | `2` | Retries on timeout or truncated JSON |
 | `max_steps_per_plan_step` | `5` | Tool iterations per plan step |
-| `max_steps` | `15` | Overall graph step limit |
+| `max_steps` | `90` | Overall graph / ReAct step budget (profile may override) |
+
+## Meta-agent & Reflexion
+
+Main-agent **pre-thinking** and **post-draft self-critique** (default **on**). Full behaviour: [EXECUTION_MODES.md](EXECUTION_MODES.md#reflexion-self-critique).
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `HOLIX_ENABLE_META_AGENT` / `enable_meta_agent` | `true` | Meta node after memory retrieval |
+| `HOLIX_ENABLE_SELF_REFINEMENT` / `enable_self_refinement` | `true` | Reflect after draft final answers |
+| `HOLIX_MAX_REFINEMENT_ITERATIONS` / `max_refinement_iterations` | `2` | Max Reflexion retries |
+| `HOLIX_REFINEMENT_QUALITY_THRESHOLD` / `refinement_quality_threshold` | `0.7` | Accept when quality ≥ threshold |
+
+## Step budget extension
+
+When `max_steps` is hit, Holix may grant more steps if the agent is still making progress ([EXECUTION_MODES.md](EXECUTION_MODES.md#step-budget-max_steps)):
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Enable auto-extension |
+| `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Steps per extension |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `3` | Max extensions per run |
+| `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Absolute cap (`0` = derived) |
+
+## Subagents & supervisor
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `enable_subagents` | `true` | Allow delegation / waves |
+| `subagent_default_process_mode` | `async` | `async` or `process` |
+| `subagent_max_concurrent` | `4` | Parallel jobs |
+| `subagent_process_timeout` | `900` | Wait / job budget (seconds) |
+| `HOLIX_SUBAGENT_SUPERVISOR_ENABLED` | `true` | Mid-job + graph rework supervisor |
+| `HOLIX_SUBAGENT_SUPERVISOR_POLL_S` | `4` | Runtime poll interval |
+| `HOLIX_SUBAGENT_SUPERVISOR_IDLE_S` | `90` | Hung threshold |
+| `HOLIX_SUBAGENT_SUPERVISOR_MAX_INTERVENTIONS` | `3` | Cap per job / rework rounds |
+| `HOLIX_SUBAGENT_SUPERVISOR_COOLDOWN_S` | `45` | Cooldown between interventions |
+
+See [SUBAGENTS.md](SUBAGENTS.md).
 
 ## Local project supplements
 

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -2,9 +2,31 @@
 
 ## Docker
 
-First-time container install (token, volumes, user approval): **[INSTALLATION.md § Path B](INSTALLATION.md#path-b--docker)**.
+First-time container install (token, volumes, user approval, extensions): **[INSTALLATION.md § Path B](INSTALLATION.md#path-b--docker)**.
 
-This section covers **production operations** for an already-running Docker deployment: env hardening, persistence, upgrades, and pairing with reverse proxy / monitoring below.
+Compose entry points:
+
+| Goal | Command |
+|------|---------|
+| Full agent (gateway + Telegram) | `docker compose up -d` |
+| + local Ollama | `docker compose --profile ollama up -d` |
+| Gateway API only | `docker compose --profile gateway-only up -d holix-gateway` |
+| Multi-user prod (bind mounts) | `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` |
+
+Templates: `docker/env.example`, `docker-compose.yml`, `docker-compose.prod.yml`.
+
+### Production checklist (Docker)
+
+1. Set a strong `HOLIX_API_KEY_PEPPER` (and rotate if leaked).
+2. Use named profile `HOLIX_PROFILE=shared` (never `default` in production).
+3. Bind-mount `HOLIX_DATA_DIR` so profiles/workspaces survive image upgrades.
+4. Keep `HOLIX_TELEGRAM_ACCESS_REQUESTS=true`; approve users with `--create-profile`.
+5. Leave `HOLIX_WORKSPACE_JAIL=true` for multi-tenant file isolation.
+6. Put reverse proxy TLS in front; optionally set `HOLIX_CORS_ORIGINS`.
+7. Drop extensions into `HOLIX_EXTENSIONS_DIR` or set `HOLIX_EXTENSIONS_PIP`.
+8. Upgrade: `docker compose pull && docker compose up -d` (data volume untouched).
+
+This section below covers **host** production (systemd). Docker ops pair with reverse proxy / monitoring the same way.
 
 ## systemd
 

--- a/docs/en/EXECUTION_MODES.md
+++ b/docs/en/EXECUTION_MODES.md
@@ -27,22 +27,26 @@ Check the active mode: `/status`.
 ```mermaid
 flowchart LR
   subgraph react [ReAct]
-    R1[User message] --> R2[Think + tools loop]
-    R2 --> R3[Answer]
+    R1[User message] --> R2[Meta]
+    R2 --> R3[Think + tools loop]
+    R3 --> R4[Reflect]
+    R4 --> R5[Answer]
   end
 
   subgraph plan [Plan and Execute]
-    P1[User message] --> P2[Build plan]
+    P1[User message] --> P2[Meta + plan]
     P2 --> P3[Your approval]
-    P3 --> P4[Step 1..N with tools]
-    P4 --> P5[Answer]
+    P3 --> P4[Steps / subagents]
+    P4 --> P5[Reflect]
+    P5 --> P6[Answer]
   end
 
   subgraph hybrid [Hybrid]
-    H1[User message] --> H2[Build plan]
+    H1[User message] --> H2[Meta + plan]
     H2 --> H3[Your approval]
-    H3 --> H4[ReAct inside each step]
-    H4 --> H5[Answer]
+    H3 --> H4[ReAct inside steps]
+    H4 --> H5[Reflect]
+    H5 --> H6[Answer]
   end
 ```
 
@@ -50,6 +54,9 @@ flowchart LR
 |---|-------|----------------|--------|
 | Plan before tools | No | Yes | Yes |
 | Tool loop style | One continuous loop | Per plan step | ReAct within each step |
+| Meta-agent (pre-thinking) | Yes (default on) | Yes | Yes |
+| Reflexion after draft | Yes (default on) | On final / max steps | Yes |
+| Subagent waves + supervisor | — | Yes when subagents on | Optional via tools |
 | Good task size | Small–medium | Medium, structured | Large, open-ended |
 | User approvals | Tool risk only | Plan + optional per-step | Plan + optional per-step |
 
@@ -69,11 +76,17 @@ flowchart LR
 ### How it behaves
 
 1. You send a message.
-2. The model may call tools (`read_file`, `run_terminal_command`, …).
-3. Results go back to the model; the loop continues.
-4. You get a final answer (or hit the step limit).
+2. **Meta-agent** (optional, default on) adds a short strategic hint from memory/context.
+3. The model may call tools (`read_file`, `run_terminal_command`, …).
+4. Results go back to the model; the loop continues.
+5. On a draft answer (or `max_steps`), **Reflexion** evaluates quality; if low, Holix retries with verbal self-feedback (up to `max_refinement_iterations`).
+6. You get the accepted final answer.
 
 Risky tools still ask for `/yes` or `/1`–`/4` confirmation.
+
+```text
+memory → meta → react ⇄ tools → reflect ⇄ react → finalize
+```
 
 ### Prompt examples
 
@@ -311,6 +324,59 @@ During `/plan-auto`, plan-step tools may auto-approve per security policy.
 
 ---
 
+## Reflexion (self-critique)
+
+Holix uses a **Reflexion-style** loop on the main agent (not Tree/Graph of Thoughts):
+
+1. Produce a draft final answer.
+2. Evaluate quality (and optional tool trajectory) via the meta evaluator.
+3. If below threshold → inject **verbal self-reflection** into the conversation and run **another ReAct pass**.
+4. Store reflection episodes in long-term memory when available.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `HOLIX_ENABLE_META_AGENT` / `enable_meta_agent` | `true` | Pre-thinking strategic hint after memory retrieval |
+| `HOLIX_ENABLE_SELF_REFINEMENT` / `enable_self_refinement` | `true` | Run Reflect after draft answers |
+| `HOLIX_MAX_REFINEMENT_ITERATIONS` | `2` | Max Reflexion retries per turn |
+| `HOLIX_REFINEMENT_QUALITY_THRESHOLD` | `0.7` | Accept draft when score ≥ threshold |
+
+Disable: `HOLIX_ENABLE_SELF_REFINEMENT=false` (or profile YAML `enable_self_refinement: false`).
+
+---
+
+## Step budget (max_steps)
+
+When the agent hits `max_steps`, Holix does not always stop immediately:
+
+1. **Health check** — recent tools, loops, errors, pending work.
+2. **Working + relevant** → grant extra steps (`max_steps_extend_by`, capped).
+3. **Hung / pure error thrash** → stop (or subagent supervisor guidance).
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `max_steps` | `90` (runtime; profile may override) | Base ReAct/graph step budget |
+| `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Allow auto-extension |
+| `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Steps added per extension |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `3` | Max extensions per run |
+| `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Absolute cap (`0` = base + extend×N) |
+
+---
+
+## Subagents in Plan mode
+
+With `enable_subagents: true`, `plan_and_execute` can run **waves** of sub-agents, then a **supervisor** cycle:
+
+```text
+delegate → collect → supervisor → (rework failed jobs?) → react synthesis
+```
+
+- **Runtime supervisor** — mid-job loop/hang → inject guidance into the same job.  
+- **Graph supervisor** — after collect, re-delegate failed types with repair instructions.  
+
+Details: [SUBAGENTS.md](SUBAGENTS.md#supervisor).
+
+---
+
 ## Configuration
 
 Profile `.env` / settings (see [.env.example](../../.env.example)):
@@ -323,7 +389,9 @@ Profile `.env` / settings (see [.env.example](../../.env.example)):
 | `plan_generation_max_tokens` | `12000` | Max tokens for plan JSON (large reports) |
 | `plan_generation_retries` | `2` | Retries on timeout or truncated JSON |
 | `max_steps_per_plan_step` | `5` | Tool iterations per step in Plan mode |
-| `max_steps` | `15` | Global graph step limit |
+| `max_steps` | profile / `90` | Global graph step limit |
+| `enable_meta_agent` | `true` | Meta pre-thinking node |
+| `enable_self_refinement` | `true` | Reflexion after draft |
 
 Execution mode itself is a **session setting** in TUI/Telegram (not usually stored in `.env`). Use `/mode` or Shift+Tab.
 
@@ -344,6 +412,9 @@ Execution mode itself is a **session setting** in TUI/Telegram (not usually stor
 ## Related docs
 
 - [SLASH_COMMANDS.md](SLASH_COMMANDS.md) — `/mode`, `/plan-*`, `/status`
+- [SUBAGENTS.md](SUBAGENTS.md) — workers, supervisor, rework
+- [MEMORY.md](MEMORY.md) — Reflexion episodes in LTM
+- [CONFIGURATION.md](CONFIGURATION.md) — env / profile keys
 - [TUI.md](TUI.md) — Shift+Tab, web UI
 - [USER_GUIDE.md](USER_GUIDE.md) — learning path (links to all topics)
 - [ARCHITECTURE.md](ARCHITECTURE.md) — LangGraph and runtime

--- a/docs/en/GATEWAY_API.md
+++ b/docs/en/GATEWAY_API.md
@@ -3,13 +3,14 @@
 > **On this documentation site:** `/docs/gateway-api` (same content as this page).  
 > **Live OpenAPI (try requests):** `http://127.0.0.1:8000/docs` on the gateway port — not the docs site port.
 
-Holix runs a **single multi-profile HTTP gateway** with three public surfaces:
+Holix runs a **single multi-profile HTTP gateway** with four public surfaces:
 
 | Surface | Prefix | Purpose |
 |---------|--------|---------|
 | **Hermes-compatible API** | `/v1`, `/api/sessions`, `/api/jobs` | Drop-in for Open WebUI, LobeChat, Hermes clients |
 | **Holix agent extensions** | `/v1/chat/completions`, permissions, plans | OpenAI chat + tool permissions + plan review |
 | **Holix Management API** | `/api/holix/` | SaaS control plane: profiles, models, MCP, skills, Telegram |
+| **A2A (Agent2Agent)** | `/a2a`, `/.well-known/agent.json` | Interop with remote agents (JSON-RPC + REST + **SSE streaming**) — see [A2A.md](A2A.md) |
 
 Operational guide (start/stop, ports, logs): [GATEWAY.md](GATEWAY.md).
 

--- a/docs/en/INSTALLATION.md
+++ b/docs/en/INSTALLATION.md
@@ -186,44 +186,122 @@ Or: `pipx upgrade Holix` / `uv tool upgrade Holix`
 
 No Python on the host required. Image includes Telegram, voice, and browser extras.
 
-### B1 — Quick start
+Files:
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | Agent + optional Ollama + gateway-only profile |
+| `docker-compose.prod.yml` | Bind-mount storage, always-restart, log rotation |
+| `docker/env.example` | Full environment template → copy to `.env` |
+| `./extensions/` | Drop-in extensions (mounted into the container) |
+
+### B1 — Quick start (model + Telegram → working agent)
 
 ```bash
-export TELEGRAM_BOT_TOKEN="123456789:AAH..."
-docker compose up -d
+cp docker/env.example .env
+# Edit at least:
+#   TELEGRAM_BOT_TOKEN=123456789:AAH...
+#   MODEL=gpt-4o-mini
+#   BASE_URL=https://api.openai.com/v1
+#   API_KEY=sk-...
+#   HOLIX_API_KEY_PEPPER=$(openssl rand -hex 32)
+
+docker compose up -d --build
+# or with local Ollama:
+# docker compose --profile ollama up -d --build
 ```
 
-On first run Holix bootstraps `HOLIX_HOME` inside the container and saves the bot token.
+On first run Holix creates profile `shared` (production-safe; `default` is forbidden when `HOLIX_ENV=production`), writes LLM and Telegram settings under `HOLIX_HOME`, enables workspace jail, and starts **gateway + Telegram + cron**.
 
-### B2 — Approve Telegram users
+Gateway health: `http://127.0.0.1:8000/health`
+
+### B2 — Approve Telegram users (multi-user)
 
 Users send `/start` in Telegram. Approve from the container:
 
 ```bash
 docker compose exec holix holix -p shared telegram requests list
 docker compose exec holix holix -p shared telegram requests approve USER_ID --create-profile alice
-# bind to existing profile:
+# bind to an existing profile:
 docker compose exec holix holix -p shared telegram requests approve USER_ID --profile existing
 ```
 
-Use a **named** bot profile (`-p shared` or your bootstrap profile). Profile `default` is dev-only when `HOLIX_ENV=production`.
+Each approved user gets an isolated profile under `profiles/<name>/` (memory, workspace, SOUL). Use a **named** bot host profile (`-p shared`).
 
-### B3 — Environment variables
+### B3 — Gateway only (API, no messengers)
+
+```bash
+# HOLIX_TELEGRAM_AUTOSTART / HOLIX_MAX_AUTOSTART forced off
+docker compose --profile gateway-only up -d holix-gateway
+```
+
+Same image and volumes; no Telegram/MAX OS companions. Useful behind Studio, mobile apps, or reverse proxy.
+
+### B4 — Production multi-user (bind-mounted storage)
+
+```bash
+mkdir -p ./data/holix ./extensions ./data/files
+# in .env (paths become bind mounts via docker-compose.yml):
+#   HOLIX_DATA_DIR=./data/holix
+#   HOLIX_EXTENSIONS_DIR=./extensions
+#   HOLIX_FILES_DIR=./data/files
+# plus secrets + MODEL + TELEGRAM_BOT_TOKEN
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+| Env / host path | Container | Content |
+|-----------------|-----------|---------|
+| `HOLIX_DATA_DIR` (default named volume `holix-data`) | `/data/.holix` | Profiles, memory, gateway state, telegram.env |
+| `HOLIX_EXTENSIONS_DIR` (default `./extensions`) | `/data/.holix/extensions` | Drop-in / git-cloned extensions |
+| `HOLIX_FILES_DIR` (default `./data/files`) | `/data/files` | Optional shared host files |
+
+Per-user workspace: `$HOLIX_DATA_DIR/profiles/<user>/workspace/` (jail on by default via `HOLIX_WORKSPACE_JAIL=true`).
+
+### B5 — Extensions (load & register)
+
+**Drop-in (no rebuild):**
+
+```bash
+# clone or copy under ./extensions/
+git clone <repo> ./extensions/my-billing
+docker compose restart holix
+docker compose exec holix holix extensions list
+docker compose exec holix holix extensions agent-list
+```
+
+**Pip on start** (comma-separated specs in `.env`):
+
+```bash
+HOLIX_EXTENSIONS_PIP=some-pypi-package,/data/.holix/extensions/local-pkg
+HOLIX_EXTENSIONS_SYNC=true   # reinstall each start; false after first install
+```
+
+Entrypoint installs specs, then Holix discovers entry points + folders. See [EXTENSIONS.md](EXTENSIONS.md).
+
+### B6 — Environment variables (main)
 
 | Variable | Purpose |
 |----------|---------|
-| `TELEGRAM_BOT_TOKEN` | Required for Telegram bot |
-| `MODEL`, `BASE_URL` | Cloud LLM instead of bundled Ollama |
-| `HOLIX_API_KEY_PEPPER` | Production API key hashing |
-| `HOLIX_ENV=production` | Production policy (named profiles) |
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token |
+| `MODEL`, `BASE_URL`, `API_KEY` | OpenAI-compatible LLM |
+| `HOLIX_API_KEY_PEPPER` | **Required** production API key hashing |
+| `HOLIX_PROFILE` | Bot host profile (default `shared`) |
+| `HOLIX_ENV=production` | Named profiles, auth enforced |
+| `HOLIX_WORKSPACE_JAIL` | Per-profile file jail (default `true`) |
+| `HOLIX_TELEGRAM_AUTOSTART` | Start Telegram companion (`false` = gateway-only) |
+| `HOLIX_MAX_AUTOSTART` | Start MAX polling companion |
+| `HOLIX_EXTENSIONS_PIP` | Comma-separated pip/path specs at boot |
+| `HOLIX_DATA_DIR` | Host path for `HOLIX_HOME` (prod compose) |
 
-Bind `HOLIX_HOME` to a host volume to persist profiles across container restarts (see `docker-compose.yml` in the repo).
+Full template: [`docker/env.example`](../../docker/env.example).
 
-### B4 — What runs inside
+### B7 — What runs inside
 
-`holix gateway start -f` — gateway, Telegram bot, and cron scheduler in one process.
+Command `agent` (default): `holix gateway start -f` — gateway, Telegram/MAX when tokens set, cron, extension sidecars.
 
-Production layout (systemd, TLS, encryption): [DEPLOYMENT.md](DEPLOYMENT.md) — Docker section there points back here for install; DEPLOYMENT covers **operations**, not first-time container setup.
+Commands: `agent` | `gateway` | `telegram` | `max` | `bootstrap` | `extensions` | `cli` | `shell`.
+
+Production ops (systemd, TLS, encryption): [DEPLOYMENT.md](DEPLOYMENT.md).
 
 ---
 

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -12,10 +12,20 @@ Data path: `~/.holix/profiles/<name>/data/memory/` (encrypted when [profile encr
 |-------|------|
 | Conversation | Messages per `conversation_id` (TUI session, Telegram chat, `cron-<id>`, API) |
 | Episodic / strategic | Summaries and extracted facts from successful runs |
+| Reflexion episodes | Quality critiques / retries (`metadata.type=reflexion` or `self_refinement`) |
 | Semantic (Chroma) | Embeddings for `/memory` and `holix memory search` |
 | Skills index | Chroma index for `holix skills search` (related, not chat memory) |
 
 The agent retrieves relevant past context automatically during runs; you can also search explicitly.
+
+### Reflexion and LTM
+
+When **self-refinement** is enabled (default), each evaluate/retry cycle may store:
+
+- **Episodic** — quality score, improvement areas, accept vs retry  
+- **Strategic** (on retry) — short “when quality is low on X, apply …” tips  
+
+See [EXECUTION_MODES.md](EXECUTION_MODES.md#reflexion-self-critique).
 
 ---
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -38,7 +38,9 @@ Holix is a self-improving AI agent: memory, skills, MCP, CLI, TUI, API gateway, 
 
 ### Agents & automation
 
-- [SUBAGENTS.md](SUBAGENTS.md) · [LAUNCH.md](LAUNCH.md) · [CRON.md](CRON.md)
+- [EXECUTION_MODES.md](EXECUTION_MODES.md) — ReAct / Plan / Hybrid, **Reflexion**, step budget
+- [SUBAGENTS.md](SUBAGENTS.md) — workers, **supervisor**, rework · [A2A.md](A2A.md) — Agent2Agent protocol · [LAUNCH.md](LAUNCH.md) · [CRON.md](CRON.md)
+- [SUBAGENT_SUPERVISOR.md](SUBAGENT_SUPERVISOR.md) — design notes
 
 ### Integrations & API
 

--- a/docs/en/SUBAGENTS.md
+++ b/docs/en/SUBAGENTS.md
@@ -8,12 +8,15 @@ In the profile `config.yaml` or global `.env`:
 
 ```yaml
 enable_subagents: true
-subagent_default_process_mode: process   # process | async
+subagent_default_process_mode: async   # async | process
 subagent_max_concurrent: 4
-subagent_process_timeout: 120
+subagent_process_timeout: 900
+# Runtime supervisor (mid-job guidance) + graph rework caps
+subagent_supervisor_enabled: true
+subagent_supervisor_max_interventions: 3
 ```
 
-Default in Holix: `enable_subagents: true`.
+Default in Holix: `enable_subagents: true`, default process mode **`async`** (OS process available with fallback).
 
 If disabled, `delegate_to_subagent` and `/subagent-spawn` return an error.
 
@@ -126,14 +129,63 @@ Available tools on the main agent (when `enable_subagents: true`):
 
 With `enable_subagents: true`, multi-step plans can delegate steps to sub-agents (e.g. `researcher` → `coder` → `reviewer`). See [EXECUTION_MODES.md](EXECUTION_MODES.md).
 
+In **`plan_and_execute`**, Holix may run **waves** of sub-agents, then a **graph supervisor** before synthesis:
+
+```text
+delegate → collect → supervisor → (rework failed jobs?) → react synthesis
+```
+
+---
+
+## Supervisor
+
+Holix runs two complementary helpers so stuck workers do not fail silently.
+
+### 1. Runtime supervisor (mid-job)
+
+Background watcher started with the first spawn (`core/subagents/supervisor.py`):
+
+| Detects | Action |
+|---------|--------|
+| **Loop** — same tool + args repeated | Inject **guidance** into the same job’s message stream |
+| **Thrash** — only tool errors | Guidance: fix root cause, do not repeat |
+| **Hung** — no activity for `idle_s` | Nudge to finish or change strategy |
+| **Stall** — steps without progress | Narrow the task |
+
+Limits: max interventions per job, cooldown between nudges. Emits `SubAgentSupervisorEvent` for UIs.
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `HOLIX_SUBAGENT_SUPERVISOR_ENABLED` | `true` | Master switch |
+| `HOLIX_SUBAGENT_SUPERVISOR_POLL_S` | `4` | Poll interval (seconds) |
+| `HOLIX_SUBAGENT_SUPERVISOR_IDLE_S` | `90` | Hung threshold |
+| `HOLIX_SUBAGENT_SUPERVISOR_MAX_INTERVENTIONS` | `3` | Cap per job / graph rework rounds |
+| `HOLIX_SUBAGENT_SUPERVISOR_COOLDOWN_S` | `45` | Min seconds between interventions |
+
+Async and process workers both apply guidance **before the next LLM step**.
+
+### 2. Graph supervisor (after a wave)
+
+In `plan_and_execute`, after `collect_subagent`:
+
+1. Inspect wave results.  
+2. For **failed** jobs, schedule **rework** of the same agent type with repair instructions.  
+3. Keep successful jobs; supersede failed `prior_job` ids.  
+4. Cap rework rounds with the same max-interventions setting.  
+5. Then synthesize in `react`.
+
+Design notes: [SUBAGENT_SUPERVISOR.md](SUBAGENT_SUPERVISOR.md).
+
+Sub-agents also share **step-budget extension** with the main agent (extra steps when still making progress) — [EXECUTION_MODES.md](EXECUTION_MODES.md#step-budget-max_steps).
+
 ---
 
 ## Process model
 
 | Mode | Behavior |
 |------|----------|
-| `process` (default on Linux/macOS) | Separate OS process — parallelism, isolation |
-| `async` | In-process `asyncio` task — lower overhead |
+| `async` (default) | In-process `asyncio` task — lower overhead, shared memory options |
+| `process` | Separate OS process — stronger isolation; may fall back to async if spawn fails |
 
 Configured via `subagent_default_process_mode` in profile config.
 
@@ -181,7 +233,9 @@ Sub-agent coder (claude assigned to coder slot):
 - Structured log: `logs/subagent.jsonl` — see [LOGS.md](LOGS.md)
 - CLI: `holix logs -s subagent`
 - Concurrent limit: `subagent_max_concurrent` (default 4)
-- Timeout per job: `subagent_process_timeout` (seconds)
+- Timeout per job: `subagent_process_timeout` (seconds; default often `900`)
+- Wait budgets can extend while a job is still active (activity heartbeat)
+- Supervisor interventions appear as activity (`supervisor_guidance`) and agent events
 
 ---
 

--- a/docs/en/SUBAGENT_SUPERVISOR.md
+++ b/docs/en/SUBAGENT_SUPERVISOR.md
@@ -1,0 +1,149 @@
+# Subagent Supervisor (runtime orchestrator)
+
+**Status:** Phase 1 (runtime sidecar) + Phase 1.5 (graph-native rework cycle)  
+**Date:** 2026-07-30  
+**Related:** `core/runtime/step_budget.py`, `core/subagents/manager.py`, plan-wave `orchestrator.py`  
+**Code:**  
+- Runtime: `core/subagents/supervisor.py`, `SubAgentSupervisorEvent`  
+- Graph: `core/graph/nodes/supervisor_node.py`, plan_execute edges  
+  `collect → supervisor → (rework? delegate : react)`  
+- Tests: `tests/test_subagent_supervisor.py`, `tests/test_graph_supervisor.py`  
+
+**User docs:** [SUBAGENTS.md](SUBAGENTS.md) · [EXECUTION_MODES.md](EXECUTION_MODES.md) · [CONFIGURATION.md](CONFIGURATION.md)
+
+## Problem
+
+When a sub-agent loops, thrash-fails, or hangs, Holix today either:
+
+- extends wait/step budget if there is still progress, or  
+- stops / times out the job.
+
+The **main agent does not intervene mid-run** with diagnosis and course correction. The same job is not guided toward recovery.
+
+## Goal
+
+A background **Subagent Supervisor** (worker attached to the main agent run):
+
+1. Watches running sub-agent status, activity, and recent tools.  
+2. Detects loop / thrash / hang / stall.  
+3. Diagnoses a short root-cause summary.  
+4. Sends **guidance** (or revise hint) to the **same** sub-agent.  
+5. Caps interventions to avoid recursion / cost blow-ups.  
+6. Emits UI events so Studio/CLI can show interventions.
+
+This is **not** the plan-wave builder (`orchestrator.py`). Naming: **Supervisor**.
+
+## Architecture
+
+```
+main agent
+  └─ SubAgentManager.spawn(...)
+        └─ SubagentSupervisor.ensure_running()
+              └─ asyncio watch_loop (poll 3–5s)
+                    ├─ assess(handle) → Diagnosis
+                    ├─ build_guidance(diagnosis)
+                    ├─ bus.send(guidance) → same job
+                    └─ SubAgentSupervisorEvent
+  └─ async_runner / process loop
+        └─ each step: drain inbox → inject system message
+```
+
+### MVP scope (Phase 1)
+
+| Item | In MVP |
+|------|--------|
+| Asyncio supervisor task | ✅ |
+| Detect: LOOP, THRASH, HUNG, STALL | ✅ |
+| Heuristic diagnosis text (no extra LLM) | ✅ |
+| Inject `guidance` into async sub-agents | ✅ |
+| Config flags + limits | ✅ |
+| Events + unit tests | ✅ |
+| Process-mode guidance via input_queue | ✅ if low-cost |
+| LLM diagnosis | ❌ Phase 2 |
+| `revise` rewrite of full task | ❌ Phase 2 |
+| OS subprocess supervisor | ❌ Phase 2/3 |
+| Studio panel | ❌ Phase 3 |
+
+### Config (env / Settings)
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `HOLIX_SUBAGENT_SUPERVISOR_ENABLED` | `true` | Master switch |
+| `HOLIX_SUBAGENT_SUPERVISOR_POLL_S` | `4.0` | Watch interval |
+| `HOLIX_SUBAGENT_SUPERVISOR_IDLE_S` | `90.0` | Hang threshold |
+| `HOLIX_SUBAGENT_SUPERVISOR_MAX_INTERVENTIONS` | `3` | Per job |
+| `HOLIX_SUBAGENT_SUPERVISOR_COOLDOWN_S` | `45.0` | Min gap between interventions |
+
+### Detection (reuse step-budget traces)
+
+- **LOOP** — same tool+args signature 3× in a row (activity log / tool history).  
+- **THRASH** — last ≥3 tool results all look like errors.  
+- **HUNG** — `RUNNING` and not `is_actively_working(idle_s)`.  
+- **STALL** — enough steps taken, no progress markers, not OK.  
+- **OK** — recent progress or idle window not exceeded → no action.
+
+### Intervention
+
+`AgentMessage(msg_type="guidance", content=..., metadata={kind, attempt, ...})`
+
+Sub-agent loop, before the next LLM call:
+
+```
+while msg := receive(timeout=0):
+  if msg_type == "guidance":
+    messages.append(system: SUPERVISOR GUIDANCE ...)
+```
+
+After max interventions without recovery: log + emit event; do **not** auto-kill in MVP (main/wait/timeout still own termination). Phase 2 may escalate/terminate.
+
+### Events
+
+`SubAgentSupervisorEvent`: name, kind, attempt, message, severity.
+
+### Non-goals (MVP)
+
+- Supervisor must not raise sub-agent permissions.  
+- No infinite guidance loops (cooldown + max interventions).  
+- No replacement of plan-wave orchestration.
+
+## Phases
+
+### Phase 1 — MVP (done)
+
+Detect + heuristic guidance inject for async/process; wire manager; tests; plan doc.
+
+### Phase 1.5 — Graph-native rework (done)
+
+- `supervisor` node in `plan_and_execute` after collect  
+- On failed wave jobs → re-delegate same agent types with guided task  
+- Caps via `subagent_supervisor_max_interventions`  
+- Wave result merge + prior_job supersede so successes are kept  
+
+### Related: Reflexion (main agent)
+
+Main-agent Reflexion is implemented separately (`reflect_node`, meta-agent defaults on):
+
+- `memory → meta → react ⇄ tools → reflect ⇄ react → finalize`
+- Verbal self-feedback + LTM episodes; config `enable_self_refinement` / `enable_meta_agent`
+
+### Phase 2
+
+LLM diagnosis; richer `revise`; auto-extend steps once after successful guidance; optional terminate after exhausted interventions.
+
+### Phase 3
+
+Main tool `guide_subagent`; Studio panel; multi-job priority; optional OS-process supervisor.
+
+## Test plan
+
+- Unit: diagnosis classifiers (loop/thrash/hung/ok).  
+- Unit: intervention caps / cooldown.  
+- Integration-style: mock handle + bus receives guidance.  
+- Regression: normal successful sub-agent not guided.
+
+## Acceptance (MVP)
+
+1. Spawned async sub-agent with simulated loop receives guidance message.  
+2. At most `max_interventions` guidance messages per job.  
+3. Healthy sub-agent with recent activity is not nudged.  
+4. Feature can be disabled via config.

--- a/docs/ru/A2A.md
+++ b/docs/ru/A2A.md
@@ -1,0 +1,82 @@
+# Протокол Agent2Agent (A2A)
+
+Holix участвует в открытом протоколе **[Agent2Agent (A2A)](https://a2a-protocol.org)**:
+
+| Роль | Что делает Holix |
+|------|------------------|
+| **A2A Server** | Agent Card + JSON-RPC `/a2a` + REST + **SSE streaming** |
+| **A2A Client** | Tools discovery и вызова удалённых A2A-агентов |
+
+Внутренние **субагенты** Holix остаются локальными. A2A — для **внешних** систем.
+
+## Включение
+
+`config.yaml` профиля:
+
+```yaml
+a2a:
+  enabled: true
+  public_url: https://agent.example.com/a2a
+  name: Holix Coding Agent
+  remote_agents:
+    - name: research
+      url: https://other.example.com/a2a
+```
+
+| Переменная | Смысл |
+|------------|--------|
+| `HOLIX_A2A_ENABLED` | вкл/выкл |
+| `HOLIX_A2A_PUBLIC_URL` | публичный URL карточки |
+| `HOLIX_A2A_TIMEOUT_S` | таймаут клиента |
+
+## Эндпоинты gateway
+
+Нужен API-ключ gateway (`hx_…`).
+
+| Метод | Путь | Назначение |
+|-------|------|------------|
+| `GET` | `/.well-known/agent.json` | Agent Card |
+| `POST` | `/a2a` | JSON-RPC: `message/send`, **`message/stream` (SSE)**, `tasks/*` |
+| `POST` | `/a2a/message:send` | REST (JSON или SSE при `Accept: text/event-stream`) |
+| `POST` | `/a2a/message:stream` | REST, всегда SSE |
+| `GET` | `/a2a/tasks/{id}` | статус задачи |
+| `GET` | `/a2a/tasks/{id}/subscribe` | SSE-снимок состояния |
+
+В карточке: `"capabilities": {"streaming": true}`.
+
+### Streaming (SSE) — пример
+
+```bash
+curl -sSN -X POST "http://127.0.0.1:8000/a2a" \
+  -H "Authorization: Bearer $HOLIX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/stream",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Привет"}]
+      }
+    }
+  }'
+```
+
+События: `task` → `statusUpdate` / `artifactUpdate` → `statusUpdate.final=true`.
+
+## Инструменты агента
+
+- `a2a_list_agents`
+- `a2a_discover`
+- `a2a_send_message` (blocking)
+- `a2a_get_task`
+
+## Ограничения
+
+- Push notifications (webhook) пока нет  
+- Task store в памяти процесса gateway  
+- Live progress — через `message/stream`; `/tasks/{id}/subscribe` даёт снимок  
+
+Полная EN-версия: [en/A2A.md](../en/A2A.md).

--- a/docs/ru/ARCHITECTURE.md
+++ b/docs/ru/ARCHITECTURE.md
@@ -6,10 +6,26 @@ Holix — платформа AI-агента на Python: единый цикл 
 
 ```
 HolixAgent (core/agent.py)
-    → run_agent_loop() / LangGraph (core/agent_execution.py)
+    → LangGraph mode graph (core/graph/)  [предпочтительно при use_langgraph=true]
+    → или legacy loop (core/agent_execution.py)
     → события AgentEvent (core/agent_events.py)
-    → ToolRegistry, MemoryManager, SkillManager
+    → ToolRegistry, MemoryManager, SkillManager, SubAgentManager
 ```
+
+### Режимы LangGraph (циклы)
+
+| Режим | Схема |
+|-------|--------|
+| `react` | `memory → meta → react ⇄ tools → reflect ⇄ react → finalize` |
+| `hybrid` | `memory → meta → plan → review → react ⇄ tools → reflect → finalize` |
+| `plan_and_execute` | plan/review + steps + `delegate → collect → supervisor → rework/react` + `reflect` |
+
+- **Meta-agent** — pre-thinking.  
+- **Reflexion** — оценка черновика + verbal retry.  
+- **Step budget** — расширение `max_steps` при прогрессе.  
+- **Субагенты** — runtime supervisor + graph rework.  
+
+Документация: [EXECUTION_MODES.md](EXECUTION_MODES.md), [SUBAGENTS.md](SUBAGENTS.md).
 
 | Адаптер | Роль |
 |---------|------|
@@ -22,8 +38,11 @@ HolixAgent (core/agent.py)
 | Компонент | Путь | Роль |
 |-----------|------|------|
 | Агент | `core/agent.py` | Память, навыки, tools, цикл |
-| Выполнение | `core/agent_execution.py` | Единый agent loop |
+| Граф | `core/graph/` | LangGraph modes, nodes, routers, state |
+| Выполнение | `core/agent_execution.py` | Legacy / non-graph loop |
 | События | `core/agent_events.py` | Pub/sub `AgentEventBus` |
+| Субагенты | `core/subagents/` | Manager, spawn, supervisor, runners |
+| Meta / refine | `core/meta_agent.py`, `core/self_refinement/` | Advisory + quality |
 | Tools | `core/tools/` | `BaseTool`, registry, browser, terminal |
 | Память | `core/memory/` | SQLite + ChromaDB |
 | Навыки | `core/skills/` | Markdown, generator, hub |
@@ -106,6 +125,8 @@ cli / api / integrations  →  core
 
 ## См. также
 
+- [EXECUTION_MODES.md](EXECUTION_MODES.md) — режимы, Reflexion, step budget
+- [SUBAGENTS.md](SUBAGENTS.md) — воркеры и supervisor
 - [CLI.md](CLI.md)
 - [GATEWAY.md](GATEWAY.md)
 - [MEMORY.md](MEMORY.md) · [MCP.md](MCP.md) · [MODELS.md](MODELS.md)

--- a/docs/ru/CONFIGURATION.md
+++ b/docs/ru/CONFIGURATION.md
@@ -186,7 +186,43 @@ providers:
 | `plan_generation_max_tokens` | `12000` | Макс. токенов для JSON плана (большие отчёты) |
 | `plan_generation_retries` | `2` | Повторы при таймауте или обрезанном JSON |
 | `max_steps_per_plan_step` | `5` | Итераций инструментов на шаг плана |
-| `max_steps` | `15` | Общий лимит шагов графа |
+| `max_steps` | `90` | Общий бюджет шагов графа / ReAct |
+
+## Meta-agent и Reflexion
+
+| Переменная | Default | Эффект |
+|------------|---------|--------|
+| `HOLIX_ENABLE_META_AGENT` / `enable_meta_agent` | `true` | Meta после retrieval памяти |
+| `HOLIX_ENABLE_SELF_REFINEMENT` / `enable_self_refinement` | `true` | Reflect после черновика ответа |
+| `HOLIX_MAX_REFINEMENT_ITERATIONS` | `2` | Макс. retry Reflexion |
+| `HOLIX_REFINEMENT_QUALITY_THRESHOLD` | `0.7` | Принять при score ≥ |
+
+См. [EXECUTION_MODES.md](EXECUTION_MODES.md).
+
+## Расширение step budget
+
+| Переменная | Default | Эффект |
+|------------|---------|--------|
+| `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Авто-расширение при прогрессе |
+| `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Шагов за расширение |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `3` | Сколько раз |
+| `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Жёсткий потолок (`0` = вычисляется) |
+
+## Субагенты и supervisor
+
+| Переменная | Default | Эффект |
+|------------|---------|--------|
+| `enable_subagents` | `true` | Делегирование / волны |
+| `subagent_default_process_mode` | `async` | `async` или `process` |
+| `subagent_max_concurrent` | `4` | Параллельные jobs |
+| `subagent_process_timeout` | `900` | Бюджет ожидания (сек) |
+| `HOLIX_SUBAGENT_SUPERVISOR_ENABLED` | `true` | Runtime + graph supervisor |
+| `HOLIX_SUBAGENT_SUPERVISOR_POLL_S` | `4` | Интервал опроса |
+| `HOLIX_SUBAGENT_SUPERVISOR_IDLE_S` | `90` | Порог hang |
+| `HOLIX_SUBAGENT_SUPERVISOR_MAX_INTERVENTIONS` | `3` | Лимит вмешательств / rework |
+| `HOLIX_SUBAGENT_SUPERVISOR_COOLDOWN_S` | `45` | Пауза между guidance |
+
+См. [SUBAGENTS.md](SUBAGENTS.md).
 
 ## Локальные дополнения проекта
 

--- a/docs/ru/DEPLOYMENT.md
+++ b/docs/ru/DEPLOYMENT.md
@@ -2,9 +2,31 @@
 
 ## Docker
 
-Первая установка в контейнере (токен, тома, одобрение пользователей): **[INSTALLATION.md § Путь B](INSTALLATION.md#путь-b--docker)**.
+Первая установка в контейнере (токен, тома, одобрение, расширения): **[INSTALLATION.md § Путь B](INSTALLATION.md#путь-b--docker)**.
 
-Здесь — **эксплуатация** уже запущенного Docker: hardening, обновления, связка с reverse proxy ниже.
+Точки входа Compose:
+
+| Цель | Команда |
+|------|---------|
+| Полный агент (gateway + Telegram) | `docker compose up -d` |
+| + локальная Ollama | `docker compose --profile ollama up -d` |
+| Только Gateway API | `docker compose --profile gateway-only up -d holix-gateway` |
+| Multi-user prod (bind mounts) | `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` |
+
+Шаблоны: `docker/env.example`, `docker-compose.yml`, `docker-compose.prod.yml`.
+
+### Чеклист production (Docker)
+
+1. Сильный `HOLIX_API_KEY_PEPPER`.
+2. Именованный профиль `HOLIX_PROFILE=shared` (не `default` в production).
+3. Bind-mount `HOLIX_DATA_DIR` — профили/workspace переживают апгрейд образа.
+4. `HOLIX_TELEGRAM_ACCESS_REQUESTS=true`; approve с `--create-profile`.
+5. `HOLIX_WORKSPACE_JAIL=true` для multi-tenant.
+6. TLS на reverse proxy; при необходимости `HOLIX_CORS_ORIGINS`.
+7. Расширения в `HOLIX_EXTENSIONS_DIR` или через `HOLIX_EXTENSIONS_PIP`.
+8. Апгрейд: `docker compose pull && docker compose up -d` (том данных не трогать).
+
+Ниже — **host**-production (systemd). Docker стыкуется с reverse proxy / мониторингом так же.
 
 ## systemd
 

--- a/docs/ru/EXECUTION_MODES.md
+++ b/docs/ru/EXECUTION_MODES.md
@@ -27,22 +27,26 @@ Holix запускает агента через **LangGraph**. **Режим р�
 ```mermaid
 flowchart LR
   subgraph react [ReAct]
-    R1[Сообщение] --> R2[Цикл мысль + инструменты]
-    R2 --> R3[Ответ]
+    R1[Сообщение] --> R2[Meta]
+    R2 --> R3[Цикл мысль + tools]
+    R3 --> R4[Reflect]
+    R4 --> R5[Ответ]
   end
 
   subgraph plan [Plan and Execute]
-    P1[Сообщение] --> P2[План]
+    P1[Сообщение] --> P2[Meta + план]
     P2 --> P3[Согласование]
-    P3 --> P4[Шаги 1..N]
-    P4 --> P5[Ответ]
+    P3 --> P4[Шаги / субагенты]
+    P4 --> P5[Reflect]
+    P5 --> P6[Ответ]
   end
 
   subgraph hybrid [Hybrid]
-    H1[Сообщение] --> H2[План]
+    H1[Сообщение] --> H2[Meta + план]
     H2 --> H3[Согласование]
     H3 --> H4[ReAct внутри шага]
-    H4 --> H5[Ответ]
+    H4 --> H5[Reflect]
+    H5 --> H6[Ответ]
   end
 ```
 
@@ -50,6 +54,9 @@ flowchart LR
 |---|-------|----------------|--------|
 | План до инструментов | Нет | Да | Да |
 | Цикл инструментов | Один общий | По шагам плана | ReAct внутри шага |
+| Meta-agent (pre-thinking) | Да (по умолчанию) | Да | Да |
+| Reflexion после черновика | Да (по умолчанию) | На final / max_steps | Да |
+| Волны субагентов + supervisor | — | Да при enable_subagents | Через tools |
 | Размер задачи | Небольшая–средняя | Средняя, структурированная | Крупная, открытая |
 | Согласования | Риск инструментов | План + опционально шаги | План + опционально шаги |
 
@@ -58,6 +65,16 @@ flowchart LR
 ## ReAct (`react`)
 
 **Режим по умолчанию.** Агент чередует рассуждение и вызовы инструментов, пока не ответит или не достигнет `max_steps`.
+
+Типичный граф:
+
+```text
+memory → meta → react ⇄ tools → reflect ⇄ react → finalize
+```
+
+1. **Meta-agent** (по умолчанию вкл.) — короткая стратегическая подсказка.  
+2. Цикл ReAct / tools.  
+3. **Reflexion** — оценка черновика; при низком качестве — verbal feedback и повтор ReAct (до `max_refinement_iterations`).
 
 ### Когда использовать
 
@@ -311,6 +328,56 @@ flowchart LR
 
 ---
 
+## Reflexion (самокритика)
+
+Holix использует цикл в стиле **Reflexion** (не Tree/Graph of Thoughts):
+
+1. Черновик финального ответа.  
+2. Оценка качества (+ опционально траектория tools).  
+3. Ниже порога → **verbal reflection** в сообщения и ещё один проход ReAct.  
+4. Эпизоды reflection в LTM при доступной памяти.
+
+| Переменная | По умолчанию | Эффект |
+|------------|--------------|--------|
+| `HOLIX_ENABLE_META_AGENT` / `enable_meta_agent` | `true` | Meta после retrieval памяти |
+| `HOLIX_ENABLE_SELF_REFINEMENT` / `enable_self_refinement` | `true` | Reflect после черновика |
+| `HOLIX_MAX_REFINEMENT_ITERATIONS` | `2` | Макс. retry Reflexion |
+| `HOLIX_REFINEMENT_QUALITY_THRESHOLD` | `0.7` | Принять ответ при score ≥ |
+
+Выключить: `HOLIX_ENABLE_SELF_REFINEMENT=false`.
+
+---
+
+## Бюджет шагов (max_steps)
+
+При достижении `max_steps` Holix не всегда останавливается сразу:
+
+1. Проверка прогресса (tools, loop, ошибки).  
+2. **Работает + релевантно** → +шаги (`max_steps_extend_by`).  
+3. **Завис / thrash** → стоп (или guidance supervisor у субагентов).
+
+| Переменная | По умолчанию | Эффект |
+|------------|--------------|--------|
+| `max_steps` | `90` (runtime; профиль может переопределить) | Базовый бюджет |
+| `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Авто-расширение |
+| `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Шагов за раз |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `3` | Сколько раз |
+| `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Жёсткий потолок (`0` = base+extend×N) |
+
+---
+
+## Субагенты в Plan mode
+
+При `enable_subagents: true` режим `plan_and_execute` может запускать **волны** субагентов и **supervisor**:
+
+```text
+delegate → collect → supervisor → (rework failed?) → react synthesis
+```
+
+Подробнее: [SUBAGENTS.md](SUBAGENTS.md#supervisor).
+
+---
+
 ## Настройки
 
 `.env` профиля / settings (см. [.env.example](../../.env.example)):
@@ -323,7 +390,9 @@ flowchart LR
 | `plan_generation_max_tokens` | `12000` | Макс. токенов для JSON плана (большие отчёты) |
 | `plan_generation_retries` | `2` | Повторы при таймауте или обрезанном JSON |
 | `max_steps_per_plan_step` | `5` | Итераций инструментов на шаг в Plan |
-| `max_steps` | `15` | Общий лимит шагов графа |
+| `max_steps` | `90` | Общий лимит шагов графа / ReAct |
+| `enable_meta_agent` | `true` | Meta pre-thinking |
+| `enable_self_refinement` | `true` | Reflexion после черновика |
 
 Сам режим — **настройка сессии** в TUI/Telegram (обычно не в `.env`). Используйте `/mode` или Shift+Tab.
 
@@ -344,6 +413,9 @@ flowchart LR
 ## См. также
 
 - [SLASH_COMMANDS.md](SLASH_COMMANDS.md) — `/mode`, `/plan-*`, `/status`
+- [SUBAGENTS.md](SUBAGENTS.md) — воркеры, supervisor, rework
+- [MEMORY.md](MEMORY.md) — эпизоды Reflexion в LTM
+- [CONFIGURATION.md](CONFIGURATION.md) — env / профиль
 - [TUI.md](TUI.md) — Shift+Tab, веб-интерфейс
 - [USER_GUIDE.md](USER_GUIDE.md) — маршрут обучения (ссылки на все темы)
 - [ARCHITECTURE.md](ARCHITECTURE.md) — LangGraph и runtime

--- a/docs/ru/INSTALLATION.md
+++ b/docs/ru/INSTALLATION.md
@@ -167,18 +167,38 @@ holix update --channel pypi
 
 Python на хосте не нужен. В образе уже Telegram, voice, browser.
 
-### B1 — Быстрый старт
+Файлы:
+
+| Файл | Назначение |
+|------|------------|
+| `docker-compose.yml` | Агент + опционально Ollama + профиль gateway-only |
+| `docker-compose.prod.yml` | Bind-mount хранилища, restart always, ротация логов |
+| `docker/env.example` | Полный шаблон env → скопировать в `.env` |
+| `./extensions/` | Drop-in расширения (монтируются в контейнер) |
+
+### B1 — Быстрый старт (модель + Telegram → рабочий агент)
 
 ```bash
-export TELEGRAM_BOT_TOKEN="123456789:AAH..."
-docker compose up -d
+cp docker/env.example .env
+# Минимум:
+#   TELEGRAM_BOT_TOKEN=123456789:AAH...
+#   MODEL=gpt-4o-mini
+#   BASE_URL=https://api.openai.com/v1
+#   API_KEY=sk-...
+#   HOLIX_API_KEY_PEPPER=$(openssl rand -hex 32)
+
+docker compose up -d --build
+# с локальной Ollama:
+# docker compose --profile ollama up -d --build
 ```
 
-При первом запуске создаётся `HOLIX_HOME` в контейнере.
+При старте создаётся профиль `shared` (в production `default` запрещён), пишутся LLM и Telegram в `HOLIX_HOME`, включается workspace jail, поднимаются **gateway + Telegram + cron**.
 
-### B2 — Одобрение пользователей Telegram
+Health: `http://127.0.0.1:8000/health`
 
-Пользователь отправляет `/start`. Одобрение из контейнера:
+### B2 — Одобрение пользователей Telegram (мультипользователь)
+
+Пользователь шлёт `/start`. Одобрение из контейнера:
 
 ```bash
 docker compose exec holix holix -p shared telegram requests list
@@ -186,22 +206,76 @@ docker compose exec holix holix -p shared telegram requests approve USER_ID --cr
 docker compose exec holix holix -p shared telegram requests approve USER_ID --profile existing
 ```
 
-Используйте **именованный** профиль бота (`-p shared`). В production профиль `default` недоступен.
+У каждого пользователя — изолированный профиль `profiles/<name>/` (память, workspace, SOUL). Хост-бот: **именованный** профиль (`-p shared`).
 
-### B3 — Переменные окружения
+### B3 — Только gateway (API без мессенджеров)
+
+```bash
+docker compose --profile gateway-only up -d holix-gateway
+```
+
+Тот же образ и тома; companions Telegram/MAX не стартуют. Удобно за Studio, мобильным клиентом или reverse proxy.
+
+### B4 — Production multi-user (файловое хранилище на хосте)
+
+```bash
+mkdir -p ./data/holix ./extensions ./data/files
+# в .env (пути → bind mounts через docker-compose.yml):
+#   HOLIX_DATA_DIR=./data/holix
+#   HOLIX_EXTENSIONS_DIR=./extensions
+#   HOLIX_FILES_DIR=./data/files
+# + секреты, MODEL, TELEGRAM_BOT_TOKEN
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+| Env / путь на хосте | Контейнер | Содержимое |
+|---------------------|-----------|------------|
+| `HOLIX_DATA_DIR` (по умолчанию том `holix-data`) | `/data/.holix` | Профили, память, gateway, telegram.env |
+| `HOLIX_EXTENSIONS_DIR` (по умолчанию `./extensions`) | `/data/.holix/extensions` | Drop-in / git-clone расширения |
+| `HOLIX_FILES_DIR` (по умолчанию `./data/files`) | `/data/files` | Общие файлы хоста (опционально) |
+
+Workspace: `$HOLIX_DATA_DIR/profiles/<user>/workspace/` (`HOLIX_WORKSPACE_JAIL=true` по умолчанию).
+
+### B5 — Расширения (загрузка и регистрация)
+
+**Drop-in (без пересборки образа):**
+
+```bash
+git clone <repo> ./extensions/my-billing
+docker compose restart holix
+docker compose exec holix holix extensions list
+docker compose exec holix holix extensions agent-list
+```
+
+**Pip при старте** (в `.env`, через запятую):
+
+```bash
+HOLIX_EXTENSIONS_PIP=some-pypi-package,/data/.holix/extensions/local-pkg
+HOLIX_EXTENSIONS_SYNC=true
+```
+
+См. [EXTENSIONS.md](EXTENSIONS.md).
+
+### B6 — Основные переменные
 
 | Переменная | Назначение |
 |------------|------------|
 | `TELEGRAM_BOT_TOKEN` | Токен бота |
-| `MODEL`, `BASE_URL` | Облачная LLM вместо Ollama в контейнере |
-| `HOLIX_API_KEY_PEPPER` | Хеширование API-ключей |
-| `HOLIX_ENV=production` | Политика production |
+| `MODEL`, `BASE_URL`, `API_KEY` | OpenAI-совместимая LLM |
+| `HOLIX_API_KEY_PEPPER` | **Обязателен** в production |
+| `HOLIX_PROFILE` | Профиль хоста бота (по умолчанию `shared`) |
+| `HOLIX_WORKSPACE_JAIL` | Изоляция файлов на профиль |
+| `HOLIX_TELEGRAM_AUTOSTART` | Companion Telegram (`false` = только API) |
+| `HOLIX_EXTENSIONS_PIP` | pip/path-пакеты при старте |
+| `HOLIX_DATA_DIR` | Путь `HOLIX_HOME` на хосте (prod compose) |
 
-Смонтируйте том для `HOLIX_HOME`, чтобы сохранить профили между перезапусками (см. `docker-compose.yml` в репозитории).
+Полный шаблон: [`docker/env.example`](../../docker/env.example).
 
-### B4 — Что работает внутри
+### B7 — Что внутри
 
-`holix gateway start -f` — gateway, Telegram и cron в одном процессе.
+Команда `agent` (по умолчанию): `holix gateway start -f` — gateway, Telegram/MAX при наличии токенов, cron, sidecars расширений.
+
+Команды entrypoint: `agent` | `gateway` | `telegram` | `max` | `bootstrap` | `extensions` | `cli` | `shell`.
 
 Эксплуатация (systemd, TLS, шифрование): [DEPLOYMENT.md](DEPLOYMENT.md).
 

--- a/docs/ru/MEMORY.md
+++ b/docs/ru/MEMORY.md
@@ -12,10 +12,20 @@ Holix хранит историю диалогов и долгосрочные �
 |------|------------|
 | Диалог | Сообщения по `conversation_id` (TUI, Telegram, cron, API) |
 | Эпизодическая / стратегическая | Сводки и факты из успешных запусков |
+| Reflexion | Критики качества / retry (`metadata.type=reflexion` или `self_refinement`) |
 | Семантика (Chroma) | Эмбеддинги для `/memory` и `holix memory search` |
 | Индекс навыков | Поиск по skills (отдельно от чата) |
 
 Агент подтягивает контекст автоматически; можно искать явно.
+
+### Reflexion и LTM
+
+При включённом **self-refinement** (по умолчанию) каждый evaluate/retry может писать:
+
+- **эпизодическую** память — score, areas, accept vs retry  
+- **стратегическую** (при retry) — короткие советы «когда quality low on X…»  
+
+См. [EXECUTION_MODES.md](EXECUTION_MODES.md).
 
 ---
 

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -35,7 +35,9 @@
 
 ### Агенты и автоматизация
 
-- [SUBAGENTS.md](SUBAGENTS.md) · [LAUNCH.md](LAUNCH.md) · [CRON.md](CRON.md)
+- [EXECUTION_MODES.md](EXECUTION_MODES.md) — ReAct / Plan / Hybrid, **Reflexion**, step budget
+- [SUBAGENTS.md](SUBAGENTS.md) — воркеры, **supervisor**, rework · [LAUNCH.md](LAUNCH.md) · [CRON.md](CRON.md)
+- [en/SUBAGENT_SUPERVISOR.md](../en/SUBAGENT_SUPERVISOR.md) — дизайн supervisor
 
 ### Интеграции и API
 

--- a/docs/ru/SUBAGENTS.md
+++ b/docs/ru/SUBAGENTS.md
@@ -8,12 +8,14 @@
 
 ```yaml
 enable_subagents: true
-subagent_default_process_mode: process   # process | async
+subagent_default_process_mode: async   # async | process
 subagent_max_concurrent: 4
-subagent_process_timeout: 120
+subagent_process_timeout: 900
+subagent_supervisor_enabled: true
+subagent_supervisor_max_interventions: 3
 ```
 
-По умолчанию: `enable_subagents: true`.
+По умолчанию: `enable_subagents: true`, режим процесса **`async`** (OS process доступен с fallback).
 
 Если выключено — `delegate_to_subagent` и `/subagent-spawn` вернут ошибку.
 
@@ -126,14 +128,59 @@ Tools главного агента (при `enable_subagents: true`):
 
 При `enable_subagents: true` план может делегировать шаги субагентам (`researcher` → `coder` → `reviewer`). См. [EXECUTION_MODES.md](EXECUTION_MODES.md).
 
+В **`plan_and_execute`** возможны **волны** субагентов и цикл **supervisor** до синтеза:
+
+```text
+delegate → collect → supervisor → (rework failed?) → react synthesis
+```
+
+---
+
+## Supervisor
+
+Два уровня помощи застрявшим воркерам.
+
+### 1. Runtime supervisor (во время job)
+
+Фоновый watcher при первом spawn (`core/subagents/supervisor.py`):
+
+| Детект | Действие |
+|--------|----------|
+| **Loop** — один и тот же tool+args | Guidance в тот же job |
+| **Thrash** — только ошибки tools | Не повторять; чинить причину |
+| **Hung** — нет activity `idle_s` | Подтолкнуть к финалу / смене стратегии |
+| **Stall** — шаги без прогресса | Сузить задачу |
+
+Лимиты: max interventions, cooldown. Событие: `SubAgentSupervisorEvent`.
+
+| Переменная | Default | Смысл |
+|------------|---------|--------|
+| `HOLIX_SUBAGENT_SUPERVISOR_ENABLED` | `true` | Вкл/выкл |
+| `HOLIX_SUBAGENT_SUPERVISOR_POLL_S` | `4` | Интервал опроса |
+| `HOLIX_SUBAGENT_SUPERVISOR_IDLE_S` | `90` | Порог hang |
+| `HOLIX_SUBAGENT_SUPERVISOR_MAX_INTERVENTIONS` | `3` | Лимит на job / rework |
+| `HOLIX_SUBAGENT_SUPERVISOR_COOLDOWN_S` | `45` | Пауза между вмешательствами |
+
+### 2. Graph supervisor (после волны)
+
+После `collect_subagent` в plan mode:
+
+1. Смотрит результаты волны.  
+2. Failed jobs → **rework** того же `agent_type` с инструкциями.  
+3. Успешные jobs сохраняются; failed `prior_job` заменяется.  
+4. Синтез в `react`.
+
+План: [SUBAGENT_SUPERVISOR.md](../en/SUBAGENT_SUPERVISOR.md).  
+Общий step-budget: [EXECUTION_MODES.md](EXECUTION_MODES.md).
+
 ---
 
 ## Модель выполнения
 
 | Режим | Поведение |
 |-------|-----------|
-| `process` (по умолчанию на Linux/macOS) | Отдельный OS-процесс — параллелизм и изоляция |
-| `async` | Задача `asyncio` в процессе Holix — меньше накладных расходов |
+| `async` (по умолчанию) | Задача `asyncio` в процессе Holix — меньше накладных расходов |
+| `process` | Отдельный OS-процесс — сильнее изоляция; возможен fallback на async |
 
 Настраивается через `subagent_default_process_mode`.
 
@@ -167,7 +214,9 @@ Tools главного агента (при `enable_subagents: true`):
 - Лог: `logs/subagent.jsonl` — см. [LOGS.md](LOGS.md)
 - CLI: `holix logs -s subagent`
 - Параллельно: не больше `subagent_max_concurrent` (по умолчанию 4)
-- Таймаут job: `subagent_process_timeout` (секунды)
+- Таймаут job: `subagent_process_timeout` (секунды; часто `900`)
+- Wait-бюджет может продлеваться при активной работе
+- Вмешательства supervisor видны в activity и agent events
 
 ---
 

--- a/docs/ru/SUBAGENT_SUPERVISOR.md
+++ b/docs/ru/SUBAGENT_SUPERVISOR.md
@@ -1,0 +1,16 @@
+# Supervisor субагентов
+
+Дизайн и поведение runtime + graph supervisor для застрявших sub-agent jobs.
+
+Полная версия (EN): [SUBAGENT_SUPERVISOR.md](../en/SUBAGENT_SUPERVISOR.md).
+
+## Кратко
+
+| Уровень | Когда | Действие |
+|---------|--------|----------|
+| Runtime | job RUNNING, loop/hang/thrash | Guidance в тот же job |
+| Graph | после collect в plan mode | Rework failed agent types |
+
+Настройки: `HOLIX_SUBAGENT_SUPERVISOR_*` — см. [CONFIGURATION.md](CONFIGURATION.md), [SUBAGENTS.md](SUBAGENTS.md).
+
+Связанные темы: [EXECUTION_MODES.md](EXECUTION_MODES.md) (Reflexion, step budget).

--- a/extensions/.gitkeep
+++ b/extensions/.gitkeep
@@ -1,0 +1,7 @@
+# Drop-in Holix extensions (mounted into the container at $HOLIX_HOME/extensions).
+#
+# Layout examples:
+#   extensions/my_stats/agent.py
+#   extensions/holix-telegram-billing/   (git clone)
+#
+# See docs/en/EXTENSIONS.md

--- a/integrations/max/gateway_routes.py
+++ b/integrations/max/gateway_routes.py
@@ -43,7 +43,10 @@ def max_should_webhook(profile: str = "default") -> bool:
 
 
 def max_should_poll(profile: str = "default") -> bool:
-    """True when MAX token is set and mode is polling (default outside production)."""
+    """True when MAX token is set, mode is polling, and autostart is enabled."""
+    raw = os.getenv("HOLIX_MAX_AUTOSTART", "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return False
     load_max_env_files()
     settings = load_max_settings(profile)
     return max_enabled(profile) and not settings.is_webhook_mode

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -407,7 +407,6 @@ class HolixTelegramBot:
         """Return False if a plugin gate blocked the message (reply already sent)."""
         from integrations.telegram.plugin_api import (
             get_active_telegram_plugin_api,
-            run_message_gates,
         )
 
         api = getattr(self, "_plugin_api", None) or get_active_telegram_plugin_api()
@@ -603,7 +602,6 @@ class HolixTelegramBot:
             TelegramPluginAPI,
             apply_telegram_handlers,
             load_telegram_plugins,
-            run_message_gates,
         )
 
         plugin_api = TelegramPluginAPI(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.1"
+version = "1.0.2"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,36 +2,132 @@
 set -e
 
 export HOLIX_HOME="${HOLIX_HOME:-/data/.holix}"
-export HOLIX_PROFILE="${HOLIX_PROFILE:-default}"
+export HOLIX_PROFILE="${HOLIX_PROFILE:-shared}"
 export HOLIX_ENV="${HOLIX_ENV:-production}"
 
-mkdir -p "$HOLIX_HOME"
+mkdir -p "$HOLIX_HOME" \
+  "$HOLIX_HOME/extensions" \
+  "$HOLIX_HOME/profiles" \
+  "${HOLIX_FILES_DIR:-/data/files}"
 
-cmd="${1:-gateway}"
+# ---------------------------------------------------------------------------
+# Optional: install / sync extensions via pip (HOLIX_EXTENSIONS_PIP)
+# Specs are comma-separated: package names or paths visible in the container.
+# ---------------------------------------------------------------------------
+_install_extensions() {
+  specs="${HOLIX_EXTENSIONS_PIP:-}"
+  if [ -z "$specs" ]; then
+    return 0
+  fi
+  sync="${HOLIX_EXTENSIONS_SYNC:-true}"
+  marker="$HOLIX_HOME/.extensions-pip-installed"
+  if [ "$sync" != "true" ] && [ "$sync" != "1" ] && [ -f "$marker" ]; then
+    echo "[holix] extensions pip already installed (HOLIX_EXTENSIONS_SYNC=false)"
+    return 0
+  fi
+  echo "[holix] Installing extensions: $specs"
+  old_ifs=$IFS
+  IFS=','
+  # shellcheck disable=SC2086
+  for spec in $specs; do
+    spec=$(echo "$spec" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [ -z "$spec" ] && continue
+    if [ -d "$spec" ] || [ -f "$spec" ]; then
+      echo "[holix] uv pip install -e $spec"
+      uv pip install -e "$spec" || {
+        echo "[holix] WARN: failed to install $spec" >&2
+        continue
+      }
+    else
+      echo "[holix] uv pip install $spec"
+      uv pip install "$spec" || {
+        echo "[holix] WARN: failed to install $spec" >&2
+        continue
+      }
+    fi
+  done
+  IFS=$old_ifs
+  date -u +%Y-%m-%dT%H:%M:%SZ >"$marker" 2>/dev/null || true
+}
+
+# List drop-in extension roots for logs
+_list_dropin_extensions() {
+  root="$HOLIX_HOME/extensions"
+  if [ ! -d "$root" ]; then
+    return 0
+  fi
+  count=0
+  for d in "$root"/*/; do
+    [ -d "$d" ] || continue
+    name=$(basename "$d")
+    case "$name" in
+      .* | __pycache__) continue ;;
+    esac
+    count=$((count + 1))
+    echo "[holix] drop-in extension: $name"
+  done
+  if [ "$count" -eq 0 ]; then
+    echo "[holix] no drop-in extensions under $root"
+  fi
+}
+
+cmd="${1:-agent}"
 shift || true
 
+_install_extensions
+_list_dropin_extensions
+
 case "$cmd" in
-  gateway)
+  agent|full)
+    # Gateway + Telegram/MAX companions (when tokens set) + cron
     uv run python scripts/docker_bootstrap.py
-    exec uv run holix gateway start -f \
+    exec uv run holix -p "$HOLIX_PROFILE" gateway start -f \
+      --host "${HOLIX_GATEWAY_HOST:-0.0.0.0}" \
+      --port "${HOLIX_GATEWAY_PORT:-8000}" \
+      "$@"
+    ;;
+  gateway|gateway-only|api)
+    # API gateway; companions controlled by HOLIX_TELEGRAM_AUTOSTART / HOLIX_MAX_AUTOSTART
+    # For pure API, compose profile gateway-only sets autostart=false
+    export HOLIX_TELEGRAM_AUTOSTART="${HOLIX_TELEGRAM_AUTOSTART:-true}"
+    export HOLIX_MAX_AUTOSTART="${HOLIX_MAX_AUTOSTART:-true}"
+    uv run python scripts/docker_bootstrap.py
+    exec uv run holix -p "$HOLIX_PROFILE" gateway start -f \
       --host "${HOLIX_GATEWAY_HOST:-0.0.0.0}" \
       --port "${HOLIX_GATEWAY_PORT:-8000}" \
       "$@"
     ;;
   telegram)
     uv run python scripts/docker_bootstrap.py
-    exec uv run holix telegram run "$@"
+    exec uv run holix -p "$HOLIX_PROFILE" telegram run "$@"
     ;;
-  cli|helix)
-    exec uv run holix "$@"
+  max)
+    uv run python scripts/docker_bootstrap.py
+    exec uv run holix -p "$HOLIX_PROFILE" max run "$@"
     ;;
   bootstrap)
     exec uv run python scripts/docker_bootstrap.py
     ;;
+  extensions|ext)
+    # Register / inspect: holix extensions …
+    sub="${1:-list}"
+    shift || true
+    exec uv run holix -p "$HOLIX_PROFILE" extensions "$sub" "$@"
+    ;;
+  cli|helix|holix)
+    exec uv run holix -p "$HOLIX_PROFILE" "$@"
+    ;;
   shell|bash|sh)
+    if [ "$#" -eq 0 ]; then
+      exec /bin/bash
+    fi
     exec "$@"
     ;;
   *)
-    exec "$cmd" "$@"
+    # Pass-through: docker run … holix-agent holix doctor
+    if command -v "$cmd" >/dev/null 2>&1; then
+      exec "$cmd" "$@"
+    fi
+    exec uv run holix -p "$HOLIX_PROFILE" "$cmd" "$@"
     ;;
 esac

--- a/scripts/docker_bootstrap.py
+++ b/scripts/docker_bootstrap.py
@@ -1,9 +1,19 @@
-"""First-run bootstrap for the Holix Docker image."""
+"""First-run bootstrap for the Holix Docker image.
+
+Creates the named profile, writes LLM / messenger env, enables workspace jail
+for multi-user production, and ensures extension drop-in directories exist.
+"""
 
 from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
+
+
+def _truthy(name: str, default: str = "") -> bool:
+    raw = os.getenv(name, default).strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 def _upsert_profile_env(profile: str, values: dict[str, str]) -> None:
@@ -14,19 +24,87 @@ def _upsert_profile_env(profile: str, values: dict[str, str]) -> None:
             upsert_profile_env_var(profile, key, value)
 
 
+def _default_profile_name() -> str:
+    """Production-safe host profile (``default`` is forbidden when HOLIX_ENV=production)."""
+    env_name = (os.getenv("HOLIX_ENV") or "production").strip().lower()
+    configured = (os.getenv("HOLIX_PROFILE") or "").strip()
+    if configured:
+        if env_name == "production" and configured == "default":
+            print(
+                "[holix] WARN: HOLIX_PROFILE=default is invalid in production; using 'shared'",
+                flush=True,
+            )
+            return "shared"
+        return configured
+    return "default" if env_name != "production" else "shared"
+
+
+def _bootstrap_extensions_dirs(home: Path, profile: str) -> None:
+    global_ext = home / "extensions"
+    global_ext.mkdir(parents=True, exist_ok=True)
+    try:
+        from core.profile.names import profile_dir_for_name
+
+        prof_ext = profile_dir_for_name(profile) / "extensions"
+        prof_ext.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        print(f"[holix] WARN: profile extensions dir: {exc}", flush=True)
+    files = Path(os.getenv("HOLIX_FILES_DIR") or "/data/files")
+    try:
+        files.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+
+
+def _enable_workspace_jail(manager: object, profile: str) -> None:
+    if not _truthy("HOLIX_WORKSPACE_JAIL", "true"):
+        return
+    try:
+        from core.profile.service import enable_profile_workspace_isolation
+
+        path = enable_profile_workspace_isolation(manager, profile)  # type: ignore[arg-type]
+        print(f"[holix] Workspace jail enabled: {path}", flush=True)
+    except Exception as exc:
+        print(f"[holix] WARN: workspace jail: {exc}", flush=True)
+
+
+def _bootstrap_max(profile: str) -> None:
+    token = (
+        os.getenv("MAX_ACCESS_TOKEN", "").strip()
+        or os.getenv("HOLIX_MAX_ACCESS_TOKEN", "").strip()
+    )
+    if not token:
+        return
+    try:
+        from core.env_loader import upsert_profile_env_var
+
+        upsert_profile_env_var(profile, "MAX_ACCESS_TOKEN", token)
+        upsert_profile_env_var(profile, "HOLIX_MAX_ACCESS_TOKEN", token)
+        print("[holix] MAX messenger token configured", flush=True)
+    except Exception as exc:
+        print(f"[holix] WARN: MAX bootstrap: {exc}", flush=True)
+
+
 def bootstrap() -> None:
     from cli.core import ProfileManager
-    from core.env_loader import bootstrap_profile_env, init_holix_home
+    from core.env_loader import bootstrap_profile_env, holix_home, init_holix_home
     from integrations.telegram.env_store import read_telegram_env_values, save_telegram_env
 
-    profile = (os.getenv("HOLIX_PROFILE") or "default").strip() or "default"
+    profile = _default_profile_name()
+    # Ensure process env matches resolved name (entrypoint / holix -p)
+    os.environ["HOLIX_PROFILE"] = profile
+
     init_holix_home()
+    home = Path(holix_home())
+    _bootstrap_extensions_dirs(home, profile)
+
     manager = ProfileManager()
     if not manager.profile_exists(profile):
         manager.create_profile(profile)
         print(f"[holix] Created profile '{profile}'", flush=True)
 
     bootstrap_profile_env(profile, force=True)
+    _enable_workspace_jail(manager, profile)
 
     profile_env: dict[str, str] = {
         "HOLIX_ENV": os.getenv("HOLIX_ENV", "production"),
@@ -42,14 +120,29 @@ def bootstrap() -> None:
         "HOLIX_API_KEY_PEPPER",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "MOONSHOT_API_KEY",
+        "XAI_API_KEY",
+        "GROQ_API_KEY",
+        "GOOGLE_API_KEY",
+        "MISTRAL_API_KEY",
         "LITELLM_API_BASE",
         "LITELLM_API_KEY",
         "OLLAMA_HOST",
+        "VLLM_HOST",
         "HOLIX_ENABLE_TERMINAL_TOOL",
         "HOLIX_ENABLE_CODE_EXECUTOR",
+        "HOLIX_TERMINAL_COMMAND_WHITELIST",
         "HOLIX_TELEGRAM_VOICE_ENABLED",
         "HOLIX_TELEGRAM_FILES_ENABLED",
         "ENABLE_BROWSER_TOOLS",
+        "BROWSER_HEADLESS",
+        "HOLIX_CORS_ORIGINS",
+        "HOLIX_UNLOCK_KEY",
+        "MAX_STEPS",
+        "HOLIX_ENABLE_META_AGENT",
+        "HOLIX_ENABLE_SELF_REFINEMENT",
+        "HOLIX_SUBAGENT_SUPERVISOR_ENABLED",
     ):
         val = os.getenv(key, "").strip()
         if val:
@@ -71,10 +164,31 @@ def bootstrap() -> None:
             tg_values["HOLIX_TELEGRAM_ALLOWED_USERS"] = allowed.replace(" ", "")
         elif existing.get("HOLIX_TELEGRAM_ALLOWED_USERS"):
             tg_values["HOLIX_TELEGRAM_ALLOWED_USERS"] = existing["HOLIX_TELEGRAM_ALLOWED_USERS"]
+
+        admin_id = os.getenv("HOLIX_TELEGRAM_ADMIN_USER_ID", "").strip()
+        if admin_id:
+            tg_values["HOLIX_TELEGRAM_ADMIN_USER_ID"] = admin_id
+        allow_all = os.getenv("HOLIX_TELEGRAM_ALLOW_ALL", "").strip()
+        if allow_all:
+            tg_values["HOLIX_TELEGRAM_ALLOW_ALL"] = allow_all
+
         path = save_telegram_env(tg_values, profile=profile)
         print(f"[holix] Telegram configured: {path}", flush=True)
     else:
         print("[holix] TELEGRAM_BOT_TOKEN not set — Telegram bot disabled", flush=True)
+
+    _bootstrap_max(profile)
+
+    # Hint for multi-user
+    if _truthy("HOLIX_TELEGRAM_ACCESS_REQUESTS", "true") and token:
+        print(
+            "[holix] Multi-user: users send /start, then "
+            f"docker compose exec holix holix -p {profile} telegram requests approve USER_ID "
+            "--create-profile <name>",
+            flush=True,
+        )
+
+    print(f"[holix] Bootstrap complete (profile={profile}, home={home})", flush=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,0 +1,191 @@
+"""A2A protocol: models, card, server, client tools, config."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.a2a.card import build_agent_card
+from core.a2a.client import extract_task_text
+from core.a2a.config import load_a2a_config
+from core.a2a.models import A2AMessage, TaskState
+from core.a2a.server import cancel_task, get_task_public, handle_message_send
+from core.a2a.store import A2ATaskStore
+
+
+def test_message_parse_and_text() -> None:
+    msg = A2AMessage.parse(
+        {
+            "role": "user",
+            "parts": [{"kind": "text", "text": "hello"}],
+            "contextId": "ctx1",
+        }
+    )
+    assert msg.role == "user"
+    assert msg.text_content() == "hello"
+    assert msg.contextId == "ctx1"
+
+
+def test_load_a2a_config_from_raw() -> None:
+    cfg = load_a2a_config(
+        raw={
+            "a2a": {
+                "enabled": True,
+                "public_url": "https://x.example/a2a",
+                "remote_agents": [
+                    {"name": "r1", "url": "https://r1.example/a2a"},
+                ],
+            }
+        }
+    )
+    assert cfg.enabled is True
+    assert cfg.public_url == "https://x.example/a2a"
+    assert len(cfg.remote_agents) == 1
+    assert cfg.remote_agents[0].name == "r1"
+
+
+def test_build_agent_card_minimal() -> None:
+    card = build_agent_card(
+        "default",
+        public_url="https://gw.example/a2a",
+        config=load_a2a_config(raw={"enabled": True, "name": "TestAgent"}),
+    )
+    assert card["name"] == "TestAgent"
+    assert card["url"] == "https://gw.example/a2a"
+    assert card["protocolVersion"] == "0.3.0"
+    assert card["capabilities"]["streaming"] is True
+    assert isinstance(card["skills"], list) and card["skills"]
+
+
+@pytest.mark.asyncio
+async def test_handle_message_send_success() -> None:
+    store = A2ATaskStore()
+    agent = SimpleNamespace(
+        run=AsyncMock(return_value="pong from holix"),
+    )
+    result = await handle_message_send(
+        agent=agent,
+        message={
+            "role": "user",
+            "parts": [{"kind": "text", "text": "ping"}],
+            "contextId": "ctx-test",
+        },
+        profile="p1",
+        store=store,
+    )
+    assert result["contextId"] == "ctx-test"
+    assert result["status"]["state"] == TaskState.COMPLETED.value
+    assert extract_task_text(result) == "pong from holix"
+    agent.run.assert_awaited_once()
+    # conversation mapped
+    kwargs = agent.run.await_args.kwargs
+    assert kwargs["conversation_id"] == "a2a:ctx-test"
+    assert kwargs["user_input"] == "ping"
+
+    got = get_task_public(result["id"], store=store, profile="p1")
+    assert got is not None
+    assert got["id"] == result["id"]
+
+
+@pytest.mark.asyncio
+async def test_handle_message_send_failure() -> None:
+    store = A2ATaskStore()
+    agent = SimpleNamespace(run=AsyncMock(side_effect=RuntimeError("boom")))
+    result = await handle_message_send(
+        agent=agent,
+        message=A2AMessage.from_user_text("x"),
+        profile="p1",
+        store=store,
+    )
+    assert result["status"]["state"] == TaskState.FAILED.value
+    assert "boom" in extract_task_text(result)
+
+
+def test_cancel_task() -> None:
+    store = A2ATaskStore()
+    from core.a2a.models import A2ATask, A2ATaskStatus
+
+    task = A2ATask(
+        id="task_c1",
+        profile="p1",
+        status=A2ATaskStatus(state=TaskState.WORKING),
+    )
+    store.put(task)
+    out = cancel_task("task_c1", store=store, profile="p1")
+    assert out is not None
+    assert out["status"]["state"] == TaskState.CANCELED.value
+
+
+def test_extract_task_text_from_artifacts() -> None:
+    text = extract_task_text(
+        {
+            "status": {"state": "completed"},
+            "artifacts": [
+                {"parts": [{"kind": "text", "text": "artifact body"}]},
+            ],
+        }
+    )
+    assert text == "artifact body"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_stream_events() -> None:
+    from core.a2a.server import handle_message_stream
+    from core.agent_events import FinalResponseEvent, ThinkingEvent
+
+    store = A2ATaskStore()
+
+    async def _fake_run_holix(agent, user_input, conversation_id, *, stream=False, execution_mode=None):
+        yield ThinkingEvent(message="planning")
+        yield FinalResponseEvent(content="streamed answer")
+
+    agent = SimpleNamespace(
+        _initialized=True,
+        emit=lambda e: None,
+        run=AsyncMock(return_value="fallback"),
+    )
+
+    import core.a2a.server as server_mod
+
+    # Patch run_holix import path used inside handle_message_stream
+    import core.runtime.executor as executor_mod
+
+    original = executor_mod.run_holix
+    executor_mod.run_holix = _fake_run_holix  # type: ignore[assignment]
+    try:
+        events = []
+        async for item in handle_message_stream(
+            agent=agent,
+            message={"role": "user", "parts": [{"kind": "text", "text": "hi"}]},
+            profile="p1",
+            store=store,
+        ):
+            events.append(item)
+    finally:
+        executor_mod.run_holix = original
+
+    assert events, "expected stream events"
+    assert "task" in events[0]
+    assert events[0]["task"]["status"]["state"] in {"working", "submitted"}
+    # should include statusUpdate and/or artifactUpdate and final completed
+    kinds = set()
+    for e in events:
+        kinds.update(e.keys())
+    assert "statusUpdate" in kinds or "artifactUpdate" in kinds
+    finals = [
+        e
+        for e in events
+        if e.get("statusUpdate", {}).get("final")
+        or (
+            e.get("task", {}).get("status", {}).get("state")
+            in {"completed", "failed"}
+        )
+    ]
+    assert finals
+    # completed answer stored
+    last_task = get_task_public(events[0]["task"]["id"], store=store, profile="p1")
+    assert last_task is not None
+    assert last_task["status"]["state"] == "completed"
+    assert extract_task_text(last_task) == "streamed answer"

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-
 from core.a2a.card import build_agent_card
 from core.a2a.client import extract_task_text
 from core.a2a.config import load_a2a_config
@@ -147,7 +146,6 @@ async def test_handle_message_stream_events() -> None:
         run=AsyncMock(return_value="fallback"),
     )
 
-    import core.a2a.server as server_mod
 
     # Patch run_holix import path used inside handle_message_stream
     import core.runtime.executor as executor_mod

--- a/tests/test_background_process.py
+++ b/tests/test_background_process.py
@@ -414,3 +414,33 @@ def test_live_buffer_renders_background_process() -> None:
     buf.set_background_process(label="uvicorn :8000 · pid 1234", process_id="proc_abc")
     text = buf.render_plain()
     assert "🟢 Process: uvicorn :8000 · pid 1234" in text
+
+@pytest.mark.asyncio
+async def test_registry_persists_and_hydrates_across_instances(tmp_path, monkeypatch) -> None:
+    """Telegram and Studio are separate OS processes — disk index bridges them."""
+    monkeypatch.setenv("HOLIX_HOME", str(tmp_path))
+    (tmp_path / "profiles" / "p1" / "data").mkdir(parents=True)
+    ws = tmp_path / "profiles" / "p1" / "workspace"
+    ws.mkdir(parents=True)
+    popen = _mock_popen(424242)
+
+    reg_telegram = BackgroundProcessRegistry()
+    with (
+        patch("core.runtime.background_process.popen_background", return_value=popen),
+        patch("core.runtime.background_process.is_process_alive", return_value=True),
+        patch("core.runtime.port_utils.find_busy_ports", return_value=[]),
+        patch("core.runtime.port_utils.force_free_ports", return_value=[]),
+        patch("core.workspace.get_effective_workspace_root", return_value=ws),
+    ):
+        record = await reg_telegram.start(
+            command="npm run dev -- --host 0.0.0.0 --port 5173",
+            label="app_front",
+            conversation_id="tg-1",
+            profile="p1",
+        )
+        reg_studio = BackgroundProcessRegistry()
+        listed = reg_studio.list_for_profile(profile="p1")
+
+    assert any(r.process_id == record.process_id for r in listed)
+    assert listed[0].label == "app_front"
+    assert listed[0].command.startswith("npm run dev")

--- a/tests/test_browser_tools.py
+++ b/tests/test_browser_tools.py
@@ -258,7 +258,8 @@ async def test_browser_record_stop():
     finally:
         reset_conversation_scope(token)
 
-    assert result == "Video saved: /data/browser_videos/c1.webm"
+    assert result.startswith("Video saved: ")
+    assert Path(result.removeprefix("Video saved: ")) == Path("/data/browser_videos/c1.webm")
     mgr.return_value.stop_recording.assert_awaited_once_with("c1", keep_session=True)
 
 

--- a/tests/test_bundled_skills.py
+++ b/tests/test_bundled_skills.py
@@ -54,16 +54,20 @@ def test_bundled_holix_studio_frontend_backend_skill_exists():
     assert parsed is not None
     assert parsed["name"] == "holix-studio-frontend-backend"
     body = parsed["content"].lower()
-    assert "vite_api_url" in body
-    assert "localhost" in body
-    assert "preview_origins" in parsed["content"]
-    assert "resolve_preview_origin" in parsed["content"]
+    assert "0.0.0.0" in body or "0.0.0.0" in parsed["content"]
     assert "open_preview_url" in parsed["content"]
-    assert "hmr" in body
-    assert "clientPort" in parsed["content"]
+    assert "docker-compose" in body or "docker compose" in body
+    assert "nginx" in body
+    assert "preview" in body
+    # Platform / required flags
+    assert parsed.get("required") is True or parsed.get("platform") is True or "required" in (
+        parsed.get("tags") or []
+    )
 
 
 def test_seed_bundled_skills(tmp_path: Path):
+    from core.skills.bundled import required_bundled_skill_names
+
     dest = tmp_path / "skills"
     first = seed_bundled_skills(dest)
     assert "holix-cron" in first
@@ -75,8 +79,14 @@ def test_seed_bundled_skills(tmp_path: Path):
     assert (dest / "holix-sdd-apply.md").is_file()
     assert (dest / "holix-studio-frontend-backend.md").is_file()
 
+    # Non-required skills are not re-seeded; required platform skill is refreshed
+    fe = dest / "holix-studio-frontend-backend.md"
+    fe.write_text("stale", encoding="utf-8")
     second = seed_bundled_skills(dest)
-    assert second == []
+    assert "holix-cron" not in second
+    assert "holix-studio-frontend-backend" in second
+    assert "stale" not in fe.read_text(encoding="utf-8")
+    assert "holix-studio-frontend-backend" in required_bundled_skill_names()
 
     third = seed_bundled_skills(dest, overwrite=True)
     assert "holix-cron" in third

--- a/tests/test_context_session.py
+++ b/tests/test_context_session.py
@@ -43,7 +43,7 @@ def test_route_after_react_respects_max_steps_with_tools() -> None:
         max_steps=15,
         is_final=False,
     )
-    assert route_after_react(state) == "finalize"
+    assert route_after_react(state) == "reflect"
 
 
 def test_truncate_tool_content_for_memory() -> None:

--- a/tests/test_gateway_supervisor.py
+++ b/tests/test_gateway_supervisor.py
@@ -34,10 +34,19 @@ def test_telegram_enabled_with_token(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_telegram_should_start_requires_aiogram(monkeypatch: pytest.MonkeyPatch) -> None:
     _block_telegram_env_files(monkeypatch)
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.delenv("HOLIX_TELEGRAM_AUTOSTART", raising=False)
     if telegram_aiogram_available():
         assert telegram_should_start() is True
     else:
         assert telegram_should_start() is False
+
+
+def test_telegram_should_start_respects_autostart_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gateway-only Docker sets HOLIX_TELEGRAM_AUTOSTART=false."""
+    _block_telegram_env_files(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("HOLIX_TELEGRAM_AUTOSTART", "false")
+    assert telegram_should_start() is False
 
 
 def test_docs_should_start_when_site_configured(
@@ -90,6 +99,7 @@ def test_max_should_poll_in_development(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("HOLIX_MAX_ACCESS_TOKEN", "test-token")
     monkeypatch.setenv("HOLIX_MAX_MODE", "polling")
     monkeypatch.setenv("HOLIX_ENV", "development")
+    monkeypatch.delenv("HOLIX_MAX_AUTOSTART", raising=False)
     assert max_should_poll() is True
     assert max_should_webhook() is False
 
@@ -100,5 +110,14 @@ def test_max_allows_polling_in_production(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv("HOLIX_MAX_ACCESS_TOKEN", "test-token")
     monkeypatch.setenv("HOLIX_MAX_MODE", "polling")
     monkeypatch.setenv("HOLIX_ENV", "production")
+    monkeypatch.delenv("HOLIX_MAX_AUTOSTART", raising=False)
     assert max_should_webhook() is False
     assert max_should_poll() is True
+
+
+def test_max_should_poll_respects_autostart_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    _block_max_env_files(monkeypatch)
+    monkeypatch.setenv("HOLIX_MAX_ACCESS_TOKEN", "test-token")
+    monkeypatch.setenv("HOLIX_MAX_MODE", "polling")
+    monkeypatch.setenv("HOLIX_MAX_AUTOSTART", "false")
+    assert max_should_poll() is False

--- a/tests/test_graph_supervisor.py
+++ b/tests/test_graph_supervisor.py
@@ -1,0 +1,140 @@
+"""Tests for graph-native supervisor node and routing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from core.graph.nodes.supervisor_node import supervisor_node
+from core.graph.routers import route_after_supervisor
+
+
+def test_route_after_supervisor_rework() -> None:
+    assert (
+        route_after_supervisor(
+            {
+                "supervisor_needs_rework": True,
+                "supervisor_rework_tasks": [{"agent_type": "coder", "task": "x"}],
+            }
+        )
+        == "delegate_subagent"
+    )
+
+
+def test_route_after_supervisor_react() -> None:
+    assert (
+        route_after_supervisor(
+            {
+                "supervisor_needs_rework": False,
+                "supervisor_rework_tasks": [],
+                "subagent_awaiting_synthesis": True,
+            }
+        )
+        == "react"
+    )
+
+
+@pytest.mark.asyncio
+async def test_supervisor_node_schedules_rework_on_failures() -> None:
+    agent = MagicMock()
+    agent.config = SimpleNamespace(
+        subagent_supervisor_enabled=True,
+        subagent_supervisor_max_interventions=2,
+    )
+    agent.emit = MagicMock()
+
+    state = {
+        "subagent_awaiting_synthesis": True,
+        "current_subagent_wave": 1,  # collect already advanced past wave 0
+        "subagent_wave_results": {
+            "0": {
+                "coder-1": {
+                    "success": False,
+                    "response": "",
+                    "error": "Max steps (50) reached: hung",
+                },
+                "researcher-1": {
+                    "success": True,
+                    "response": "ok findings",
+                    "error": None,
+                },
+            }
+        },
+        "subagent_task_meta": {
+            "coder-1": {
+                "agent_type": "coder",
+                "task": "Implement auth",
+                "step_ref": 1,
+                "step_index": 0,
+            },
+            "researcher-1": {
+                "agent_type": "researcher",
+                "task": "Research OAuth",
+                "step_ref": 1,
+                "step_index": 0,
+            },
+        },
+        "messages": [],
+        "supervisor_rework_round": 0,
+        "conversation_id": "t1",
+    }
+    config = {"configurable": {"_agent": agent}}
+
+    out = await supervisor_node(state, config)  # type: ignore[arg-type]
+    assert out["supervisor_needs_rework"] is True
+    assert len(out["supervisor_rework_tasks"]) == 1
+    task = out["supervisor_rework_tasks"][0]
+    assert task["agent_type"] == "coder"
+    assert task["prior_job"] == "coder-1"
+    assert "Supervisor rework" in task["task"]
+    assert out["subagent_awaiting_synthesis"] is False
+    assert out["supervisor_rework_round"] == 1
+
+
+@pytest.mark.asyncio
+async def test_supervisor_node_ok_when_all_success() -> None:
+    agent = MagicMock()
+    agent.config = SimpleNamespace(subagent_supervisor_enabled=True)
+    state = {
+        "subagent_awaiting_synthesis": True,
+        "current_subagent_wave": 1,
+        "subagent_wave_results": {
+            "0": {"coder-1": {"success": True, "response": "done", "error": None}}
+        },
+        "subagent_task_meta": {
+            "coder-1": {"agent_type": "coder", "task": "x", "step_ref": 1, "step_index": 0}
+        },
+        "messages": [],
+        "supervisor_rework_round": 0,
+    }
+    out = await supervisor_node(state, {"configurable": {"_agent": agent}})  # type: ignore[arg-type]
+    assert out["supervisor_needs_rework"] is False
+    assert out["supervisor_rework_tasks"] == []
+
+
+@pytest.mark.asyncio
+async def test_supervisor_node_exhausted_rework() -> None:
+    agent = MagicMock()
+    agent.config = SimpleNamespace(
+        subagent_supervisor_enabled=True,
+        subagent_supervisor_max_interventions=1,
+    )
+    agent.emit = MagicMock()
+    state = {
+        "subagent_awaiting_synthesis": True,
+        "current_subagent_wave": 1,
+        "subagent_wave_results": {
+            "0": {"coder-1": {"success": False, "response": "", "error": "timeout"}}
+        },
+        "subagent_task_meta": {
+            "coder-1": {"agent_type": "coder", "task": "x", "step_ref": 1, "step_index": 0}
+        },
+        "messages": [],
+        "supervisor_rework_round": 1,  # already used max
+        "conversation_id": "t1",
+    }
+    out = await supervisor_node(state, {"configurable": {"_agent": agent}})  # type: ignore[arg-type]
+    assert out["supervisor_needs_rework"] is False
+    assert out["supervisor_last_diagnosis"]["kind"] == "exhausted"
+    assert any("Supervisor" in m.get("content", "") for m in out.get("messages") or [])

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -26,11 +26,12 @@ class _FakeHost:
         self.profile = profile
 
 
-def test_default_locale_is_en(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_locale_is_ru(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Product default UI locale is Russian (Russia-first SaaS)."""
     _patch_holix_home(tmp_path, monkeypatch)
-    store = LocaleStore("default_en")
-    assert store.get() == "en"
-    assert t("cleared", store.get()) == "Chat cleared"
+    store = LocaleStore("default_ru_check")
+    assert store.get() == "ru"
+    assert t("cleared", store.get()) == "Чат очищен"
 
 
 def test_set_locale_ru(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -56,6 +57,8 @@ def test_set_locale_rejects_unknown(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 def test_host_locale_helpers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_holix_home(tmp_path, monkeypatch)
     host = _FakeHost("host_helpers")
+    assert host_locale(host) == "ru"
+    assert set_host_locale(host, "en") == "en"
     assert host_locale(host) == "en"
     assert set_host_locale(host, "ru") == "ru"
     assert host_locale(host) == "ru"

--- a/tests/test_model_discovery_context.py
+++ b/tests/test_model_discovery_context.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from core.models.discovery import ModelDiscovery, extract_context_length
 
 

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -411,6 +411,7 @@ class TestBuildPlanMarkdown:
             ],
             step_count=1,
             user_input="Build a REST API",
+            locale="en",
         )
         assert "Execution Plan" in md
         assert "Build a REST API" in md
@@ -427,6 +428,7 @@ class TestBuildPlanMarkdown:
                        "clarifying_questions": ["Which framework?"], "constraints": ["Python only"]},
             architecture={"approach": "FastAPI", "tech_stack": ["Python", "FastAPI"],
                          "structure": "api/", "risks": [{"risk": "Migration issues", "mitigation": "Use Alembic"}]},
+            locale="en",
         )
         assert "📊 Analysis" in md
         assert "Complex" in md
@@ -455,6 +457,7 @@ class TestBuildPlanMarkdown:
         md = build_plan_markdown(
             plan_steps=[{"step": 1, "description": "Simple task"}],
             step_count=1,
+            locale="en",
         )
         assert "📊 Analysis" not in md
         assert "Step 1" in md

--- a/tests/test_project_init.py
+++ b/tests/test_project_init.py
@@ -86,8 +86,12 @@ async def test_run_project_init_warns_when_agent_busy() -> None:
 
 @pytest.mark.asyncio
 async def test_run_project_init_starts_agent_on_telegram(tmp_path, monkeypatch) -> None:
+    from core.i18n.locale import LocaleStore
+
     monkeypatch.chdir(tmp_path)
     (tmp_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+    # Pin English so assertions stay locale-stable regardless of product default.
+    LocaleStore("default").set("en")
     session = ChatSession(chat_id=1, user_id=1, profile="default", conversation_id="tg")
     host = MagicMock()
     host.profile = "default"

--- a/tests/test_reflexion.py
+++ b/tests/test_reflexion.py
@@ -1,0 +1,177 @@
+"""Tests for Reflexion routing and reflect_node behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from core.graph.routers import route_after_react, route_after_react_plan, route_after_reflect
+from core.meta_agent import QualityAssessment
+
+
+def test_route_after_react_goes_to_reflect_on_final() -> None:
+    assert (
+        route_after_react(
+            {
+                "is_final": True,
+                "tool_calls": [],
+                "step_count": 3,
+                "max_steps": 90,
+            }
+        )
+        == "reflect"
+    )
+
+
+def test_route_after_react_tools_still_preferred() -> None:
+    assert (
+        route_after_react(
+            {
+                "is_final": False,
+                "tool_calls": [{"id": "1"}],
+                "step_count": 3,
+                "max_steps": 90,
+            }
+        )
+        == "tool_execution"
+    )
+
+
+def test_route_after_reflect_retry() -> None:
+    assert (
+        route_after_reflect(
+            {
+                "needs_refinement": True,
+                "step_count": 5,
+                "max_steps": 90,
+            }
+        )
+        == "react"
+    )
+
+
+def test_route_after_reflect_finalize() -> None:
+    assert route_after_reflect({"needs_refinement": False}) == "finalize"
+
+
+def test_route_after_react_plan_final_to_reflect() -> None:
+    assert (
+        route_after_react_plan(
+            {
+                "is_final": True,
+                "tool_calls": [],
+                "step_count": 10,
+                "max_steps": 90,
+                "plan_steps": [{"description": "x"}],
+                "current_plan_step": 0,
+            }
+        )
+        == "reflect"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reflect_node_accepts_high_quality() -> None:
+    from core.graph.nodes.reflect_node import reflect_node
+
+    agent = MagicMock()
+    agent.config = SimpleNamespace(
+        enable_self_refinement=True,
+        max_refinement_iterations=2,
+        refinement_quality_threshold=0.7,
+    )
+    agent.client = MagicMock()
+    agent.model = "test-model"
+    agent.emit = MagicMock()
+    agent.memory = MagicMock()
+    agent.memory.episodic = MagicMock()
+    agent.memory.episodic.store_episode = AsyncMock()
+
+    assessment = QualityAssessment(
+        quality_score=0.92,
+        needs_refinement=False,
+        improvement_areas=[],
+        refinement_prompt="",
+        reasoning="good",
+    )
+
+    with patch("core.graph.nodes.reflect_node.MetaAgent") as Meta:
+        Meta.return_value.evaluate_response = AsyncMock(return_value=assessment)
+        out = await reflect_node(
+            {
+                "final_response": "Here is a complete working solution.",
+                "user_input": "Build auth",
+                "messages": [],
+                "reflection_count": 0,
+                "max_refinement_iterations": 2,
+                "conversation_id": "c1",
+            },
+            {"configurable": {"_agent": agent}},  # type: ignore[arg-type]
+        )
+
+    assert out["needs_refinement"] is False
+    assert out.get("is_final") is not False or "is_final" not in out
+
+
+@pytest.mark.asyncio
+async def test_reflect_node_retries_on_low_quality() -> None:
+    from core.graph.nodes.reflect_node import reflect_node
+
+    agent = MagicMock()
+    agent.config = SimpleNamespace(
+        enable_self_refinement=True,
+        max_refinement_iterations=2,
+        refinement_quality_threshold=0.7,
+    )
+    agent.client = MagicMock()
+    agent.model = "test-model"
+    agent.emit = MagicMock()
+    agent.memory = MagicMock()
+    agent.memory.episodic = MagicMock()
+    agent.memory.episodic.store_episode = AsyncMock()
+    agent.memory.strategic = MagicMock()
+    agent.memory.strategic.store_strategy = AsyncMock()
+
+    assessment = QualityAssessment(
+        quality_score=0.4,
+        needs_refinement=True,
+        improvement_areas=["completeness"],
+        refinement_prompt="Add the missing implementation details",
+        reasoning="too vague",
+    )
+
+    with patch("core.graph.nodes.reflect_node.MetaAgent") as Meta:
+        Meta.return_value.evaluate_response = AsyncMock(return_value=assessment)
+        out = await reflect_node(
+            {
+                "final_response": "Done.",
+                "user_input": "Build auth",
+                "messages": [],
+                "reflection_count": 0,
+                "max_refinement_iterations": 2,
+                "conversation_id": "c1",
+            },
+            {"configurable": {"_agent": agent}},  # type: ignore[arg-type]
+        )
+
+    assert out["needs_refinement"] is True
+    assert out["is_final"] is False
+    assert out["final_response"] == ""
+    assert out["reflection_count"] == 1
+    msgs = out["messages"]
+    assert any("Reflexion" in str(m.get("content", "")) for m in msgs)
+    agent.memory.episodic.store_episode.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reflect_disabled() -> None:
+    from core.graph.nodes.reflect_node import reflect_node
+
+    agent = MagicMock()
+    agent.config = SimpleNamespace(enable_self_refinement=False)
+    out = await reflect_node(
+        {"final_response": "x", "user_input": "y"},
+        {"configurable": {"_agent": agent}},  # type: ignore[arg-type]
+    )
+    assert out["needs_refinement"] is False

--- a/tests/test_sdd.py
+++ b/tests/test_sdd.py
@@ -147,6 +147,114 @@ The system SHALL support password and OAuth login.
     assert out.count("### Requirement:") == 2
 
 
+def test_merge_document_order_removed_wins_after_modified():
+    main = "# D\n\n### Requirement: Foo\nOld\n"
+    delta = """## MODIFIED Requirements
+
+### Requirement: Foo
+New body
+
+## REMOVED Requirements
+
+### Requirement: Foo
+"""
+    out = merge_delta_into_main(main, delta)
+    assert "Foo" not in out
+    assert "New body" not in out
+
+
+def test_merge_collapses_duplicate_titles_in_main():
+    main = """# D
+
+### Requirement: Dup
+First
+
+### Requirement: Dup
+Second
+"""
+    delta = """## MODIFIED Requirements
+
+### Requirement: Dup
+Third
+"""
+    out = merge_delta_into_main(main, delta)
+    assert out.count("### Requirement:") == 1
+    assert "Third" in out
+    assert "First" not in out
+
+
+def test_archive_nested_spec_merges_into_parent_domain(tmp_path: Path):
+    store = SpecStore(tmp_path)
+    store.init(example_domain="auth")
+    store.create_change("nested-merge", domain="auth")
+    store.write_artifact(
+        "nested-merge",
+        "proposal",
+        "# Proposal\n\n## Why\nNeed nested layout fix.\n\n## What\nMerge correctly.\n\n## Impact\nSpecs.\n",
+    )
+    store.write_artifact(
+        "nested-merge",
+        "specs",
+        "## ADDED Requirements\n\n### Requirement: Top level\nBody top.\n\n#### Scenario: S\n- **GIVEN** a\n- **WHEN** b\n- **THEN** c\n",
+        domain="auth",
+    )
+    nested = (
+        tmp_path
+        / "openspec"
+        / "changes"
+        / "nested-merge"
+        / "specs"
+        / "auth"
+        / "notes"
+        / "spec.md"
+    )
+    nested.parent.mkdir(parents=True, exist_ok=True)
+    nested.write_text(
+        "## ADDED Requirements\n\n### Requirement: Nested note\nBody nested.\n\n"
+        "#### Scenario: S\n- **GIVEN** a\n- **WHEN** b\n- **THEN** c\n",
+        encoding="utf-8",
+    )
+    store.write_artifact(
+        "nested-merge",
+        "tasks",
+        "# Tasks\n\n- [x] 1.1 Done\n  - **assignee:** `main`\n  - **reason:** ok\n",
+    )
+    archived = store.archive("nested-merge")
+    assert archived["ok"] is True
+    # Must NOT create openspec/specs/notes/
+    assert not (tmp_path / "openspec" / "specs" / "notes").exists()
+    main = (tmp_path / "openspec" / "specs" / "auth" / "spec.md").read_text(encoding="utf-8")
+    assert "Top level" in main
+    assert "Nested note" in main
+    assert archived["merged_specs"] == ["openspec/specs/auth/spec.md"]
+
+
+def test_archive_warns_on_open_tasks(tmp_path: Path):
+    store = SpecStore(tmp_path)
+    store.init(example_domain="auth")
+    store.create_change("open-tasks", domain="auth")
+    store.write_artifact(
+        "open-tasks",
+        "proposal",
+        "# Proposal\n\n## Why\nWhy enough for propose.\n\n## What\nWhat.\n\n## Impact\nImpact.\n",
+    )
+    store.write_artifact(
+        "open-tasks",
+        "specs",
+        "## ADDED Requirements\n\n### Requirement: Open\nBody.\n\n#### Scenario: S\n- **GIVEN** a\n- **WHEN** b\n- **THEN** c\n",
+        domain="auth",
+    )
+    store.write_artifact(
+        "open-tasks",
+        "tasks",
+        "# Tasks\n\n- [ ] 1.1 Still open\n  - **assignee:** `main`\n  - **reason:** work\n",
+    )
+    archived = store.archive("open-tasks")
+    assert archived["ok"] is True
+    assert archived.get("warnings")
+    assert any("open task" in w.lower() for w in archived["warnings"])
+
+
 def test_store_lifecycle(tmp_path: Path):
     store = SpecStore(tmp_path)
     init = store.init(example_domain="auth")

--- a/tests/test_step_budget.py
+++ b/tests/test_step_budget.py
@@ -1,0 +1,154 @@
+"""Tests for step-budget health check and auto-extension."""
+
+from __future__ import annotations
+
+from core.runtime.step_budget import (
+    StepBudgetPolicy,
+    evaluate_step_budget,
+    maybe_extend_for_graph_result,
+)
+
+
+def test_not_at_limit_no_extend() -> None:
+    d = evaluate_step_budget(step_count=10, max_steps=90)
+    assert not d.extend
+    assert d.status == "not_at_limit"
+
+
+def test_extend_when_pending_tools_and_progress() -> None:
+    messages = [
+        {"role": "user", "content": "Implement auth module"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": '{"path":"auth.py"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "1",
+            "content": "OK: wrote auth.py successfully with login handlers",
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "2",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"auth.py"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "2",
+            "content": "def login(): ... found existing helpers",
+        },
+    ]
+    d = evaluate_step_budget(
+        step_count=90,
+        max_steps=90,
+        pending_tool_calls=[{"id": "3", "function": {"name": "run_terminal_command"}}],
+        messages=messages,
+        task="Implement auth module",
+        policy=StepBudgetPolicy(extend_by=30, max_extensions=3),
+        base_max_steps=90,
+    )
+    assert d.extend
+    assert d.status == "working"
+    assert d.new_max_steps == 120
+    assert d.extensions_used == 1
+
+
+def test_hung_on_identical_tool_loop() -> None:
+    log = [
+        {"name": "run_terminal_command", "arguments": "ls", "result": "Error: fail"},
+        {"name": "run_terminal_command", "arguments": "ls", "result": "Error: fail"},
+        {"name": "run_terminal_command", "arguments": "ls", "result": "Error: fail"},
+    ]
+    d = evaluate_step_budget(
+        step_count=50,
+        max_steps=50,
+        pending_tool_calls=[{"id": "x"}],
+        tool_calls_log=log,
+        task="list files",
+        policy=StepBudgetPolicy(),
+    )
+    assert not d.extend
+    assert d.status == "hung"
+    assert "loop" in d.reason.lower()
+
+
+def test_extension_cap() -> None:
+    d = evaluate_step_budget(
+        step_count=150,
+        max_steps=150,
+        extensions_used=3,
+        pending_tool_calls=[{"id": "1"}],
+        tool_calls_log=[
+            {"name": "write_file", "arguments": "a", "result": "OK written successfully"},
+            {"name": "read_file", "arguments": "b", "result": "content found here"},
+        ],
+        task="write code",
+        policy=StepBudgetPolicy(max_extensions=3),
+        base_max_steps=90,
+    )
+    assert not d.extend
+    assert "extension limit" in d.reason
+
+
+def test_graph_result_extends_max_steps() -> None:
+    state = {
+        "user_input": "Build a REST API",
+        "max_steps": 15,
+        "base_max_steps": 15,
+        "step_budget_extensions": 0,
+        "conversation_id": "t1",
+        "messages": [
+            {"role": "user", "content": "Build a REST API"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "1",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": '{"path":"api.py"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "1",
+                "content": "OK: created api.py with endpoints successfully",
+            },
+        ],
+    }
+    result = {
+        "step_count": 15,
+        "tool_calls": [{"id": "2", "function": {"name": "read_file"}}],
+        "is_final": False,
+        "messages": state["messages"],
+    }
+    out = maybe_extend_for_graph_result(state, result, agent=None, task="Build a REST API")
+    assert out["max_steps"] > 15
+    assert out["step_budget_extensions"] == 1
+
+
+def test_graph_result_no_extend_when_final() -> None:
+    state = {"max_steps": 15, "user_input": "hi"}
+    result = {"step_count": 15, "is_final": True, "tool_calls": []}
+    out = maybe_extend_for_graph_result(state, result, agent=None)
+    assert out is result or out.get("max_steps") is None or "max_steps" not in out or out.get("step_count") == 15
+    assert out.get("max_steps", 15) == 15 or "step_budget_extensions" not in out

--- a/tests/test_step_orchestrate.py
+++ b/tests/test_step_orchestrate.py
@@ -129,9 +129,9 @@ class TestRouteAfterReactPlan:
             plan_steps=[{"step": 1, "description": "Step 1"}],
             current_plan_step=0,
         )
-        assert route_after_react_plan(state) == "finalize"
+        assert route_after_react_plan(state) == "reflect"
 
-    def test_is_final_routes_to_finalize(self):
+    def test_is_final_routes_to_reflect(self):
         from core.graph.nodes.step_orchestrate_node import route_after_react_plan
 
         state = HolixGraphState(
@@ -141,7 +141,7 @@ class TestRouteAfterReactPlan:
             step_count=5,
             max_steps=15,
         )
-        assert route_after_react_plan(state) == "finalize"
+        assert route_after_react_plan(state) == "reflect"
 
     def test_step_complete_routes_to_orchestrate(self):
         from core.graph.nodes.step_orchestrate_node import route_after_react_plan
@@ -548,7 +548,7 @@ class TestPerStepLimitEnforcement:
         assert result == "react"
 
     def test_no_plan_uses_global_limit(self):
-        """Without plan steps, use global max_steps for finalize."""
+        """Without plan steps, use global max_steps → Reflexion then finalize."""
         from core.graph.nodes.step_orchestrate_node import route_after_react_plan
 
         state = HolixGraphState(
@@ -562,4 +562,4 @@ class TestPerStepLimitEnforcement:
             current_step_start_count=0,
         )
         result = route_after_react_plan(state)
-        assert result == "finalize"
+        assert result == "reflect"

--- a/tests/test_subagent_supervisor.py
+++ b/tests/test_subagent_supervisor.py
@@ -1,0 +1,180 @@
+"""Tests for runtime Subagent Supervisor (detect + guidance)."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from core.subagents.base import SubAgentConfig, SubAgentHandle, SubAgentStatus
+from core.subagents.supervisor import (
+    SubagentSupervisor,
+    SupervisorPolicy,
+    assess_handle,
+    format_guidance_system_message,
+)
+
+
+def _running_handle(name: str = "coder-1") -> SubAgentHandle:
+    h = SubAgentHandle(
+        name=name,
+        config=SubAgentConfig(name=name, max_steps=50),
+        status=SubAgentStatus.RUNNING,
+        started_at=time.monotonic(),
+        max_steps=50,
+    )
+    h.touch_activity()
+    return h
+
+
+def test_assess_ok_when_fresh_activity() -> None:
+    h = _running_handle()
+    h.record_activity("tool_start", "Calling read_file", tool_name="read_file", details="a.py")
+    h.record_activity(
+        "tool_result",
+        "read_file finished",
+        tool_name="read_file",
+        details="OK: file contents successfully loaded here for analysis",
+    )
+    d = assess_handle(h, policy=SupervisorPolicy(idle_s=90, min_steps_before_stall=10))
+    assert d.kind == "ok"
+    assert not d.needs_intervention
+
+
+def test_assess_loop() -> None:
+    h = _running_handle()
+    for _ in range(3):
+        h.record_activity(
+            "tool_start",
+            "Calling read_file",
+            tool_name="read_file",
+            details='{"path":"same.py"}',
+        )
+        h.record_activity(
+            "tool_result",
+            "read_file finished",
+            tool_name="read_file",
+            details="same content again",
+        )
+    d = assess_handle(h)
+    assert d.kind == "loop"
+    assert d.needs_intervention
+    assert "GUIDANCE" in d.guidance
+
+
+def test_assess_thrash() -> None:
+    h = _running_handle()
+    for i, tool in enumerate(["run_terminal_command", "read_file", "write_file"]):
+        h.record_activity("tool_start", f"Calling {tool}", tool_name=tool, details=f"args{i}")
+        h.record_activity(
+            "tool_result",
+            f"{tool} finished",
+            tool_name=tool,
+            details=f"Error: permission denied attempt {i}",
+        )
+    d = assess_handle(h)
+    assert d.kind == "thrash"
+    assert "failed" in d.guidance.lower() or "error" in d.guidance.lower()
+
+
+def test_assess_hung() -> None:
+    h = _running_handle()
+    h.last_activity_at = time.monotonic() - 200
+    d = assess_handle(h, policy=SupervisorPolicy(idle_s=90))
+    assert d.kind == "hung"
+
+
+def test_assess_not_running() -> None:
+    h = _running_handle()
+    h.status = SubAgentStatus.COMPLETED
+    d = assess_handle(h)
+    assert d.kind == "ok"
+    assert not d.needs_intervention
+
+
+def test_format_guidance_system_message() -> None:
+    text = format_guidance_system_message(["Do not loop on read_file"])
+    assert "supervisor" in text.lower()
+    assert "Do not loop" in text
+
+
+@pytest.mark.asyncio
+async def test_supervisor_sends_guidance_with_cap() -> None:
+    h = _running_handle("loop-job")
+    for _ in range(3):
+        h.record_activity(
+            "tool_start",
+            "Calling read_file",
+            tool_name="read_file",
+            details="same",
+        )
+        h.record_activity(
+            "tool_result",
+            "done",
+            tool_name="read_file",
+            details="same",
+        )
+
+    async_bus = MagicMock()
+    async_bus.send = AsyncMock()
+    comm = SimpleNamespace(async_bus=async_bus, process_bus=MagicMock())
+
+    manager = MagicMock()
+    manager._handles = {"loop-job": h}
+    manager._comm_bus = comm
+    manager._emit_agent_event = MagicMock()
+    manager.notify_progress = MagicMock()
+
+    policy = SupervisorPolicy(
+        enabled=True,
+        poll_s=1.0,
+        idle_s=90.0,
+        max_interventions=2,
+        cooldown_s=0.0,
+    )
+    sup = SubagentSupervisor(manager, policy=policy)
+
+    await sup._maybe_intervene(h)
+    assert async_bus.send.await_count == 1
+    assert sup._interventions["loop-job"] == 1
+
+    await sup._maybe_intervene(h)
+    assert async_bus.send.await_count == 2
+    assert sup._interventions["loop-job"] == 2
+
+    # Cap reached — no more sends
+    await sup._maybe_intervene(h)
+    assert async_bus.send.await_count == 2
+
+    # Exhausted event emitted
+    assert manager._emit_agent_event.call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_supervisor_respects_cooldown() -> None:
+    h = _running_handle("cd-job")
+    for _ in range(3):
+        h.record_activity(
+            "tool_start",
+            "Calling x",
+            tool_name="read_file",
+            details="z",
+        )
+        h.record_activity("tool_result", "r", tool_name="read_file", details="z")
+
+    async_bus = MagicMock()
+    async_bus.send = AsyncMock()
+    manager = MagicMock()
+    manager._handles = {"cd-job": h}
+    manager._comm_bus = SimpleNamespace(async_bus=async_bus, process_bus=MagicMock())
+    manager._emit_agent_event = MagicMock()
+    manager.notify_progress = MagicMock()
+
+    sup = SubagentSupervisor(
+        manager,
+        policy=SupervisorPolicy(max_interventions=5, cooldown_s=60.0),
+    )
+    await sup._maybe_intervene(h)
+    await sup._maybe_intervene(h)
+    assert async_bus.send.await_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1041,7 +1041,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release **1.0.2** with runtime orchestration upgrades and production Docker.

- **Step budget extension** — health-check may grant more steps when still progressing (`HOLIX_MAX_STEPS_EXTEND_*`)
- **Subagent supervisor** — mid-run guidance (async/process) + graph rework after `collect` in plan mode
- **Reflexion** — meta score + `reflect` retry on react/hybrid/plan graphs
- **A2A** — Agent Card, JSON-RPC/REST/SSE server + client tools
- **Docker** — full agent / gateway-only / Ollama profiles, prod overlay, drop-in + pip extensions, multi-user storage mounts
- Docs EN/RU + CHANGELOG

## Test plan

- [x] Local: supervisor / reflexion / gateway companion unit tests
- [ ] GitHub CI on this PR (ruff, pytest matrix, doctor, build)
- [ ] After merge: tag `v1.0.2` → GitHub Release + PyPI publish

## Notes

Supersedes the narrower step-budget work on #45 (same commits plus full 1.0.2 scope).