### PR TITLE
release: Holix 1.0.7 — terminal safety + SDD archive gates

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 1.0.7 — 2026-08-08
+
+Terminal safety when whitelist is off, and SDD archive merge gates.
+
+### Fixed
+
+- **Destructive terminal patterns with whitelist off** — `HOLIX_TERMINAL_COMMAND_WHITELIST=false` still blocks `rm -rf`, `curl|sh`, `mkfs`, `dd`, shutdown/reboot, etc. (`blocks_dangerous_patterns` always applied).
+- **SDD archive without merge** — `archive` refuses to move a change unless delta specs merge into main `openspec/specs/<domain>/spec.md` (unless `force=true`).
+- **Plan path resolution** — relative plan paths resolve against profile `workspace_root`, not process CWD (Studio list/open plans).
+
+### Tests
+
+- Terminal dangerous patterns when whitelist is disabled.
+
 ## 1.0.6 — 2026-08-05
 
 Agent reliability for messengers: anti-monologue pipeline, classic/modern switch, background process history, and workspace access for admin (jail-off) profiles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.6"
+version = "1.0.7"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release **Holix 1.0.7** (patch after 1.0.6).

- Terminal: always block destructive patterns when allowlist is off
- SDD: refuse archive unless deltas merge into main specs
- Plans: resolve relative paths via workspace_root

## Version

- `1.0.7` in pyproject + cli
- CHANGELOG section for 1.0.7

## Test plan

- [x] Local terminal + sdd tests
- [ ] CI green
- [ ] Tag `v1.0.7` after merge → GitHub Release + PyPI