### PR TITLE
release: Holix 1.0.5 — messenger draft spam fix and subagents menu

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -31,13 +31,12 @@ def terminal_whitelist_enabled() -> bool:
     3. Settings singleton default.
     """
     try:
-        from core.env_loader import active_profile_name
+        from core.env_loader import active_profile_name, read_profile_env_map
         from core.terminal_whitelist_config import (
             WHITELIST_ENABLED_KEY,
             WHITELIST_ENABLED_LEGACY_KEY,
             read_whitelist_enabled,
         )
-        from core.env_loader import read_profile_env_map
 
         profile = active_profile_name()
         env_map = read_profile_env_map(profile)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 1.0.5 — 2026-08-05
+
+Messenger reliability: no draft-answer spam, think-tag stripping, and UX toggles.
+
+### Added
+
+- **Sub-agents menu toggle** — Telegram/MAX `/status` panel can enable or disable `enable_subagents` for the active profile (persisted + live agent tools sync).
+
+### Fixed
+
+- **Draft FinalResponse spam** — successful ReAct drafts no longer emit `FinalResponseEvent` before Reflexion; messengers receive a single final after the graph finishes (stops TG/MAX monologue spam like «Что сделаю… Начинаю»).
+- **Think/CoT markup in content** — strip `<think>…</think>` and similar tags from assistant text before delivery.
+- **Plan monologue without tools** — honesty nudge when the model only narrates a plan («Что сделаю», «Начинаю») without tool calls.
+- **Subagent metering** — emit `LLMCallCompleted` for model.calls dashboards on sub-agent runs.
+- **Terminal whitelist** — honor profile whitelist toggle over systemd env.
+- **Subagent confirmations** — stamp parent `conversation_id` on tool confirmations.
+
+### Tests
+
+- Strip think markup; plan monologue honesty; react defers FinalResponseEvent; messenger subagents settings.
+
 ## 1.0.4 — 2026-08-04
 
 Plan-mode UX, OpenTelemetry GenAI conventions, and SDD safety during planning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.4"
+version = "1.0.5"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_subagent_llm_usage_emit.py
+++ b/tests/test_subagent_llm_usage_emit.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
-
-import pytest
 
 from core.agent_events import AgentEventBus, LLMCallCompletedEvent, SubAgentStartedEvent
 from core.llm.usage import emit_llm_call_usage

--- a/uv.lock
+++ b/uv.lock
@@ -1041,7 +1041,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Fix messenger spam** after 1.0.2→1.0.4: draft `FinalResponseEvent` no longer posts monologue to Telegram/MAX before Reflexion; one final after graph end.
- **Strip think/CoT tags** from assistant content.
- **Honesty nudge** for plan-only replies without tools.
- **Sub-agents on/off** in TG/MAX status menu (profile `enable_subagents`).
- Related fixes: subagent metering, terminal whitelist, subagent confirmation `conversation_id`.

## Test plan

- [x] Local pytest for response_text, honesty, react defer, final dedup, messenger final, graph e2e
- [ ] GitHub Actions CI green on this PR
- [ ] After merge: tag `v1.0.5` triggers GitHub Release + PyPI publish