### PR TITLE
fix(runtime): per-tab stop + plan/router LLM metering

### DIFF
--- a/cli/shared/agent_stop.py
+++ b/cli/shared/agent_stop.py
@@ -61,6 +61,36 @@ def reject_all_pending_plan_reviews(*, feedback: str = "stopped by user") -> int
     return resolved
 
 
+def reject_pending_plan_reviews_for_conversation(
+    conversation_id: str | None,
+    *,
+    feedback: str = "stopped by user",
+) -> int:
+    """Reject plan reviews for one conversation tab only (parallel tabs keep theirs)."""
+    from core.plan_review.review_guard import (
+        PlanReviewChoice,
+        get_plan_review_guard,
+        reject_global_pending_reviews_for_conversation,
+    )
+
+    cid = (conversation_id or "").strip()
+    if not cid:
+        return reject_all_pending_plan_reviews(feedback=feedback)
+
+    resolved = reject_global_pending_reviews_for_conversation(cid, feedback=feedback)
+    guard = get_plan_review_guard()
+    if guard is None:
+        return resolved
+    pending = getattr(guard, "_pending_reviews", None) or {}
+    suffix = f"_{cid}"
+    for review_id in list(pending.keys()):
+        rid = str(review_id or "")
+        if rid == cid or rid.endswith(suffix) or f"_{cid}_" in rid:
+            if guard.resolve_review(review_id, PlanReviewChoice.REJECT, feedback):
+                resolved += 1
+    return resolved
+
+
 def dismiss_host_modals(host: Any) -> None:
     """Close TUI confirmation / plan-review waits."""
     from core.security.confirmation import ConfirmationChoice

