### PR TITLE
release: Holix 1.0.4 — plan progress, GenAI OTEL, SDD-safe planning

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## 1.0.4 — 2026-08-04
+
+Plan-mode UX, OpenTelemetry GenAI conventions, and SDD safety during planning.
+
+### Added
+
+- **Plan-build live progress** — `ThinkingEvent` phases while the plan is generated (context, handbook, LLM wait heartbeats every ~12s, quality retries, save/ready) so Studio/Telegram show the agent is working.
+- **OpenTelemetry GenAI** — optional `Holix[otel]` instrumentation (`core/monitoring/genai_otel.py`) with GenAI semantic-convention spans (`chat {model}`, `plan holix`) and token/duration metrics; auto-setup when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Docs: [OBSERVABILITY.md](en/OBSERVABILITY.md).
+- **Meta/reflect token metering** — MetaAgent analyze/evaluate emit `LLMCallCompletedEvent` with duration for Studio dashboards.
+
+### Fixed
+
+- **Plan mode must not bootstrap SDD** — planning only **reads** `openspec/` and may run `/init` for `HOLIX.md`; no `sdd_init` / `sdd_apply` / `sdd_propose` in plan prompt tools or generated steps.
+- **CI** — drop private `holix-studio` git pin from `uv.lock` so public Actions can `uv sync` without private-repo credentials.
+
+### Tests
+
+- Plan progress, GenAI OTEL no-op, plan SDD guard, planning context (no sdd_init suggestion).
+
 ## 1.0.3 — 2026-08-03
 
 Plan orchestration quality, SDD task sizing, and runtime/resource fixes since 1.0.2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.3"
+version = "1.0.4"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1041,7 +1041,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release **1.0.4** after merge of plan progress / OTEL / SDD-safe planning.

- Plan-build live UI progress (heartbeats while model runs)
- Optional OpenTelemetry GenAI semantic conventions (`Holix[otel]`)
- Plan mode does not run `sdd_init` / auto SDD apply
- Meta/reflect LLM usage events
- CI lock: no private holix-studio git fetch

## Test plan

- [ ] GitHub CI on this PR
- [ ] After merge: tag `v1.0.4` → GitHub Release + PyPI