--- a/core/agent_events.py
+++ b/core/agent_events.py
@@ -281,6 +281,16 @@ class LLMCallStartedEvent(AgentEvent):
     model: str = ""
     step: int = 0
 
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.LLM_CALL_STARTED)
+
+    def _extra_fields(self) -> dict[str, Any]:
+        return {
+            "model": self.model,
+            "step": self.step,
+        }
+
 
 @dataclass
 class LLMCallCompletedEvent(AgentEvent):

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -144,10 +144,12 @@ async def run_graph_loop(
     if resume_plan:
         execution_mode = "plan_and_execute"
     elif execution_mode == "auto":
-        mode_router = ModeRouter(client=agent.client)
+        mode_router = ModeRouter(client=agent.client, model=getattr(agent, "model", "") or "")
         selected_by_auto = await mode_router.select_mode(
             user_input,
             context={"relevant_strategies": [], "relevant_memories": []},
+            agent=agent,
+            conversation_id=conversation_id,
         )
         execution_mode = selected_by_auto or "react"
 

--- a/core/graph/modes/router.py
+++ b/core/graph/modes/router.py
@@ -65,12 +65,17 @@ class ModeRouter:
         self,
         user_input: str,
         context: dict[str, Any] | None = None,
+        *,
+        agent: Any | None = None,
+        conversation_id: str = "",
     ) -> str:
         """Select the best execution mode for a task.
 
         Args:
             user_input: The user's task/query.
             context: Optional context (conversation history, skills, etc.).
+            agent: Optional HolixAgent — when set, router LLM usage is metered.
+            conversation_id: Correlation id for usage events.
 
         Returns:
             One of "react", "plan_and_execute", or "hybrid".
@@ -99,19 +104,56 @@ class ModeRouter:
                         logger.info("Strategic memory suggests hybrid mode")
                         return "hybrid"
 
+        messages = [
+            {
+                "role": "system",
+                "content": "You classify tasks into execution modes. Respond with ONLY the mode name.",
+            },
+            {"role": "user", "content": prompt},
+        ]
         try:
+            import time
+
+            t0 = time.perf_counter()
             response = await self._client.chat.completions.create(
                 model=self._model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": "You classify tasks into execution modes. Respond with ONLY the mode name.",
-                    },
-                    {"role": "user", "content": prompt},
-                ],
+                messages=messages,
                 temperature=0.0,  # Deterministic classification
                 max_tokens=10,    # Very short response
             )
+            duration_ms = (time.perf_counter() - t0) * 1000.0
+
+            # Meter auto-mode classification like every other model request.
+            if agent is not None:
+                try:
+                    from core.llm.usage import (
+                        completion_text_from_message,
+                        emit_llm_call_usage,
+                        resolve_usage,
+                        usage_dict_from_response,
+                    )
+
+                    provider_usage = usage_dict_from_response(response)
+                    usage = resolve_usage(
+                        response,
+                        messages=messages,
+                        completion_text=completion_text_from_message(
+                            response.choices[0].message
+                        ),
+                        model=self._model,
+                    )
+                    emit_llm_call_usage(
+                        agent,
+                        model=self._model,
+                        step=0,
+                        conversation_id=conversation_id or "",
+                        usage=usage,
+                        duration_ms=duration_ms,
+                        finish_reason="mode_router",
+                        estimated=provider_usage is None,
+                    )
+                except Exception:
+                    logger.debug("Mode router token accounting failed", exc_info=True)
 
             mode_text = response.choices[0].message.content or ""
             mode = mode_text.strip().lower()

--- a/core/graph/nodes/execute_step_node.py
+++ b/core/graph/nodes/execute_step_node.py
@@ -111,12 +111,16 @@ async def execute_step_node(state: HolixGraphState, config: RunnableConfig) -> d
                 {"role": "system", "content": _step_system_prompt(profile_name)},
                 {"role": "user", "content": step_prompt},
             ]
+            import time as _time
+
+            t0 = _time.perf_counter()
             response = await client.chat.completions.create(
                 model=model,
                 messages=step_messages,
                 temperature=temperature,
                 max_tokens=2000,
             )
+            duration_ms = (_time.perf_counter() - t0) * 1000.0
 
             step_response = response.choices[0].message.content or ""
             try:
@@ -142,10 +146,11 @@ async def execute_step_node(state: HolixGraphState, config: RunnableConfig) -> d
                     step=step_num,
                     conversation_id=conversation_id,
                     usage=usage,
+                    duration_ms=duration_ms,
                     estimated=provider_usage is None,
                 )
             except Exception:
-                logger.debug("Execute-step token accounting failed", exc_info=True)
+                logger.warning("Execute-step token accounting failed", exc_info=True)
         except Exception as e:
             logger.warning(f"LLM call failed in execute_step: {e}")
             step_response = f"Error executing step {step_num}: {str(e)}"

--- a/core/graph/nodes/plan_node.py
+++ b/core/graph/nodes/plan_node.py
@@ -559,6 +559,75 @@ async def plan_node(state: HolixGraphState, config: RunnableConfig) -> dict:
     use_json_mode = True
     attempt_timeout = plan_timeout
 
+    def _account_plan_llm(
+        response: object,
+        *,
+        step: int,
+        duration_ms: float | None = None,
+        finish_reason: str | None = None,
+    ) -> None:
+        """Record tokens + model call for Studio/Grafana (plan bypasses LLM middleware)."""
+        try:
+            from core.llm.usage import (
+                completion_text_from_message,
+                emit_llm_call_usage,
+                resolve_usage,
+                usage_dict_from_response,
+            )
+
+            message = None
+            try:
+                message = response.choices[0].message  # type: ignore[attr-defined]
+            except Exception:
+                message = None
+            provider_usage = usage_dict_from_response(response)
+            usage = resolve_usage(
+                response,
+                messages=list(api_kwargs.get("messages") or []),
+                completion_text=completion_text_from_message(message),
+                model=model,
+            )
+            total = emit_llm_call_usage(
+                agent,
+                model=model,
+                step=step,
+                conversation_id=conversation_id,
+                usage=usage,
+                duration_ms=duration_ms,
+                finish_reason=finish_reason,
+                estimated=provider_usage is None,
+            )
+            if total <= 0:
+                logger.warning(
+                    "Plan LLM usage emitted 0 tokens (model=%s, estimated=%s, usage=%s)",
+                    model,
+                    provider_usage is None,
+                    usage,
+                )
+        except Exception:
+            logger.warning("Plan token accounting failed", exc_info=True)
+
+    # Announce plan LLM work so metrics middleware / dashboards can open a run window.
+    if hasattr(agent, "emit"):
+        try:
+            from core.agent_events import LLMCallStartedEvent, ThinkingEvent
+
+            agent.emit(
+                ThinkingEvent(
+                    message=f"Generating plan with {model}…",
+                    conversation_id=conversation_id,
+                )
+            )
+            agent.emit(
+                LLMCallStartedEvent(
+                    model=model,
+                    step=1,
+                    conversation_id=conversation_id,
+                )
+            )
+        except Exception:
+            logger.debug("Plan LLM start event failed", exc_info=True)
+
     for attempt in range(1 + plan_retries):
         try:
             logger.info(
@@ -566,6 +635,9 @@ async def plan_node(state: HolixGraphState, config: RunnableConfig) -> dict:
                 f"(model={model}, timeout={attempt_timeout}s, "
                 f"max_tokens={api_kwargs['max_tokens']}, json_mode={use_json_mode})"
             )
+            import time as _time
+
+            t0 = _time.perf_counter()
 
             # Try with response_format first, fallback without
             if use_json_mode:
@@ -591,34 +663,19 @@ async def plan_node(state: HolixGraphState, config: RunnableConfig) -> dict:
                     timeout=attempt_timeout,
                 )
 
-            result_text = response.choices[0].message.content or ""
+            duration_ms = (_time.perf_counter() - t0) * 1000.0
+            finish_reason = None
             try:
-                from core.llm.usage import (
-                    completion_text_from_message,
-                    emit_llm_call_usage,
-                    resolve_usage,
-                    usage_dict_from_response,
-                )
-
-                provider_usage = usage_dict_from_response(response)
-                usage = resolve_usage(
-                    response,
-                    messages=list(api_kwargs.get("messages") or []),
-                    completion_text=completion_text_from_message(
-                        response.choices[0].message
-                    ),
-                    model=model,
-                )
-                emit_llm_call_usage(
-                    agent,
-                    model=model,
-                    step=attempt + 1,
-                    conversation_id=conversation_id,
-                    usage=usage,
-                    estimated=provider_usage is None,
-                )
+                finish_reason = getattr(response.choices[0], "finish_reason", None)
             except Exception:
-                logger.debug("Plan token accounting failed", exc_info=True)
+                finish_reason = None
+            result_text = response.choices[0].message.content or ""
+            _account_plan_llm(
+                response,
+                step=attempt + 1,
+                duration_ms=duration_ms,
+                finish_reason=str(finish_reason) if finish_reason else None,
+            )
             logger.info(
                 f"Plan LLM response received: {len(result_text)} chars "
                 f"(first 200: {result_text[:200]})"

--- a/core/plan_review/review_guard.py
+++ b/core/plan_review/review_guard.py
@@ -131,6 +131,37 @@ def reject_all_global_pending_reviews(*, feedback: str = "stopped by user") -> i
     return n
 
 
+def reject_global_pending_reviews_for_conversation(
+    conversation_id: str,
+    *,
+    feedback: str = "stopped by user",
+) -> int:
+    """Reject pending plan reviews whose review_id is bound to *conversation_id*.
+
+    Review ids are ``plan_review_{n}_{conversation_id}`` (see request_review).
+    Other tabs' plan reviews stay open.
+    """
+    cid = (conversation_id or "").strip()
+    if not cid:
+        return 0
+    suffix = f"_{cid}"
+    with _GLOBAL_LOCK:
+        items = list(_GLOBAL_PENDING.items())
+    n = 0
+    for rid, fut in items:
+        rid_s = str(rid or "")
+        if rid_s == cid or rid_s.endswith(suffix) or f"_{cid}_" in rid_s:
+            if _set_future_result(fut, (PlanReviewChoice.REJECT, feedback)):
+                n += 1
+                logger.info(
+                    "PlanReviewGuard: rejected pending id=%s for conversation=%s (%s)",
+                    rid,
+                    cid,
+                    feedback,
+                )
+    return n
+
+
 class PlanReviewGuard:
     """Manages plan review requests using asyncio.Future + event bus.
 

--- a/tests/test_agent_stop.py
+++ b/tests/test_agent_stop.py
@@ -62,8 +62,8 @@ def test_reject_pending_plan_reviews_for_conversation_only(
 ) -> None:
     from cli.shared.agent_stop import reject_pending_plan_reviews_for_conversation
     from core.plan_review.review_guard import (
-        _GLOBAL_PENDING,
         _GLOBAL_LOCK,
+        _GLOBAL_PENDING,
         reject_global_pending_reviews_for_conversation,
     )
 

--- a/tests/test_agent_stop.py
+++ b/tests/test_agent_stop.py
@@ -57,6 +57,43 @@ def test_reject_all_pending_plan_reviews(monkeypatch: pytest.MonkeyPatch) -> Non
         loop.close()
 
 
+def test_reject_pending_plan_reviews_for_conversation_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cli.shared.agent_stop import reject_pending_plan_reviews_for_conversation
+    from core.plan_review.review_guard import (
+        _GLOBAL_PENDING,
+        _GLOBAL_LOCK,
+        reject_global_pending_reviews_for_conversation,
+    )
+
+    loop = asyncio.new_event_loop()
+    try:
+        fut_a = loop.create_future()
+        fut_b = loop.create_future()
+        with _GLOBAL_LOCK:
+            _GLOBAL_PENDING.clear()
+            _GLOBAL_PENDING["plan_review_1_tab_a"] = fut_a
+            _GLOBAL_PENDING["plan_review_2_tab_b"] = fut_b
+        monkeypatch.setattr(
+            "core.plan_review.review_guard.get_plan_review_guard",
+            lambda: None,
+        )
+        n = reject_pending_plan_reviews_for_conversation("tab_a")
+        assert n == 1
+        assert fut_a.done()
+        assert not fut_b.done()
+        choice, feedback = fut_a.result()
+        assert choice == PlanReviewChoice.REJECT
+        assert "stopped" in feedback
+        # Cleanup leftover
+        reject_global_pending_reviews_for_conversation("tab_b")
+    finally:
+        with _GLOBAL_LOCK:
+            _GLOBAL_PENDING.clear()
+        loop.close()
+
+
 @pytest.mark.asyncio
 async def test_cancel_host_run_tasks() -> None:
     host = MagicMock()


### PR DESCRIPTION
## Summary
- Scope Stop / plan-review reject to a single conversation tab (siblings keep running).
- Meter plan_node, execute_step, and auto ModeRouter LLM calls (tokens + duration).
- Fix `LLMCallStartedEvent` type (was falling back to `error`).

## Test plan
- [x] `pytest tests/test_agent_stop.py`
- [ ] CI green on PR
- [ ] Lab: two parallel tabs — Stop one does not stop the other
- [ ] Lab: Plan mode generation shows token/model metrics in Grafana