### PR TITLE
Holix 1.0.8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,12 @@ TEMPERATURE=0.7
 # Base ReAct/graph step budget (Settings field: max_steps; env alias may vary by layer)
 MAX_STEPS=90
 DATA_DIR=data
+# Tool confirmation (TUI / Telegram / Studio). Default in code: low.
+# Risks above this need a confirmation modal (/1–/4 or buttons).
+# AUTO_ALLOW_THRESHOLD=low     # confirm medium+high (recommended for interactive TUI)
+# AUTO_ALLOW_THRESHOLD=high    # auto-run everything (no confirmation UI) — benches/dev only
+# HOLIX_UNATTENDED=1           # same as high + disable plan review (CI)
+# NON_INTERACTIVE=true         # no UI; tools above threshold are DENIED (not auto-approved)
 # Meta / Reflexion (self-refinement default off; Telegram /status → Reflexion)
 # HOLIX_ENABLE_META_AGENT=true
 # HOLIX_ENABLE_SELF_REFINEMENT=false

--- a/.gitignore
+++ b/.gitignore
@@ -80,10 +80,13 @@ mcp_registry_tool.sh
 mcp_system_config.json
 MCP_REGISTRY_SYSTEM_REPORT.md
 
-# Helix local runtime
+# Helix / Holix local runtime
 .helix/
+.holix/
 .langgraph_api/
 .pid
 
 # Local design plans (not versioned)
 plans/
+node_modules/
+presentations/

--- a/.grok/rules/make-release.md
+++ b/.grok/rules/make-release.md
@@ -1,0 +1,12 @@
+# Trigger: «сделай релиз»
+
+When the user says **сделай релиз**, **сделать релиз**, **make a release**,
+or `/make-release`, follow `.grok/skills/make-release/SKILL.md` immediately:
+
+1. Open a GitHub PR with the changes (include next version + CHANGELOG).
+2. Watch GitHub Actions until every check is green; fix code and push if not.
+3. Merge the PR into `main`.
+4. Create the next numbered release: tag `vX.Y.Z` matching `pyproject.toml`
+   (GitHub Release + PyPI workflows).
+
+Do not stop after the PR. Do not merge red CI. Do not hotfix production VDS.

--- a/.grok/skills/make-release/SKILL.md
+++ b/.grok/skills/make-release/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: make-release
+description: >
+  Ship Holix through GitHub: open a PR, wait until Actions are green (fix
+  code if needed), merge to main, then cut the next numbered GitHub release.
+  Use when the user says «сделай релиз», «сделать релиз», «make a release»,
+  «create release», «cut a release», or runs /make-release.
+---
+
+# Holix release («сделай релиз»)
+
+When the user says **сделай релиз** (or equivalent), execute this pipeline
+end-to-end. Do not stop after the PR. Do not skip CI. Do not tag before merge.
+
+Canonical package rules: `RULES.md` §8. This skill is the operational loop.
+
+## Preconditions
+
+- Repo: `javded-itres/Holix`. Default branch: `main`.
+- Auth: `gh auth status` must be logged in.
+- Fetch first: `git fetch origin --tags`.
+- Next version = latest GitHub release + **patch** (`1.0.7` → `1.0.8`), unless
+  the user asked for minor/major.
+- Confirm versions agree before tagging:
+  - `pyproject.toml` `[project].version`
+  - `cli/__init__.py` `__version__`
+  - latest `gh release list` / `git tag`
+- Do **not** rsync/scp/hotfix production. Tag on `main` is enough: GHA
+  `GitHub Release` + `Publish to PyPI` run from `vX.Y.Z`.
+- Run `./scripts/lint.sh` (or `--fix`) before every push.
+
+## 1) PR with the changes
+
+Include **code + version bump + changelog** in the same PR so there is one
+merge, then a tag.
+
+1. If an open PR already covers this work, reuse it and add the bump there
+   if missing.
+2. Otherwise branch from up-to-date `origin/main`:
+   `release/X.Y.Z` (example: `release/1.0.8`).
+3. Commit the user's uncommitted/unmerged work (no secrets, no
+   `node_modules/`, no local `.env`).
+4. Bump version with `scripts/versioning.py` (or edit both files):
+   - `pyproject.toml`
+   - `cli/__init__.py`
+5. Update `docs/CHANGELOG.md`:
+   - Move `## Unreleased` notes into `## X.Y.Z — YYYY-MM-DD`
+   - Leave a fresh empty `## Unreleased`
+   - Write Added/Fixed/Tests from the actual diff
+6. Push and open PR → `main`:
+
+```bash
+gh pr create --base main --title "Holix X.Y.Z" --body "$(cat <<'EOF'
+## Summary
+Release Holix X.Y.Z.
+
+## Checklist
+- [ ] Version matches in pyproject.toml and cli/__init__.py
+- [ ] docs/CHANGELOG.md has section X.Y.Z
+- [ ] CI green (ruff + pytest matrix)
+
+After merge: tag `vX.Y.Z` (creates GitHub Release + PyPI).
+EOF
+)"
+```
+
+## 2) GitHub tests until green
+
+Watch **GitHub Actions on the PR**, not only local pytest.
+
+```bash
+gh pr checks <n> --watch
+# or
+gh run watch <run-id>
+```
+
+On failure:
+
+1. `gh run view <id> --log-failed` (or job logs).
+2. Fix the code / tests / ruff.
+3. Local: `./scripts/lint.sh` then targeted pytest.
+4. Commit, push, re-watch.
+
+Repeat until **every** required check is green. Do not merge red CI.
+If a failure needs a product decision, stop and ask — do not paper over it.
+
+## 3) Merge into `main`
+
+User already authorized merge as part of this command.
+
+```bash
+gh pr merge <n> --merge --delete-branch
+```
+
+Use `--squash` only if the user asked. Wait until the PR is `MERGED`.
+Then `git checkout main && git pull origin main`.
+
+Verify `main` now has version `X.Y.Z`.
+
+## 4) Next numbered GitHub release
+
+Tag **must** match `pyproject.toml`. Do not create a GitHub release by hand
+if the tag workflow can do it.
+
+```bash
+git checkout main
+git pull origin main
+python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Watch:
+
+- `GitHub Release` → https://github.com/javded-itres/Holix/releases/tag/vX.Y.Z
+- `Publish to PyPI`
+
+```bash
+gh run list --branch vX.Y.Z --limit 5
+gh release view vX.Y.Z
+```
+
+If the tag workflow fails because CHANGELOG has no `## X.Y.Z` section, fix
+on a follow-up PR, delete/re-push the tag only with `--force-with-lease`
+after saying so. Prefer a new patch over rewriting a published tag.
+
+## Report back
+
+When done, reply with:
+
+- PR URL and merge SHA
+- Version `X.Y.Z` / tag `vX.Y.Z`
+- Release URL
+- CI + PyPI workflow status

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ default_stages:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.15.16
     hooks:
       - id: ruff
         name: ruff fix (pre-commit)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 Full development rules (architecture, extensions, security, deploy): **[RULES.md](RULES.md)**.
 
+## «Сделай релиз»
+
+When the user says **сделай релиз** (or `/make-release`), follow
+**[`.grok/skills/make-release/SKILL.md`](.grok/skills/make-release/SKILL.md)**:
+
+1. Open a GitHub PR with the changes (next version + CHANGELOG).
+2. Watch GitHub Actions until all checks pass; fix and push if needed.
+3. Merge the PR into `main`.
+4. Tag `vX.Y.Z` (next number after the latest GitHub release) so GHA creates
+   the GitHub Release and publishes to PyPI.
+
 ## Production / remote policy (Studio and related)
 
 - **Production** installs of Holix Studio stack: **GitHub Actions only**, **branch `main` only** (Helix + holix-studio + holix-license).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,26 @@ Run tests:
 uv run pytest
 uv run pytest -m "not llm"
 uv run pytest tests/test_agent_events.py
+uv run pytest tests/user_cases -q          # product journeys (scripted LLM + real tools)
+uv run pytest -m user_case
+
+# Live LLM (real provider — NOT in CI; needs model endpoint)
+./scripts/test_live_llm.sh
+# HOLIX_LIVE_MODEL=… HOLIX_LIVE_BASE_URL=… HOLIX_LIVE_API_KEY=… ./scripts/test_live_llm.sh -k live_01
+```
+
+**User cases** (`tests/user_cases/`): end-to-end agent journeys via `UserCaseHarness`
+(scripted LLM, real tools under an isolated workspace). See
+`tests/user_cases/catalog/README.md`.
+
+**Live LLM** (`tests/live_llm/`): real OpenAI-compatible API calls, temp workspace wiped
+after each test. See `tests/live_llm/README.md`. Always excluded by `-m "not llm"`.
+
+**TUI pilot** (`tests/tui/`): full `HolixCodeApp` launch via Textual Pilot (mock agent).
+
+```bash
+./scripts/test_tui.sh
+uv run python -m pytest tests/tui -m tui -v
 ```
 
 Lint (same scope as CI):
@@ -36,8 +56,8 @@ uv run ruff check core cli api integrations tests
 ./scripts/install-git-hooks.sh
 ```
 
-- **pre-commit** — ruff fix + format on staged files  
-- **pre-push** — `./scripts/lint.sh` (blocks push if ruff fails; same paths as CI)  
+- **pre-commit** — ruff fix + format on staged files
+- **pre-push** — `./scripts/lint.sh` (blocks push if ruff fails; same paths as CI)
 
 See [RULES.md](RULES.md) §9. Skip only in emergencies: `git push --no-verify`.
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"

--- a/cli/shared/commands/agent_commands.py
+++ b/cli/shared/commands/agent_commands.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from cli.shared.commands.registry import SLASH_COMMANDS
-from cli.shared.slash_input import is_mode_slash, is_models_slash, normalize_slash_input
 from core.i18n import host_locale, set_host_locale, t
 from core.plan_review.review_guard import PlanReviewChoice
 from core.security.confirmation import ConfirmationChoice
+
+from cli.shared.commands.registry import SLASH_COMMANDS
+from cli.shared.slash_input import is_mode_slash, is_models_slash, normalize_slash_input
 
 
 class AgentCommands:
@@ -319,8 +320,9 @@ class AgentCommands:
             await h._sync_telegram_menu()
 
     async def _profile(self, command: str) -> None:
-        from cli.core import ProfileManager
         from core.profile_keys import profile_has_access_key
+
+        from cli.core import ProfileManager
 
         h = self.host
         lang = host_locale(h)

--- a/cli/shared/commands/agent_commands.py
+++ b/cli/shared/commands/agent_commands.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from cli.shared.commands.registry import SLASH_COMMANDS
+from cli.shared.slash_input import is_mode_slash, is_models_slash, normalize_slash_input
 from core.i18n import host_locale, set_host_locale, t
 from core.plan_review.review_guard import PlanReviewChoice
 from core.security.confirmation import ConfirmationChoice
-
-from cli.shared.commands.registry import SLASH_COMMANDS
-from cli.shared.slash_input import is_mode_slash, is_models_slash, normalize_slash_input
 
 
 class AgentCommands:
@@ -264,6 +263,30 @@ class AgentCommands:
         h.transcript_write(
             f"[dim]{t('status_line', lang, profile=h.profile, mode=mode, session=h.conversation_id)}[/dim]"
         )
+        # Confirmation / safety policy (why the TUI modal may not appear)
+        thr = "low"
+        non_interactive = False
+        agent = getattr(h, "agent", None)
+        cfg = getattr(agent, "config", None) or getattr(h, "config", None)
+        if cfg is not None:
+            thr = str(getattr(cfg, "auto_allow_threshold", thr) or thr)
+            non_interactive = bool(getattr(cfg, "non_interactive", False))
+        guard = None
+        if agent is not None and getattr(agent, "tools", None) is not None:
+            guard = getattr(agent.tools, "_action_guard", None)
+        if guard is not None:
+            g_thr = getattr(guard, "_auto_allow_threshold", None)
+            if g_thr is not None:
+                thr = getattr(g_thr, "value", str(g_thr))
+            non_interactive = not bool(getattr(guard, "_interactive", True))
+        note = ""
+        if str(thr).lower() in {"medium", "high"}:
+            note = "  [yellow]→ no modal for risks ≤ threshold[/yellow]"
+        elif non_interactive:
+            note = "  [yellow]→ confirmations disabled (deny above threshold)[/yellow]"
+        h.transcript_write(
+            f"[dim]confirmations: auto_allow={thr}  non_interactive={non_interactive}{note}[/dim]"
+        )
 
     async def _metrics(self) -> None:
         h = self.host
@@ -296,9 +319,8 @@ class AgentCommands:
             await h._sync_telegram_menu()
 
     async def _profile(self, command: str) -> None:
-        from core.profile_keys import profile_has_access_key
-
         from cli.core import ProfileManager
+        from core.profile_keys import profile_has_access_key
 
         h = self.host
         lang = host_locale(h)
@@ -468,6 +490,7 @@ class AgentCommands:
                 # Fallback: try to read from current config
                 try:
                     from cli.core import get_current_config
+
                     cfg = get_current_config()
                     servers = getattr(cfg, "mcp_servers", {}) or {}
                     if not servers:
@@ -476,7 +499,7 @@ class AgentCommands:
                         lines = ["MCP servers:"]
                         for name, data in servers.items():
                             src = data.get("_source", "manual")
-                            lines.append(f"  • {name} ({data.get('transport','stdio')}) [{src}]")
+                            lines.append(f"  • {name} ({data.get('transport', 'stdio')}) [{src}]")
                         h.transcript_write("\n".join(lines))
                 except Exception as e:
                     h.transcript_write(f"MCP list error: {e}")
@@ -488,13 +511,23 @@ class AgentCommands:
             else:
                 # List tools from registry that look like mcp_
                 try:
-                    agent = getattr(h, "agent", None) or getattr(h, "_session", None) and getattr(h._session, "agent", None)
+                    agent = (
+                        getattr(h, "agent", None)
+                        or getattr(h, "_session", None)
+                        and getattr(h._session, "agent", None)
+                    )
                     if agent and hasattr(agent, "tools"):
-                        mcp_tools = [n for n in agent.tools.get_tool_names() if n.startswith("mcp_")]
+                        mcp_tools = [
+                            n for n in agent.tools.get_tool_names() if n.startswith("mcp_")
+                        ]
                         if mcp_tools:
-                            h.transcript_write("MCP tools available:\n" + "\n".join(f"  • {t}" for t in mcp_tools))
+                            h.transcript_write(
+                                "MCP tools available:\n" + "\n".join(f"  • {t}" for t in mcp_tools)
+                            )
                         else:
-                            h.transcript_write("No MCP tools currently registered (assign servers first).")
+                            h.transcript_write(
+                                "No MCP tools currently registered (assign servers first)."
+                            )
                     else:
                         h.transcript_write("Agent/tools not ready.")
                 except Exception as e:
@@ -507,7 +540,9 @@ class AgentCommands:
                 h.run_worker(h._mcp_install(arg))
             else:
                 h.transcript_write("Use CLI for install: holix mcp install [name|git-url]")
-                h.transcript_write("Example: holix mcp install compass  (or context7, filesystem, etc.)")
+                h.transcript_write(
+                    "Example: holix mcp install compass  (or context7, filesystem, etc.)"
+                )
             return
 
         if sub in ("assign", "enable"):
@@ -536,5 +571,7 @@ class AgentCommands:
             return
 
         # Unknown subcommand
-        h.transcript_write("MCP commands: /mcp, /mcp list, /mcp install <name|url>, /mcp assign, /mcp remove <name>, /mcp test <name>, /mcp tools")
+        h.transcript_write(
+            "MCP commands: /mcp, /mcp list, /mcp install <name|url>, /mcp assign, /mcp remove <name>, /mcp test <name>, /mcp tools"
+        )
         h.transcript_write("For full UI use Telegram menus or TUI, or run `holix mcp` in terminal.")

--- a/cli/tui/code/app.py
+++ b/cli/tui/code/app.py
@@ -14,6 +14,11 @@ from collections import deque
 from pathlib import Path
 from typing import Any
 
+from core.agent import HolixAgent
+from core.agent_events import AgentEvent
+from core.plan_review.review_events import PlanReviewRequestEvent
+from core.security.confirmation import ConfirmationChoice
+from core.security.confirmation_events import ConfirmationRequestEvent
 from rich.panel import Panel
 from rich.syntax import Syntax
 from textual import events, on, work
@@ -61,11 +66,6 @@ from cli.tui.shared.slash_suggestions import (
     match_slash_commands,
 )
 from cli.tui.shared.transcript_store import TranscriptStore, plain_from_rich_write
-from core.agent import HolixAgent
-from core.agent_events import AgentEvent
-from core.plan_review.review_events import PlanReviewRequestEvent
-from core.security.confirmation import ConfirmationChoice
-from core.security.confirmation_events import ConfirmationRequestEvent
 
 _TRANSCRIPT_DISPLAY_MAX = 400
 _TRANSCRIPT_REBUILD_EVERY = 40
@@ -933,8 +933,9 @@ class HolixCodeApp(App):
             event.stop()
 
     def _slash_commands_pool(self) -> list[tuple[str, str]]:
-        from cli.shared.commands.registry import slash_commands_for_locale
         from core.i18n import LocaleStore
+
+        from cli.shared.commands.registry import slash_commands_for_locale
 
         return slash_commands_for_locale(LocaleStore(self.profile).get())
 
@@ -1495,9 +1496,10 @@ class HolixCodeApp(App):
             return
         self.transcript_write(f"[dim]Installing '{what}'... (using core logic)[/dim]")
         try:
-            from cli.core import get_profile_manager
             from core.mcp.installer import build_config_from_popular, install_from_git
             from core.mcp.popular import get_popular_by_key
+
+            from cli.core import get_profile_manager
 
             manager = get_profile_manager()
             cfg = manager.load_profile(self.profile)
@@ -1623,8 +1625,9 @@ class HolixCodeApp(App):
             return
         self.transcript_write(f"[dim]Testing {name}...[/dim]")
         try:
-            from cli.core import get_profile_manager
             from core.mcp.manager import MCPManager
+
+            from cli.core import get_profile_manager
 
             manager = get_profile_manager()
             cfg = manager.load_profile(self.profile)

--- a/cli/tui/code/app.py
+++ b/cli/tui/code/app.py
@@ -14,11 +14,6 @@ from collections import deque
 from pathlib import Path
 from typing import Any
 
-from core.agent import HolixAgent
-from core.agent_events import AgentEvent
-from core.plan_review.review_events import PlanReviewRequestEvent
-from core.security.confirmation import ConfirmationChoice
-from core.security.confirmation_events import ConfirmationRequestEvent
 from rich.panel import Panel
 from rich.syntax import Syntax
 from textual import events, on, work
@@ -66,6 +61,11 @@ from cli.tui.shared.slash_suggestions import (
     match_slash_commands,
 )
 from cli.tui.shared.transcript_store import TranscriptStore, plain_from_rich_write
+from core.agent import HolixAgent
+from core.agent_events import AgentEvent
+from core.plan_review.review_events import PlanReviewRequestEvent
+from core.security.confirmation import ConfirmationChoice
+from core.security.confirmation_events import ConfirmationRequestEvent
 
 _TRANSCRIPT_DISPLAY_MAX = 400
 _TRANSCRIPT_REBUILD_EVERY = 40
@@ -193,9 +193,7 @@ class HolixCodeApp(App):
     def _rebuild_transcript_display(self, log: CodeTranscript) -> None:
         log.clear()
         if len(self._transcript_display_chunks) >= _TRANSCRIPT_DISPLAY_MAX:
-            log.write(
-                "[dim]… earlier messages hidden — /open or /copy for full transcript[/dim]\n"
-            )
+            log.write("[dim]… earlier messages hidden — /open or /copy for full transcript[/dim]\n")
         for chunk in self._transcript_display_chunks:
             log.write(chunk)
         if self._auto_scroll:
@@ -433,8 +431,7 @@ class HolixCodeApp(App):
         except Exception:
             pending_q = ""
         line = (
-            f"{self.profile} · {lang} · {model}{stream} · {cwd} · "
-            f"{mode} · {sess}{ctx}{pending_q}"
+            f"{self.profile} · {lang} · {model}{stream} · {cwd} · {mode} · {sess}{ctx}{pending_q}"
         )
         self.set_status_line(line)
 
@@ -529,6 +526,18 @@ class HolixCodeApp(App):
         self.agent.events.subscribe(self._on_agent_event)
         await self._load_conversation_history()
         self.transcript_write("[dim]ready — type a message or /help[/dim]\n")
+        thr = str(getattr(runtime_config, "auto_allow_threshold", "low") or "low").lower()
+        if thr in {"medium", "high"}:
+            self.transcript_write(
+                f"[yellow]⚠ auto_allow_threshold={thr} — tools at or below this risk "
+                "run without a confirmation modal (terminal/python included when high). "
+                "Set AUTO_ALLOW_THRESHOLD=low in profile/.env or shell to re-enable prompts.[/yellow]\n"
+            )
+        elif getattr(runtime_config, "non_interactive", False):
+            self.transcript_write(
+                "[yellow]⚠ non_interactive=true — tools above auto_allow are denied, "
+                "no confirmation UI.[/yellow]\n"
+            )
         self.set_status_line("ready")
         self._agent_init_state = "ready"
         self._set_prompt_enabled(True)
@@ -548,9 +557,7 @@ class HolixCodeApp(App):
         try:
             result = await self.agent.finish_deferred_init()
             if result.get("mcp_tools"):
-                self.transcript_write(
-                    f"[dim]MCP: +{result['mcp_tools']} tools loaded[/dim]"
-                )
+                self.transcript_write(f"[dim]MCP: +{result['mcp_tools']} tools loaded[/dim]")
         except Exception:
             pass
         await self._ensure_session_context()
@@ -643,13 +650,11 @@ class HolixCodeApp(App):
 
         if isinstance(
             event,
-            (
-                ConfirmationRequestEvent,
-                SubAgentQuestionEvent,
-                BackgroundProcessStartedEvent,
-                BackgroundProcessStoppedEvent,
-                BackgroundProcessErrorEvent,
-            ),
+            ConfirmationRequestEvent
+            | SubAgentQuestionEvent
+            | BackgroundProcessStartedEvent
+            | BackgroundProcessStoppedEvent
+            | BackgroundProcessErrorEvent,
         ):
             # Textual: call_later(callback, *args) — delay is not the first arg.
             self.call_later(self._event_handler.handle, event)
@@ -758,9 +763,7 @@ class HolixCodeApp(App):
         try:
             suggestions = self.query_one("#command-suggestions", SlashCommandSuggestions)
             if not (
-                suggestions.is_open
-                and self._slash_suggestion_navigated
-                and suggestions.matches
+                suggestions.is_open and self._slash_suggestion_navigated and suggestions.matches
             ):
                 if suggestions.is_open:
                     self._hide_slash_suggestions()
@@ -930,9 +933,8 @@ class HolixCodeApp(App):
             event.stop()
 
     def _slash_commands_pool(self) -> list[tuple[str, str]]:
-        from core.i18n import LocaleStore
-
         from cli.shared.commands.registry import slash_commands_for_locale
+        from core.i18n import LocaleStore
 
         return slash_commands_for_locale(LocaleStore(self.profile).get())
 
@@ -1294,7 +1296,9 @@ class HolixCodeApp(App):
 
     async def action_cycle_execution_mode(self, just_set: bool = False) -> None:
         if not just_set:
-            self._execution_mode_index = (self._execution_mode_index + 1) % len(self._execution_modes)
+            self._execution_mode_index = (self._execution_mode_index + 1) % len(
+                self._execution_modes
+            )
         mode = self._execution_modes[self._execution_mode_index]
         from config import settings
 
@@ -1392,9 +1396,7 @@ class HolixCodeApp(App):
                 return
 
             try:
-                messages = await agent.memory.get_conversation(
-                    self.conversation_id, limit=200
-                )
+                messages = await agent.memory.get_conversation(self.conversation_id, limit=200)
             except Exception:
                 messages = []
 
@@ -1411,18 +1413,14 @@ class HolixCodeApp(App):
                 )
             else:
                 conv_id = self.conversation_id
-                usage = agent.context_manager.get_usage(
-                    messages, conversation_id=conv_id
-                )
+                usage = agent.context_manager.get_usage(messages, conversation_id=conv_id)
                 level = agent.context_manager.get_usage_level(
                     messages, conversation_id=conv_id, usage=usage
                 )
                 color = color_map.get(level, "white")
                 used_str = TokenCounter.format_token_count(usage["used"])
                 total_str = TokenCounter.format_token_count(usage["total"])
-                self._cached_context_display = (
-                    f"[{color}]{used_str}/{total_str}[/{color}]"
-                )
+                self._cached_context_display = f"[{color}]{used_str}/{total_str}[/{color}]"
                 self._update_context_bar_widget(usage["percent"], color, usage)
 
             self._refresh_status_bar()
@@ -1474,6 +1472,7 @@ class HolixCodeApp(App):
     async def _mcp_list(self) -> None:
         try:
             from cli.core import get_profile_manager
+
             manager = get_profile_manager()
             cfg = manager.load_profile(self.profile)
             servers = getattr(cfg, "mcp_servers", {}) or {}
@@ -1483,21 +1482,22 @@ class HolixCodeApp(App):
             lines = ["MCP servers:"]
             for name, data in servers.items():
                 src = data.get("_source", "manual")
-                lines.append(f"  • {name} ({data.get('transport','stdio')}) [{src}]")
+                lines.append(f"  • {name} ({data.get('transport', 'stdio')}) [{src}]")
             self.transcript_write("\n".join(lines))
         except Exception as e:
             self.transcript_write(f"[red]MCP list error: {e}[/red]")
 
     async def _mcp_install(self, what: str = "") -> None:
         if not what:
-            self.transcript_write("Usage: /mcp install <key|git-url>\nKeys: compass, context7, filesystem, github...\nOr use terminal `holix mcp install` for full interactive.")
+            self.transcript_write(
+                "Usage: /mcp install <key|git-url>\nKeys: compass, context7, filesystem, github...\nOr use terminal `holix mcp install` for full interactive."
+            )
             return
         self.transcript_write(f"[dim]Installing '{what}'... (using core logic)[/dim]")
         try:
+            from cli.core import get_profile_manager
             from core.mcp.installer import build_config_from_popular, install_from_git
             from core.mcp.popular import get_popular_by_key
-
-            from cli.core import get_profile_manager
 
             manager = get_profile_manager()
             cfg = manager.load_profile(self.profile)
@@ -1517,7 +1517,9 @@ class HolixCodeApp(App):
                     assigns["main"].append(name)
                 cfg.mcp_assignments = assigns
                 manager.save_profile(self.profile, cfg)
-                self.transcript_write(f"Installed from git as {name} (auto to main). Use /mcp list.")
+                self.transcript_write(
+                    f"Installed from git as {name} (auto to main). Use /mcp list."
+                )
                 # Hot reload
                 if getattr(self, "agent", None):
                     try:
@@ -1528,14 +1530,20 @@ class HolixCodeApp(App):
                         self.transcript_write(f"[dim]Hot-reload note: {e}[/dim]")
                 # Show active
                 if getattr(self, "agent", None) and hasattr(self.agent, "tools"):
-                    mcp_ts = [n for n in self.agent.tools.get_tool_names() if str(n).startswith("mcp_")]
+                    mcp_ts = [
+                        n for n in self.agent.tools.get_tool_names() if str(n).startswith("mcp_")
+                    ]
                     if mcp_ts:
-                        self.transcript_write(f"[dim]MCP tools now active ({len(mcp_ts)}): use /mcp tools[/dim]")
+                        self.transcript_write(
+                            f"[dim]MCP tools now active ({len(mcp_ts)}): use /mcp tools[/dim]"
+                        )
                 return
 
             pop = get_popular_by_key(what)
             if not pop:
-                self.transcript_write(f"Unknown key '{what}'. See terminal `holix mcp list-popular`.")
+                self.transcript_write(
+                    f"Unknown key '{what}'. See terminal `holix mcp list-popular`."
+                )
                 return
 
             data = build_config_from_popular(pop, {})
@@ -1554,7 +1562,9 @@ class HolixCodeApp(App):
                 assigns["main"].append(what)
             cfg.mcp_assignments = assigns
             manager.save_profile(self.profile, cfg)
-            self.transcript_write(f"Added popular MCP '{what}' (auto-assigned to main). Use /mcp list or /mcp tools.")
+            self.transcript_write(
+                f"Added popular MCP '{what}' (auto-assigned to main). Use /mcp list or /mcp tools."
+            )
             # Hot-reload into live agent
             if getattr(self, "agent", None):
                 try:
@@ -1567,16 +1577,23 @@ class HolixCodeApp(App):
             if getattr(self, "agent", None) and hasattr(self.agent, "tools"):
                 mcp_ts = [n for n in self.agent.tools.get_tool_names() if str(n).startswith("mcp_")]
                 if mcp_ts:
-                    self.transcript_write(f"[dim]MCP tools now active ({len(mcp_ts)}): use /mcp tools[/dim]")
+                    self.transcript_write(
+                        f"[dim]MCP tools now active ({len(mcp_ts)}): use /mcp tools[/dim]"
+                    )
         except Exception as e:
-            self.transcript_write(f"Install error: {e}. Fall back to terminal: holix mcp install {what}")
+            self.transcript_write(
+                f"Install error: {e}. Fall back to terminal: holix mcp install {what}"
+            )
 
     async def _mcp_assign(self, rest: str = "") -> None:
         if not rest:
-            self.transcript_write("Usage: /mcp assign <server> <roles...>\nExample: /mcp assign context7 main")
+            self.transcript_write(
+                "Usage: /mcp assign <server> <roles...>\nExample: /mcp assign context7 main"
+            )
             return
         try:
             from cli.core import get_profile_manager
+
             manager = get_profile_manager()
             cfg = manager.load_profile(self.profile)
             parts = rest.split(None, 1)
@@ -1606,9 +1623,9 @@ class HolixCodeApp(App):
             return
         self.transcript_write(f"[dim]Testing {name}...[/dim]")
         try:
+            from cli.core import get_profile_manager
             from core.mcp.manager import MCPManager
 
-            from cli.core import get_profile_manager
             manager = get_profile_manager()
             cfg = manager.load_profile(self.profile)
             servers = getattr(cfg, "mcp_servers", {}) or {}
@@ -1623,7 +1640,9 @@ class HolixCodeApp(App):
                 pass
             tools = m.get_tool_adapters([name])
             await m.disconnect_all()
-            self.transcript_write(f"Test {name}: {len(tools)} tools. {[tt.name for tt in tools][:4]}")
+            self.transcript_write(
+                f"Test {name}: {len(tools)} tools. {[tt.name for tt in tools][:4]}"
+            )
             if not tools:
                 errs = getattr(m, "_last_errors", {})
                 if name in errs:
@@ -1638,7 +1657,9 @@ class HolixCodeApp(App):
                 return
             mcp_tools = [n for n in self.agent.tools.get_tool_names() if str(n).startswith("mcp_")]
             if mcp_tools:
-                self.transcript_write("MCP tools available:\n" + "\n".join(f"  • {t}" for t in mcp_tools))
+                self.transcript_write(
+                    "MCP tools available:\n" + "\n".join(f"  • {t}" for t in mcp_tools)
+                )
             else:
                 self.transcript_write("[dim]No MCP tools registered (use /mcp assign)[/dim]")
         except Exception as e:
@@ -1650,6 +1671,7 @@ class HolixCodeApp(App):
             return
         try:
             from cli.core import get_profile_manager
+
             manager = get_profile_manager()
             cfg = manager.load_profile(self.profile)
             servers = dict(getattr(cfg, "mcp_servers", {}) or {})

--- a/cli/tui/modals/confirmation_presenter.py
+++ b/cli/tui/modals/confirmation_presenter.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from cli.tui.modals.confirmation import ConfirmationModal
 from core.security.confirmation import ConfirmationChoice, get_action_guard
 from core.security.confirmation_events import ConfirmationRequestEvent
 from core.subagents.interaction import resolve_any_confirmation
-
-from cli.tui.modals.confirmation import ConfirmationModal
 
 if TYPE_CHECKING:
     from cli.tui.modals.stack import ModalStack
@@ -23,6 +22,7 @@ class ConfirmationPresenter:
         self._queue: list[ConfirmationRequestEvent] = []
         self._active: ConfirmationRequestEvent | None = None
         self._modal_open = False
+        self._modal: ConfirmationModal | None = None
 
     def _resolve_guard_reference(self) -> None:
         agent = getattr(self.app, "agent", None)
@@ -81,9 +81,45 @@ class ConfirmationPresenter:
                 f"{event.tool_name} — {event.reason}{extra}"
             )
 
+    def _release_active_ui(self, *, pop_screen: bool) -> bool:
+        """Clear modal lock state. Optionally pop the Textual screen without re-entry."""
+        was_locked = self._modal_open or self._active is not None
+        self._modal_open = False
+        self._active = None
+        if self._stack.active_kind == "confirmation":
+            self._stack.set_active(None)
+        modal = self._modal
+        self._modal = None
+        if pop_screen and modal is not None and hasattr(self.app, "pop_screen"):
+            try:
+                # pop_screen does not invoke the push_screen callback (unlike dismiss),
+                # so we avoid double-resolve via on_dismissed.
+                self.app.pop_screen()
+            except Exception:
+                pass
+        return was_locked
+
+    def _pump_subagent_questions(self) -> None:
+        sq = getattr(self._stack, "subagent_question", None)
+        if sq is not None and hasattr(sq, "_pump"):
+            try:
+                sq._pump()
+            except Exception:
+                pass
+
     def _pump(self) -> None:
-        if self._modal_open or self._active is not None:
-            return
+        # Recover if active confirmation was resolved outside the modal (/1–/4, stop, etc.)
+        if self._active is not None:
+            cid = (self._active.confirmation_id or "").strip()
+            if cid and not self._is_still_pending(cid):
+                self._release_active_ui(pop_screen=True)
+            else:
+                return
+        if self._modal_open:
+            if self._active is None:
+                self._modal_open = False
+            else:
+                return
         if not self._queue:
             return
         if self._stack.has_active and self._stack.active_kind not in (None, "confirmation"):
@@ -105,14 +141,18 @@ class ConfirmationPresenter:
     def _open_modal(self, event: ConfirmationRequestEvent) -> None:
         self._stack.set_active("confirmation")
         modal = ConfirmationModal.from_confirmation_event(event)
+        self._modal = modal
         self._modal_open = True
 
         def _open() -> None:
             try:
                 self.app.push_screen(modal, self.on_dismissed)
             except Exception:
+                self._modal = None
                 self._modal_open = False
                 self._active = None
+                if self._stack.active_kind == "confirmation":
+                    self._stack.set_active(None)
                 write = getattr(self.app, "_append_to_log", None) or getattr(
                     self.app, "transcript_write", None
                 )
@@ -132,6 +172,7 @@ class ConfirmationPresenter:
 
     def on_dismissed(self, result: str | None) -> None:
         self._modal_open = False
+        self._modal = None
         self._stack.set_active(None)
         event = self._active
         self._active = None
@@ -142,16 +183,12 @@ class ConfirmationPresenter:
         except ValueError:
             choice = ConfirmationChoice.DENY
 
-        self.resolve(choice, confirmation_id=getattr(event, "confirmation_id", None) if event else None)
+        self.resolve(
+            choice,
+            confirmation_id=getattr(event, "confirmation_id", None) if event else None,
+        )
         self._pump()
-
-        # After confirmation stack clears, surface any queued sub-agent questions
-        sq = getattr(self._stack, "subagent_question", None)
-        if sq is not None and hasattr(sq, "_pump"):
-            try:
-                sq._pump()
-            except Exception:
-                pass
+        self._pump_subagent_questions()
 
     def resolve(
         self,
@@ -184,9 +221,7 @@ class ConfirmationPresenter:
             if success:
                 write(f"[dim]Confirmation {labels.get(choice, 'resolved')}.[/dim]")
             else:
-                write(
-                    "[yellow]Confirmation timed out or was already resolved.[/yellow]"
-                )
+                write("[yellow]Confirmation timed out or was already resolved.[/yellow]")
 
         # Drop matching queue entries already resolved via session grant wake-up
         if success and choice in (
@@ -200,10 +235,27 @@ class ConfirmationPresenter:
         ):
             self.app._pending_confirmation = None
 
+        # External resolve (/1–/4, agent stop) while modal still open: free the lock
+        # so the next queued confirmation can open. on_dismissed clears _active first,
+        # so this path only runs for slash/stop-style resolve.
+        external_release = False
+        if self._active is not None or self._modal_open:
+            active_cid = (
+                (getattr(self._active, "confirmation_id", None) or "").strip()
+                if self._active is not None
+                else ""
+            )
+            if not cid or not active_cid or active_cid == cid:
+                external_release = self._release_active_ui(pop_screen=True)
+
         if hasattr(self.app, "_refresh_status_bar"):
             self.app._refresh_status_bar()
         elif hasattr(self.app, "set_status_line"):
             self.app.set_status_line("Ready")
+
+        if external_release:
+            self._pump()
+            self._pump_subagent_questions()
 
     def _drop_resolved_from_queue(self) -> None:
         """Remove queued events whose futures are already gone (auto-resolved)."""

--- a/cli/tui/modals/confirmation_presenter.py
+++ b/cli/tui/modals/confirmation_presenter.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from cli.tui.modals.confirmation import ConfirmationModal
 from core.security.confirmation import ConfirmationChoice, get_action_guard
 from core.security.confirmation_events import ConfirmationRequestEvent
 from core.subagents.interaction import resolve_any_confirmation
+
+from cli.tui.modals.confirmation import ConfirmationModal
 
 if TYPE_CHECKING:
     from cli.tui.modals.stack import ModalStack

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
-from core.env_loader import bootstrap_env
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from core.env_loader import bootstrap_env
 
 bootstrap_env()
 
@@ -161,9 +162,33 @@ class Settings(BaseSettings):
     evolution_auto_learn: bool = True
 
     # Confirmation / Safety Configuration
-    auto_allow_threshold: str = "low"
-    non_interactive: bool = False
+    auto_allow_threshold: str = Field(
+        default="low",
+        validation_alias=AliasChoices(
+            "AUTO_ALLOW_THRESHOLD",
+            "HOLIX_AUTO_ALLOW_THRESHOLD",
+        ),
+        description="Risk ceiling auto-approved without UI: no|low|medium|high",
+    )
+    non_interactive: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            "NON_INTERACTIVE",
+            "HOLIX_NON_INTERACTIVE",
+        ),
+        description=(
+            "No confirmation UI. Tools above auto_allow_threshold are denied "
+            "(not auto-approved). Prefer AUTO_ALLOW_THRESHOLD=high for unattended runs."
+        ),
+    )
     confirmation_timeout: int = 0  # 0 = wait indefinitely for user approval
+    # Benchmarks / CI: force auto_allow=high and disable plan-review prompts.
+    # Does not disable ActionGuard audit logs (auto_allowed still INFO).
+    holix_unattended: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("HOLIX_UNATTENDED", "HOLIX_BENCH"),
+        description="Unattended mode for benches/CI: auto_allow high, no plan review",
+    )
 
     # Plan Review Configuration
     plan_review_enabled: bool = True

--- a/core/agent_execution.py
+++ b/core/agent_execution.py
@@ -73,15 +73,11 @@ async def run_agent_loop(
     # ------------------------------------------------------------------
     from core.runtime.session import prepare_session
 
-    messages, _was_compressed = await prepare_session(
-        agent, user_input, conversation_id
-    )
+    messages, _was_compressed = await prepare_session(agent, user_input, conversation_id)
 
     # Retrieve relevant skills
     agent_slot = getattr(agent, "agent_slot", "main")
-    relevant_skills = agent.skills.get_relevant_skills(
-        user_input, top_k=3, agent_slot=agent_slot
-    )
+    relevant_skills = agent.skills.get_relevant_skills(user_input, top_k=3, agent_slot=agent_slot)
     skills_formatted = agent.skills.format_skills_for_prompt(relevant_skills)
 
     # Retrieve relevant memories from past conversations
@@ -166,102 +162,318 @@ async def run_agent_loop(
     )
 
     while True:
-      while step_count < max_steps:
-        step_count += 1
+        while step_count < max_steps:
+            step_count += 1
 
-        # Build API messages: system prompt + recent messages
-        # Use context_manager to determine how many messages fit, or fallback to last 20
-        if hasattr(agent, 'context_manager') and agent.context_manager:
-            # Context-aware message selection: fit as many messages as possible
-            # while staying within the context window (minus system prompt tokens)
-            api_messages = _build_api_messages(
-                system_prompt, messages, agent.context_manager
-            )
-        else:
-            # Legacy fallback: just last 20 messages
-            from core.llm.api_messages import prepare_conversation_for_llm
+            # Build API messages: system prompt + recent messages
+            # Use context_manager to determine how many messages fit, or fallback to last 20
+            if hasattr(agent, "context_manager") and agent.context_manager:
+                # Context-aware message selection: fit as many messages as possible
+                # while staying within the context window (minus system prompt tokens)
+                api_messages = _build_api_messages(system_prompt, messages, agent.context_manager)
+            else:
+                # Legacy fallback: just last 20 messages
+                from core.llm.api_messages import prepare_conversation_for_llm
 
-            api_messages = [
-                {"role": "system", "content": system_prompt}
-            ] + prepare_conversation_for_llm(messages[-20:])
+                api_messages = [
+                    {"role": "system", "content": system_prompt}
+                ] + prepare_conversation_for_llm(messages[-20:])
 
-        try:
-            if stream:
-                # ==================== STREAMING PATH ====================
-                from core.models.fallback import run_with_provider_fallback
+            try:
+                if stream:
+                    # ==================== STREAMING PATH ====================
+                    from core.models.fallback import run_with_provider_fallback
 
-                if model_manager:
-                    stream_response = await run_with_provider_fallback(
-                        model_manager,
-                        agent_name=agent_slot,
-                        primary_override=primary_override,
-                        on_switch=_on_fallback_switch,
-                        factory=lambda cfg, llm_client: llm_client.chat.completions.create(
-                            model=cfg.model,
+                    if model_manager:
+                        stream_response = await run_with_provider_fallback(
+                            model_manager,
+                            agent_name=agent_slot,
+                            primary_override=primary_override,
+                            on_switch=_on_fallback_switch,
+                            factory=lambda cfg, llm_client: llm_client.chat.completions.create(
+                                model=cfg.model,
+                                messages=api_messages,
+                                tools=agent.tools.get_schemas(),
+                                tool_choice="auto",
+                                temperature=temperature,
+                                stream=True,
+                            ),
+                        )
+                    else:
+                        stream_response = await client.chat.completions.create(
+                            model=model,
                             messages=api_messages,
                             tools=agent.tools.get_schemas(),
                             tool_choice="auto",
                             temperature=temperature,
                             stream=True,
-                        ),
-                    )
-                else:
-                    stream_response = await client.chat.completions.create(
-                        model=model,
-                        messages=api_messages,
-                        tools=agent.tools.get_schemas(),
-                        tool_choice="auto",
-                        temperature=temperature,
-                        stream=True,
-                    )
-
-                current_content = ""
-                tool_calls_dict: dict[int, dict[str, Any]] = {}
-
-                async for chunk in stream_response:
-                    delta = chunk.choices[0].delta
-
-                    # --- Content streaming ---
-                    if delta.content:
-                        current_content += delta.content
-                        yield AssistantDeltaEvent(
-                            content=delta.content,
-                            accumulated=current_content,
-                            conversation_id=conversation_id,
                         )
 
-                    # --- Tool call streaming (accumulate deltas) ---
-                    if delta.tool_calls:
-                        for tc_delta in delta.tool_calls:
-                            idx = tc_delta.index
-                            if idx not in tool_calls_dict:
-                                tool_calls_dict[idx] = {
-                                    "id": "",
-                                    "type": "function",
-                                    "function": {"name": "", "arguments": ""},
+                    current_content = ""
+                    tool_calls_dict: dict[int, dict[str, Any]] = {}
+
+                    async for chunk in stream_response:
+                        delta = chunk.choices[0].delta
+
+                        # --- Content streaming ---
+                        if delta.content:
+                            current_content += delta.content
+                            yield AssistantDeltaEvent(
+                                content=delta.content,
+                                accumulated=current_content,
+                                conversation_id=conversation_id,
+                            )
+
+                        # --- Tool call streaming (accumulate deltas) ---
+                        if delta.tool_calls:
+                            for tc_delta in delta.tool_calls:
+                                idx = tc_delta.index
+                                if idx not in tool_calls_dict:
+                                    tool_calls_dict[idx] = {
+                                        "id": "",
+                                        "type": "function",
+                                        "function": {"name": "", "arguments": ""},
+                                    }
+
+                                if tc_delta.id:
+                                    tool_calls_dict[idx]["id"] = tc_delta.id
+                                if tc_delta.function:
+                                    if tc_delta.function.name:
+                                        tool_calls_dict[idx]["function"]["name"] = (
+                                            tc_delta.function.name
+                                        )
+                                    if tc_delta.function.arguments:
+                                        tool_calls_dict[idx]["function"]["arguments"] += (
+                                            tc_delta.function.arguments
+                                        )
+
+                        finish_reason = chunk.choices[0].finish_reason
+                        has_stream_tools = bool(tool_calls_dict) and any(
+                            (tc.get("function") or {}).get("name", "").strip()
+                            for tc in tool_calls_dict.values()
+                        )
+
+                        if finish_reason == "stop" and not has_stream_tools:
+                            # Final answer arrived via streaming
+                            final_response = current_content or "No response generated"
+
+                            # Save assistant message
+                            assistant_msg = {"role": "assistant", "content": final_response}
+                            messages.append(assistant_msg)
+                            await agent.memory.save_message(
+                                conversation_id, "assistant", final_response
+                            )
+
+                            yield FinalResponseEvent(
+                                content=final_response,
+                                steps_taken=step_count,
+                                conversation_id=conversation_id,
+                            )
+
+                            await _maybe_self_improve(
+                                agent, conversation_id, messages, final_response
+                            )
+                            return
+
+                        elif finish_reason == "tool_calls" or (
+                            finish_reason == "stop" and has_stream_tools
+                        ):
+                            # Tool calls arrived via streaming (some providers use finish_reason=stop)
+                            tool_calls = list(tool_calls_dict.values())
+                            assistant_msg = {
+                                "role": "assistant",
+                                "content": current_content,
+                                "tool_calls": tool_calls,
+                            }
+                            messages.append(assistant_msg)
+
+                            # Execute tools
+                            for tc_data in tool_calls:
+                                tool_name = tc_data["function"]["name"]
+
+                                # Create a minimal tool call object compatible with execute()
+                                class _ToolCall:
+                                    def __init__(self, data):
+                                        self.id = data.get("id", "")
+                                        self.type = data.get("type", "function")
+                                        self.function = type(
+                                            "obj",
+                                            (object,),
+                                            {
+                                                "name": data["function"]["name"],
+                                                "arguments": data["function"]["arguments"],
+                                            },
+                                        )()
+
+                                tool_call_obj = _ToolCall(tc_data)
+
+                                yield ToolCallStartEvent(
+                                    tool_name=tool_name,
+                                    tool_id=tool_call_obj.id,
+                                    arguments_raw=tc_data["function"]["arguments"],
+                                    conversation_id=conversation_id,
+                                )
+
+                                start = time.time()
+                                try:
+                                    result = await agent.tools.execute(
+                                        tool_call_obj,
+                                        conversation_id=conversation_id,
+                                        memory=agent.memory,
+                                    )
+                                    duration = (time.time() - start) * 1000
+
+                                    yield ToolCallResultEvent(
+                                        tool_name=tool_name,
+                                        tool_id=tool_call_obj.id,
+                                        result=result,
+                                        duration_ms=duration,
+                                        conversation_id=conversation_id,
+                                    )
+                                except Exception as tool_err:
+                                    yield ToolCallErrorEvent(
+                                        tool_name=tool_name,
+                                        tool_id=tool_call_obj.id,
+                                        error=str(tool_err),
+                                        conversation_id=conversation_id,
+                                    )
+                                    result = f"Error: {tool_err}"
+
+                                from core.memory.tool_content import (
+                                    truncate_tool_content_for_graph,
+                                    truncate_tool_content_for_memory,
+                                )
+
+                                graph_result = truncate_tool_content_for_graph(
+                                    result if isinstance(result, str) else str(result)
+                                )
+                                tool_msg = {
+                                    "role": "tool",
+                                    "tool_call_id": tool_call_obj.id,
+                                    "content": graph_result,
                                 }
+                                messages.append(tool_msg)
+                                await agent.memory.save_message(
+                                    conversation_id,
+                                    "tool",
+                                    truncate_tool_content_for_memory(
+                                        result if isinstance(result, str) else str(result)
+                                    ),
+                                    metadata={"tool_name": tool_name},
+                                )
 
-                            if tc_delta.id:
-                                tool_calls_dict[idx]["id"] = tc_delta.id
-                            if tc_delta.function:
-                                if tc_delta.function.name:
-                                    tool_calls_dict[idx]["function"]["name"] = tc_delta.function.name
-                                if tc_delta.function.arguments:
-                                    tool_calls_dict[idx]["function"]["arguments"] += tc_delta.function.arguments
+                            # Continue to next reasoning step with tool results
+                            break  # exit the async for chunk loop
 
-                    finish_reason = chunk.choices[0].finish_reason
-                    has_stream_tools = bool(tool_calls_dict) and any(
-                        (tc.get("function") or {}).get("name", "").strip()
-                        for tc in tool_calls_dict.values()
-                    )
+                else:
+                    # ==================== NON-STREAMING PATH ====================
+                    from core.models.fallback import chat_completions_with_fallback
 
-                    if finish_reason == "stop" and not has_stream_tools:
-                        # Final answer arrived via streaming
-                        final_response = current_content or "No response generated"
+                    if model_manager:
+                        response = await chat_completions_with_fallback(
+                            model_manager,
+                            agent_name=agent_slot,
+                            primary_override=primary_override,
+                            on_switch=_on_fallback_switch,
+                            messages=api_messages,
+                            tools=agent.tools.get_schemas(),
+                            tool_choice="auto",
+                            temperature=temperature,
+                        )
+                    else:
+                        response = await client.chat.completions.create(
+                            model=model,
+                            messages=api_messages,
+                            tools=agent.tools.get_schemas(),
+                            tool_choice="auto",
+                            temperature=temperature,
+                        )
 
-                        # Save assistant message
-                        assistant_msg = {"role": "assistant", "content": final_response}
-                        messages.append(assistant_msg)
+                    message = response.choices[0].message
+                    msg_dict = {"role": "assistant", "content": message.content or ""}
+
+                    if message.tool_calls:
+                        msg_dict["tool_calls"] = [
+                            {
+                                "id": tc.id,
+                                "type": tc.type,
+                                "function": {
+                                    "name": tc.function.name,
+                                    "arguments": tc.function.arguments,
+                                },
+                            }
+                            for tc in message.tool_calls
+                        ]
+                        messages.append(msg_dict)
+
+                        for tool_call in message.tool_calls:
+                            tool_name = tool_call.function.name
+                            tool_id = tool_call.id
+                            args_raw = tool_call.function.arguments
+
+                            yield ToolCallStartEvent(
+                                tool_name=tool_name,
+                                tool_id=tool_id,
+                                arguments_raw=args_raw,
+                                conversation_id=conversation_id,
+                            )
+
+                            start = time.time()
+                            try:
+                                result = await agent.tools.execute(
+                                    tool_call,
+                                    conversation_id=conversation_id,
+                                    memory=agent.memory,
+                                )
+                                duration = (time.time() - start) * 1000
+
+                                yield ToolCallResultEvent(
+                                    tool_name=tool_name,
+                                    tool_id=tool_id,
+                                    result=result,
+                                    duration_ms=duration,
+                                    conversation_id=conversation_id,
+                                    truncated=len(result) > 200,
+                                )
+                            except Exception as tool_err:
+                                yield ToolCallErrorEvent(
+                                    tool_name=tool_name,
+                                    tool_id=tool_id,
+                                    error=str(tool_err),
+                                    conversation_id=conversation_id,
+                                )
+                                result = f"Error: {tool_err}"
+
+                            from core.memory.tool_content import (
+                                truncate_tool_content_for_graph,
+                                truncate_tool_content_for_memory,
+                            )
+
+                            graph_result = truncate_tool_content_for_graph(
+                                result if isinstance(result, str) else str(result)
+                            )
+                            tool_msg = {
+                                "role": "tool",
+                                "tool_call_id": tool_call.id,
+                                "content": graph_result,
+                            }
+                            messages.append(tool_msg)
+                            await agent.memory.save_message(
+                                conversation_id,
+                                "tool",
+                                truncate_tool_content_for_memory(
+                                    result if isinstance(result, str) else str(result)
+                                ),
+                                metadata={"tool_name": tool_name},
+                            )
+
+                        continue  # next reasoning iteration
+
+                    else:
+                        # Final answer (non-streaming)
+                        final_response = message.content or "No response generated"
+                        messages.append(msg_dict)
+
                         await agent.memory.save_message(
                             conversation_id, "assistant", final_response
                         )
@@ -275,243 +487,59 @@ async def run_agent_loop(
                         await _maybe_self_improve(agent, conversation_id, messages, final_response)
                         return
 
-                    elif finish_reason == "tool_calls" or (
-                        finish_reason == "stop" and has_stream_tools
-                    ):
-                        # Tool calls arrived via streaming (some providers use finish_reason=stop)
-                        tool_calls = list(tool_calls_dict.values())
-                        assistant_msg = {
-                            "role": "assistant",
-                            "content": current_content,
-                            "tool_calls": tool_calls,
-                        }
-                        messages.append(assistant_msg)
+            except Exception as e:
+                yield ErrorEvent(
+                    error=f"Error during agent step: {str(e)}",
+                    error_type="execution",
+                    recoverable=False,
+                    conversation_id=conversation_id,
+                )
+                return
 
-                        # Execute tools
-                        for tc_data in tool_calls:
-                            tool_name = tc_data["function"]["name"]
+        # Inner budget exhausted — health-check before hard stop
+        from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
 
-                            # Create a minimal tool call object compatible with execute()
-                            class _ToolCall:
-                                def __init__(self, data):
-                                    self.id = data.get("id", "")
-                                    self.type = data.get("type", "function")
-                                    self.function = type("obj", (object,), {
-                                        "name": data["function"]["name"],
-                                        "arguments": data["function"]["arguments"],
-                                    })()
-
-                            tool_call_obj = _ToolCall(tc_data)
-
-                            yield ToolCallStartEvent(
-                                tool_name=tool_name,
-                                tool_id=tool_call_obj.id,
-                                arguments_raw=tc_data["function"]["arguments"],
-                                conversation_id=conversation_id,
-                            )
-
-                            start = time.time()
-                            try:
-                                result = await agent.tools.execute(
-                                    tool_call_obj,
-                                    conversation_id=conversation_id,
-                                    memory=agent.memory,
-                                )
-                                duration = (time.time() - start) * 1000
-
-                                yield ToolCallResultEvent(
-                                    tool_name=tool_name,
-                                    tool_id=tool_call_obj.id,
-                                    result=result,
-                                    duration_ms=duration,
-                                    conversation_id=conversation_id,
-                                )
-                            except Exception as tool_err:
-                                yield ToolCallErrorEvent(
-                                    tool_name=tool_name,
-                                    tool_id=tool_call_obj.id,
-                                    error=str(tool_err),
-                                    conversation_id=conversation_id,
-                                )
-                                result = f"Error: {tool_err}"
-
-                            tool_msg = {
-                                "role": "tool",
-                                "tool_call_id": tool_call_obj.id,
-                                "content": result,
-                            }
-                            messages.append(tool_msg)
-                            await agent.memory.save_message(
-                                conversation_id, "tool", result,
-                                metadata={"tool_name": tool_name}
-                            )
-
-                        # Continue to next reasoning step with tool results
-                        break  # exit the async for chunk loop
-
-            else:
-                # ==================== NON-STREAMING PATH ====================
-                from core.models.fallback import chat_completions_with_fallback
-
-                if model_manager:
-                    response = await chat_completions_with_fallback(
-                        model_manager,
-                        agent_name=agent_slot,
-                        primary_override=primary_override,
-                        on_switch=_on_fallback_switch,
-                        messages=api_messages,
-                        tools=agent.tools.get_schemas(),
-                        tool_choice="auto",
-                        temperature=temperature,
-                    )
-                else:
-                    response = await client.chat.completions.create(
-                        model=model,
-                        messages=api_messages,
-                        tools=agent.tools.get_schemas(),
-                        tool_choice="auto",
-                        temperature=temperature,
-                    )
-
-                message = response.choices[0].message
-                msg_dict = {"role": "assistant", "content": message.content or ""}
-
-                if message.tool_calls:
-                    msg_dict["tool_calls"] = [
-                        {
-                            "id": tc.id,
-                            "type": tc.type,
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            },
-                        }
-                        for tc in message.tool_calls
-                    ]
-                    messages.append(msg_dict)
-
-                    for tool_call in message.tool_calls:
-                        tool_name = tool_call.function.name
-                        tool_id = tool_call.id
-                        args_raw = tool_call.function.arguments
-
-                        yield ToolCallStartEvent(
-                            tool_name=tool_name,
-                            tool_id=tool_id,
-                            arguments_raw=args_raw,
-                            conversation_id=conversation_id,
-                        )
-
-                        start = time.time()
-                        try:
-                            result = await agent.tools.execute(
-                                tool_call,
-                                conversation_id=conversation_id,
-                                memory=agent.memory,
-                            )
-                            duration = (time.time() - start) * 1000
-
-                            yield ToolCallResultEvent(
-                                tool_name=tool_name,
-                                tool_id=tool_id,
-                                result=result,
-                                duration_ms=duration,
-                                conversation_id=conversation_id,
-                                truncated=len(result) > 200,
-                            )
-                        except Exception as tool_err:
-                            yield ToolCallErrorEvent(
-                                tool_name=tool_name,
-                                tool_id=tool_id,
-                                error=str(tool_err),
-                                conversation_id=conversation_id,
-                            )
-                            result = f"Error: {tool_err}"
-
-                        tool_msg = {
-                            "role": "tool",
-                            "tool_call_id": tool_call.id,
-                            "content": result,
-                        }
-                        messages.append(tool_msg)
-                        await agent.memory.save_message(
-                            conversation_id, "tool", result,
-                            metadata={"tool_name": tool_name}
-                        )
-
-                    continue  # next reasoning iteration
-
-                else:
-                    # Final answer (non-streaming)
-                    final_response = message.content or "No response generated"
-                    messages.append(msg_dict)
-
-                    await agent.memory.save_message(
-                        conversation_id, "assistant", final_response
-                    )
-
-                    yield FinalResponseEvent(
-                        content=final_response,
-                        steps_taken=step_count,
-                        conversation_id=conversation_id,
-                    )
-
-                    await _maybe_self_improve(agent, conversation_id, messages, final_response)
-                    return
-
-        except Exception as e:
-            yield ErrorEvent(
-                error=f"Error during agent step: {str(e)}",
-                error_type="execution",
-                recoverable=False,
+        decision = evaluate_step_budget(
+            step_count=step_count,
+            max_steps=max_steps,
+            extensions_used=step_budget_extensions,
+            messages=messages,
+            task=str(user_input or "")[:2000],
+            policy=StepBudgetPolicy.from_config(agent_config),
+            base_max_steps=base_max_steps,
+        )
+        if decision.extend:
+            prev_max = max_steps
+            max_steps = decision.new_max_steps
+            step_budget_extensions = decision.extensions_used
+            yield MaxStepsExtendedEvent(
+                max_steps=max_steps,
+                previous_max_steps=prev_max,
+                extra_steps=decision.extra_steps,
+                extensions=step_budget_extensions,
+                reason=decision.reason,
                 conversation_id=conversation_id,
             )
-            return
+            yield ThinkingEvent(
+                message=(
+                    f"Step budget extended by {decision.extra_steps} "
+                    f"(now max {max_steps}): still working"
+                ),
+                conversation_id=conversation_id,
+            )
+            continue
 
-      # Inner budget exhausted — health-check before hard stop
-      from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
-
-      decision = evaluate_step_budget(
-          step_count=step_count,
-          max_steps=max_steps,
-          extensions_used=step_budget_extensions,
-          messages=messages,
-          task=str(user_input or "")[:2000],
-          policy=StepBudgetPolicy.from_config(agent_config),
-          base_max_steps=base_max_steps,
-      )
-      if decision.extend:
-          prev_max = max_steps
-          max_steps = decision.new_max_steps
-          step_budget_extensions = decision.extensions_used
-          yield MaxStepsExtendedEvent(
-              max_steps=max_steps,
-              previous_max_steps=prev_max,
-              extra_steps=decision.extra_steps,
-              extensions=step_budget_extensions,
-              reason=decision.reason,
-              conversation_id=conversation_id,
-          )
-          yield ThinkingEvent(
-              message=(
-                  f"Step budget extended by {decision.extra_steps} "
-                  f"(now max {max_steps}): still working"
-              ),
-              conversation_id=conversation_id,
-          )
-          continue
-
-      # Max steps reached (hung / no progress / extension cap)
-      yield MaxStepsReachedEvent(
-          max_steps=max_steps,
-          conversation_id=conversation_id,
-      )
-      timeout_msg = (
-          f"Agent reached maximum steps ({max_steps}). "
-          f"{decision.reason or 'Task may be too complex.'}"
-      )
-      await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
-      return
+        # Max steps reached (hung / no progress / extension cap)
+        yield MaxStepsReachedEvent(
+            max_steps=max_steps,
+            conversation_id=conversation_id,
+        )
+        timeout_msg = (
+            f"Agent reached maximum steps ({max_steps}). "
+            f"{decision.reason or 'Task may be too complex.'}"
+        )
+        await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
+        return
 
 
 async def _maybe_self_improve(
@@ -583,7 +611,9 @@ async def _maybe_self_improve(
             )
 
     # Auto-summarize conversation into episodic memory (LTM)
-    if settings.auto_summarize_conversations and hasattr(agent.memory, 'auto_summarize_conversation'):
+    if settings.auto_summarize_conversations and hasattr(
+        agent.memory, "auto_summarize_conversation"
+    ):
         try:
             await agent.memory.auto_summarize_conversation(
                 conversation_id=conversation_id,

--- a/core/context/manager.py
+++ b/core/context/manager.py
@@ -91,6 +91,10 @@ class ContextManager:
     ) -> int:
         if not messages:
             return 0
+        # Count after tool-output caps so a single multi-MB dump cannot report 600%+.
+        from core.memory.tool_content import sanitize_messages_tool_content
+
+        messages = sanitize_messages_tool_content(messages)
         if not conversation_id:
             return self.token_counter.count_message_tokens(messages)
 
@@ -254,22 +258,27 @@ class ContextManager:
         Returns:
             Tuple of (compressed_messages, was_compressed).
         """
+        from core.memory.tool_content import sanitize_messages_tool_content
+        from core.profile.soul import strip_soul_messages
+
+        # Drop multi-MB tool payloads before keep-recent / summarization.
+        original = messages
+        messages = sanitize_messages_tool_content(messages)
+        sanitized_only = messages is not original
+
         if not self.compressor:
             logger.warning("ContextCompressor not available — cannot compress")
-            return messages, False
+            return messages, sanitized_only
 
         keep = keep_recent if keep_recent is not None else self._adaptive_keep_recent(messages)
         if len(messages) <= keep:
-            return messages, False
+            # Short session with a runaway tool dump: capping alone is the fix.
+            return messages, sanitized_only
 
         tokens_before = self.token_counter.count_message_tokens(messages)
 
-        from core.profile.soul import strip_soul_messages
-
         to_compress = strip_soul_messages(messages)
-        compressed, summary = await self.compressor.compress(
-            to_compress, keep_recent=keep
-        )
+        compressed, summary = await self.compressor.compress(to_compress, keep_recent=keep)
 
         if not summary.strip():
             return messages, False
@@ -323,8 +332,11 @@ class ContextManager:
         Returns:
             Tuple of (messages, was_compressed).
         """
-        current = messages
-        any_compressed = False
+        from core.memory.tool_content import sanitize_messages_tool_content
+
+        original = messages
+        current = sanitize_messages_tool_content(messages)
+        any_compressed = current is not original
 
         for round_idx in range(_MAX_AUTO_COMPRESS_ROUNDS):
             usage = self.get_usage(
@@ -334,7 +346,10 @@ class ContextManager:
             )
             percent = usage["percent"]
 
-            if percent >= self.warning_threshold * 100 and percent < self.compression_threshold * 100:
+            if (
+                percent >= self.warning_threshold * 100
+                and percent < self.compression_threshold * 100
+            ):
                 self._emit_warning_event(usage, level="warning")
                 break
 
@@ -375,13 +390,15 @@ class ContextManager:
         try:
             from core.agent_events import ContextCompressedEvent
 
-            self.event_bus.emit(ContextCompressedEvent(
-                original_tokens=tokens_before,
-                compressed_tokens=tokens_after,
-                messages_before=messages_before,
-                messages_after=messages_after,
-                summary_preview=summary_preview,
-            ))
+            self.event_bus.emit(
+                ContextCompressedEvent(
+                    original_tokens=tokens_before,
+                    compressed_tokens=tokens_after,
+                    messages_before=messages_before,
+                    messages_after=messages_after,
+                    summary_preview=summary_preview,
+                )
+            )
         except Exception as e:
             logger.warning(f"Failed to emit ContextCompressedEvent: {e}")
 
@@ -393,11 +410,13 @@ class ContextManager:
         try:
             from core.agent_events import ContextWarningEvent
 
-            self.event_bus.emit(ContextWarningEvent(
-                usage_percent=usage["percent"],
-                tokens_used=usage["used"],
-                tokens_total=usage["total"],
-                level=level,
-            ))
+            self.event_bus.emit(
+                ContextWarningEvent(
+                    usage_percent=usage["percent"],
+                    tokens_used=usage["used"],
+                    tokens_total=usage["total"],
+                    level=level,
+                )
+            )
         except Exception as e:
             logger.warning(f"Failed to emit ContextWarningEvent: {e}")

--- a/core/di/container.py
+++ b/core/di/container.py
@@ -55,8 +55,10 @@ def resolve_gateway_runtime_config() -> HolixRuntimeConfig:
 
 def resolve_runtime_config(profile: ProfileConfig | None = None) -> HolixRuntimeConfig:
     """Build runtime config from env settings and optional CLI profile."""
+    from core.di.runtime_config import apply_unattended_policy
+
     if profile is None:
-        return HolixRuntimeConfig.from_settings()
+        return apply_unattended_policy(HolixRuntimeConfig.from_settings())
 
     base = HolixRuntimeConfig.from_profile(profile)
 
@@ -66,7 +68,7 @@ def resolve_runtime_config(profile: ProfileConfig | None = None) -> HolixRuntime
         model_manager = ModelManager(profile)
         model_config = model_manager.get_default_model_config()
         if model_config:
-            return base.with_overrides(
+            base = base.with_overrides(
                 model=model_config.model,
                 base_url=model_config.base_url,
                 api_key=model_config.api_key,
@@ -75,7 +77,7 @@ def resolve_runtime_config(profile: ProfileConfig | None = None) -> HolixRuntime
     except Exception:
         pass
 
-    return base
+    return apply_unattended_policy(base)
 
 
 async def create_agent(

--- a/core/di/runtime_config.py
+++ b/core/di/runtime_config.py
@@ -150,9 +150,7 @@ class HolixRuntimeConfig:
             subagent_max_concurrent=s.subagent_max_concurrent,
             subagent_process_timeout=s.subagent_process_timeout,
             subagent_heartbeat_interval=s.subagent_heartbeat_interval,
-            subagent_supervisor_enabled=bool(
-                getattr(s, "subagent_supervisor_enabled", True)
-            ),
+            subagent_supervisor_enabled=bool(getattr(s, "subagent_supervisor_enabled", True)),
             enable_meta_agent=s.enable_meta_agent,
             enable_self_refinement=s.enable_self_refinement,
             max_refinement_iterations=s.max_refinement_iterations,
@@ -160,13 +158,9 @@ class HolixRuntimeConfig:
             enable_evolution=s.enable_evolution,
             evolution_auto_learn=s.evolution_auto_learn,
             agent_pipeline=str(getattr(s, "agent_pipeline", "classic") or "classic"),
-            max_steps_extend_enabled=bool(
-                getattr(s, "max_steps_extend_enabled", True)
-            ),
+            max_steps_extend_enabled=bool(getattr(s, "max_steps_extend_enabled", True)),
             max_steps_extend_by=int(getattr(s, "max_steps_extend_by", 30) or 30),
-            max_steps_max_extensions=int(
-                getattr(s, "max_steps_max_extensions", 3) or 3
-            ),
+            max_steps_max_extensions=int(getattr(s, "max_steps_max_extensions", 3) or 3),
             max_steps_hard_cap=int(getattr(s, "max_steps_hard_cap", 0) or 0),
             auto_allow_threshold=s.auto_allow_threshold,
             non_interactive=s.non_interactive,
@@ -253,9 +247,7 @@ class HolixRuntimeConfig:
         if getattr(profile, "subagent_max_concurrent", None) is not None:
             overrides["subagent_max_concurrent"] = profile.subagent_max_concurrent
         if getattr(profile, "subagent_supervisor_enabled", None) is not None:
-            overrides["subagent_supervisor_enabled"] = bool(
-                profile.subagent_supervisor_enabled
-            )
+            overrides["subagent_supervisor_enabled"] = bool(profile.subagent_supervisor_enabled)
         if getattr(profile, "enable_meta_agent", None) is not None:
             overrides["enable_meta_agent"] = bool(profile.enable_meta_agent)
         if getattr(profile, "enable_self_refinement", None) is not None:
@@ -265,9 +257,7 @@ class HolixRuntimeConfig:
 
             overrides["agent_pipeline"] = normalize_pipeline(str(profile.agent_pipeline))
         if getattr(profile, "max_steps_extend_enabled", None) is not None:
-            overrides["max_steps_extend_enabled"] = bool(
-                profile.max_steps_extend_enabled
-            )
+            overrides["max_steps_extend_enabled"] = bool(profile.max_steps_extend_enabled)
         if getattr(profile, "search", None):
             overrides["search"] = profile.search
         overrides["workspace_jail_enabled"] = bool(
@@ -299,3 +289,38 @@ class HolixRuntimeConfig:
         """Return a copy with selective field overrides."""
         valid = {k: v for k, v in kwargs.items() if v is not None}
         return replace(self, **valid)
+
+
+def unattended_requested() -> bool:
+    """True when env or Settings asks for unattended (bench/CI) tool policy."""
+    import os
+
+    raw = (
+        (os.environ.get("HOLIX_UNATTENDED") or os.environ.get("HOLIX_BENCH") or "").strip().lower()
+    )
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    try:
+        from config import Settings
+
+        return bool(getattr(Settings(_env_file=None), "holix_unattended", False))
+    except Exception:
+        return False
+
+
+def apply_unattended_policy(cfg: HolixRuntimeConfig) -> HolixRuntimeConfig:
+    """Force no interactive tool/plan confirmations for benches / CI.
+
+    Sets ``auto_allow_threshold=high`` (all tool risks auto-run) and disables
+    plan review. Does **not** set ``non_interactive`` — that would *deny*
+    high-risk tools instead of approving them.
+
+    ActionGuard still logs ``auto_allowed`` at INFO (audit only, no UI).
+    """
+    if not unattended_requested():
+        return cfg
+    return cfg.with_overrides(
+        auto_allow_threshold="high",
+        plan_review_enabled=False,
+        non_interactive=False,
+    )

--- a/core/llm/response_text.py
+++ b/core/llm/response_text.py
@@ -433,6 +433,36 @@ def _ui_locale(profile_name: str | None) -> str:
     return "en"
 
 
+def short_answer_from_reasoning(reasoning: str) -> str:
+    """Extract an explicit short answer from CoT when ``content`` is empty.
+
+    Only recovers **clear** terminal answers (``Answer: 42``, pure numbers).
+    Generic monologue lines are left empty so callers can retry.
+    """
+    lines = [ln.strip() for ln in (reasoning or "").splitlines() if ln.strip()]
+    if not lines:
+        return ""
+    for line in reversed(lines[-16:]):
+        clean = line.strip().strip("*`\"'“”«»")
+        if not clean or len(clean) > 80:
+            continue
+        # "answer is 42" / "Answer: Paris" / "Ответ: 42" / "Результат = 221"
+        m = re.search(
+            r"(?:final\s+)?(?:answer|result|output|ответ|результат)"
+            r"(?:\s+is)?\s*[:=\-—]?\s*(.+)$",
+            clean,
+            flags=re.IGNORECASE,
+        )
+        if m:
+            candidate = m.group(1).strip().strip("*`\"'“”«».")
+            if candidate and len(candidate) <= 80:
+                return candidate
+        # Bare numeric / arithmetic result line
+        if re.fullmatch(r"[-+]?\d+(?:[.,]\d+)?", clean):
+            return clean
+    return ""
+
+
 def resolve_assistant_text(
     *,
     content: str = "",
@@ -453,6 +483,13 @@ def resolve_assistant_text(
 
     reasoning = (reasoning_content or "").strip()
     if not text and reasoning:
+        recovered = short_answer_from_reasoning(reasoning)
+        if recovered:
+            logger.info(
+                "Recovered short answer from reasoning-only response (model=%s)",
+                model,
+            )
+            return recovered
         # Do NOT surface a user-facing error here. Callers treat empty as
         # "retry / keep going" (plan step nudge, non-streaming retry). Emitting
         # llm.reasoning_only as the final answer aborted multi-step work while
@@ -471,9 +508,7 @@ def resolve_assistant_text(
             if is_pathological_repetition(text, min_repeats=3):
                 collapsed = collapse_repetitive_text(text) or text
                 # Never ship multi-KB monologue spam even if detectors disagree.
-                if len(collapsed) > 400 and is_pathological_repetition(
-                    collapsed, min_repeats=3
-                ):
+                if len(collapsed) > 400 and is_pathological_repetition(collapsed, min_repeats=3):
                     collapsed = _hard_trim_loop(collapsed)
                 return collapsed
             return text

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -14,9 +14,10 @@ from core.mcp.uvx_compat import normalize_mcp_servers_uvx
 logger = logging.getLogger(__name__)
 
 try:
-    from mcp import ClientSession, StdioServerParameters
     from mcp.client.sse import sse_client
     from mcp.client.stdio import stdio_client
+
+    from mcp import ClientSession, StdioServerParameters
 
     MCP_AVAILABLE = True
 except Exception:  # pragma: no cover

--- a/core/memory/conversation.py
+++ b/core/memory/conversation.py
@@ -99,6 +99,12 @@ class ConversationStore:
         content: str,
         metadata: dict[str, Any] | None = None,
     ) -> int:
+        # Hard cap tool payloads at the storage boundary (classic loop, graph, etc.)
+        if role == "tool" and isinstance(content, str):
+            from core.memory.tool_content import truncate_tool_content_for_memory
+
+            content = truncate_tool_content_for_memory(content)
+
         async with connect_aiosqlite(self.db_path) as db:
             cursor = await db.execute(
                 """INSERT INTO conversations (conversation_id, role, content, metadata)
@@ -164,7 +170,10 @@ class ConversationStore:
                         pass
                 messages.append(msg)
 
-            return messages
+            # Cap legacy oversized tool rows so reloads do not blow the context window.
+            from core.memory.tool_content import sanitize_messages_tool_content
+
+            return sanitize_messages_tool_content(messages)
 
     async def search(
         self,
@@ -188,11 +197,15 @@ class ConversationStore:
             if results["documents"] and results["documents"][0]:
                 for i, doc in enumerate(results["documents"][0]):
                     metadata = results["metadatas"][0][i] if results["metadatas"] else {}
-                    memories.append({
-                        "content": doc,
-                        "metadata": metadata,
-                        "distance": results["distances"][0][i] if results.get("distances") else None,
-                    })
+                    memories.append(
+                        {
+                            "content": doc,
+                            "metadata": metadata,
+                            "distance": results["distances"][0][i]
+                            if results.get("distances")
+                            else None,
+                        }
+                    )
             return _filter_searchable_hits(memories, top_k=top_k)
         except Exception as e:
             logger.warning("Error during semantic search: %s", e)
@@ -208,9 +221,13 @@ class ConversationStore:
                 "DELETE FROM conversations WHERE conversation_id = ?",
                 (conversation_id,),
             )
+            from core.memory.tool_content import truncate_tool_content_for_memory
+
             for msg in new_messages:
                 role = msg.get("role", "user")
                 content = msg.get("content", "")
+                if role == "tool" and isinstance(content, str):
+                    content = truncate_tool_content_for_memory(content)
                 metadata = msg.get("metadata")
                 metadata_json = json.dumps(metadata) if metadata else None
                 await db.execute(

--- a/core/memory/tool_content.py
+++ b/core/memory/tool_content.py
@@ -1,9 +1,15 @@
-"""Limits for tool output stored in conversation memory."""
+"""Limits for tool output stored in conversation memory / LLM context."""
 
 from __future__ import annotations
 
+from typing import Any
+
+# SQLite + session reload cap (per tool message).
 DEFAULT_TOOL_MEMORY_MAX_CHARS = 16_384
+# In-graph / classic loop message list sent to the LLM.
 GRAPH_TOOL_MAX_CHARS = 6_000
+# Hard cap at tool execution (stdout+stderr) before any host path sees it.
+TERMINAL_OUTPUT_MAX_CHARS = 32_768
 
 
 def _prepare_tool_content(content: str) -> str:
@@ -25,10 +31,7 @@ def truncate_tool_content_for_memory(
     content = _prepare_tool_content(content)
     if not content or len(content) <= max_chars:
         return content
-    return (
-        content[:max_chars]
-        + f"\n\n… [truncated for memory; total {len(content):,} chars]"
-    )
+    return content[:max_chars] + f"\n\n… [truncated for memory; total {len(content):,} chars]"
 
 
 def truncate_tool_content_for_graph(
@@ -41,7 +44,48 @@ def truncate_tool_content_for_graph(
     if not content or len(content) <= max_chars:
         return content
     return (
-        content[:max_chars]
-        + f"\n\n… [truncated for context; total {len(content):,} chars; "
+        content[:max_chars] + f"\n\n… [truncated for context; total {len(content):,} chars; "
         "re-read file if you need more]"
     )
+
+
+def truncate_terminal_output(
+    content: str,
+    *,
+    max_chars: int = TERMINAL_OUTPUT_MAX_CHARS,
+) -> str:
+    """Cap raw terminal stdout/stderr (defense in depth before hosts store it)."""
+    text = content or ""
+    if len(text) <= max_chars:
+        return text
+    return (
+        text[:max_chars] + f"\n\n… [truncated terminal output; total {len(text):,} chars; "
+        "narrow the command or use read_file for specific paths]"
+    )
+
+
+def sanitize_messages_tool_content(
+    messages: list[dict[str, Any]],
+    *,
+    max_chars: int = GRAPH_TOOL_MAX_CHARS,
+) -> list[dict[str, Any]]:
+    """Return a copy of *messages* with oversized tool/system blobs capped.
+
+    Used when loading history into the agent and before token usage / compress
+    so a single runaway ``run_terminal_command`` cannot push context to 600%+.
+    """
+    if not messages:
+        return messages
+    out: list[dict[str, Any]] = []
+    changed = False
+    for msg in messages:
+        role = str(msg.get("role") or "")
+        content = msg.get("content")
+        if role == "tool" and isinstance(content, str) and len(content) > max_chars:
+            new_msg = dict(msg)
+            new_msg["content"] = truncate_tool_content_for_graph(content, max_chars=max_chars)
+            out.append(new_msg)
+            changed = True
+        else:
+            out.append(msg)
+    return out if changed else messages

--- a/core/search/providers.py
+++ b/core/search/providers.py
@@ -44,9 +44,14 @@ async def search_duckduckgo(
 
     async with aiohttp.ClientSession() as session:
         async with session.get(url, params=params, timeout=aiohttp.ClientTimeout(total=12)) as resp:
-            if resp.status != 200:
+            # Instant Answer API may return 200 or 202 with JSON/JS content-type.
+            if resp.status not in (200, 202):
                 raise RuntimeError(f"DuckDuckGo HTTP {resp.status}")
-            data = await resp.json()
+            try:
+                data = await resp.json(content_type=None)
+            except Exception:
+                raw = await resp.text()
+                data = json.loads(raw)
 
     if data.get("Abstract"):
         hits.append(
@@ -121,7 +126,9 @@ async def search_searxng(
         url = str(item.get("url") or "").strip()
         snippet = str(item.get("content") or item.get("snippet") or "").strip()
         if title or url:
-            hits.append(SearchHit(title=title or url, url=url, snippet=snippet[:500], source="searxng"))
+            hits.append(
+                SearchHit(title=title or url, url=url, snippet=snippet[:500], source="searxng")
+            )
 
     return hits
 
@@ -183,10 +190,7 @@ async def search_firecrawl(
         title = str(item.get("title") or "").strip()
         url = str(item.get("url") or "").strip()
         snippet = str(
-            item.get("description")
-            or item.get("markdown")
-            or item.get("snippet")
-            or ""
+            item.get("description") or item.get("markdown") or item.get("snippet") or ""
         ).strip()
         if title or url:
             hits.append(

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -95,11 +95,7 @@ def _blocked_sensitive_path_access(
     # Always allow the configured workspace, even when jail is disabled.
     allow_under = workspace_root if workspace_root else None
     if references_holix_profiles(command, allow_under=allow_under):
-        ws_hint = (
-            f" Own workspace is allowed: `{workspace_root}`."
-            if workspace_root
-            else ""
-        )
+        ws_hint = f" Own workspace is allowed: `{workspace_root}`." if workspace_root else ""
         return (
             True,
             "Access to Holix profile directories and secrets is not allowed "
@@ -292,10 +288,7 @@ class TerminalTool(BaseTool):
                 "next dev",
                 "gunicorn ",
             )
-        ) or (
-            "python" in cmd_l
-            and any(x in cmd_l for x in ("bot.py", "polling", "getupdates"))
-        ):
+        ) or ("python" in cmd_l and any(x in cmd_l for x in ("bot.py", "polling", "getupdates"))):
             if not any(x in cmd_l for x in ("&& echo", "timeout ", "pkill", "pgrep", "ps ")):
                 return (
                     "Error: This looks like a **long-running** bot/server. "
@@ -314,9 +307,7 @@ class TerminalTool(BaseTool):
             if not allowed:
                 return f"Error: Command blocked by safety policy. {reason}"
         else:
-            blocked_danger, danger_reason = command_whitelist.blocks_dangerous_patterns(
-                command
-            )
+            blocked_danger, danger_reason = command_whitelist.blocks_dangerous_patterns(command)
             if blocked_danger:
                 return f"Error: Command blocked by safety policy. {danger_reason}"
 
@@ -354,9 +345,7 @@ class TerminalTool(BaseTool):
                 return f"Error: Command blocked. {jail_reason}"
 
             if jail and root is None:
-                return (
-                    "Error: Workspace jail is enabled but no workspace root is configured."
-                )
+                return "Error: Workspace jail is enabled but no workspace root is configured."
 
             cwd: str | None = str(root) if root is not None else None
             use_shell = command_needs_shell(command)
@@ -392,11 +381,14 @@ class TerminalTool(BaseTool):
                     process, timeout=float(timeout or 30)
                 )
 
-                output = sanitize_paths_in_text(
-                    stdout.decode("utf-8", errors="replace")
+                from core.memory.tool_content import truncate_terminal_output
+
+                output = truncate_terminal_output(
+                    sanitize_paths_in_text(stdout.decode("utf-8", errors="replace"))
                 )
-                error = sanitize_paths_in_text(
-                    stderr.decode("utf-8", errors="replace")
+                error = truncate_terminal_output(
+                    sanitize_paths_in_text(stderr.decode("utf-8", errors="replace")),
+                    max_chars=8_192,
                 )
                 return _format_process_result(
                     returncode=process.returncode or 0,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ Tool confirmation UX, context overflow from huge tool dumps, reasoning-only answ
 - **TUI confirmation modal hang** — `/1`–`/4` or agent stop while a modal is open now releases the lock and pumps the next queued confirmation.
 - **Runaway tool output** — cap terminal stdout/stderr, graph tool messages, and conversation memory; sanitize oversized tool rows on reload, token usage, and compress so one dump cannot report 600%+ context.
 - **DuckDuckGo Instant Answer** — accept HTTP 202 and parse JSON regardless of content-type.
+- **Wheel metadata vs twine** — pin hatchling `<1.30` so builds keep Core-Metadata 2.4 (twine 6.2 rejects 2.5).
 
 ### Tests
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+## 1.0.8 — 2026-08-14
+
+Tool confirmation UX, context overflow from huge tool dumps, reasoning-only answers, and test harnesses.
+
+### Added
+
+- **Confirmation policy on the TUI** — status and ready banner show `auto_allow_threshold` / `non_interactive` so it is clear why the confirmation modal may not appear.
+- **Unattended / bench policy** — `HOLIX_UNATTENDED` / `HOLIX_BENCH` force `auto_allow_threshold=high` and disable plan review without setting `non_interactive` (which would deny high-risk tools).
+- **Env aliases** — `AUTO_ALLOW_THRESHOLD`, `HOLIX_AUTO_ALLOW_THRESHOLD`, `NON_INTERACTIVE`, `HOLIX_NON_INTERACTIVE` documented in `.env.example`.
+- **Reasoning-only short answers** — recover explicit `Answer:` / numeric results when the model returns empty `content`.
+- **User-case journeys** — `tests/user_cases` (scripted LLM + real tools) and `scripts/test_tui.sh` / `scripts/test_live_llm.sh`.
+- **Release skill** — «сделай релиз» / `/make-release` opens a PR, waits for GitHub CI, merges to `main`, and tags the next version.
+
+### Fixed
+
+- **TUI confirmation modal hang** — `/1`–`/4` or agent stop while a modal is open now releases the lock and pumps the next queued confirmation.
+- **Runaway tool output** — cap terminal stdout/stderr, graph tool messages, and conversation memory; sanitize oversized tool rows on reload, token usage, and compress so one dump cannot report 600%+ context.
+- **DuckDuckGo Instant Answer** — accept HTTP 202 and parse JSON regardless of content-type.
+
+### Tests
+
+- ConfirmationPresenter queue + external resolve.
+- `sanitize_messages_tool_content` bounds token usage.
+- Recover short answers from reasoning.
+- User-case, TUI Pilot, and live-LLM harnesses (`live_llm` stays out of CI).
+
 ## 1.0.7 — 2026-08-08
 
 Terminal safety when whitelist is off, and SDD archive merge gates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["hatchling"]
+# hatchling 1.30+ writes Core-Metadata 2.5; twine 6.2.0 cannot validate it.
+requires = ["hatchling>=1.26,<1.30"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.7"
+version = "1.0.8"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"
@@ -154,7 +154,11 @@ python_functions = "test_*"
 markers = [
     "unit: fast isolated tests (default)",
     "integration: multi-component or graph tests with mocks",
+    "user_case: product journey via UserCaseHarness (scripted LLM + real tools)",
+    "live_llm: real provider E2E under tests/live_llm (run via scripts/test_live_llm.sh)",
+    "tui: full HolixCodeApp launch via Textual Pilot (tests/tui)",
     "llm: requires a live LLM provider (skipped in CI by default)",
+    "slow: optional long-running journeys (excluded from default local quick runs)",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning:chromadb.*",

--- a/scripts/test_live_llm.sh
+++ b/scripts/test_live_llm.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run live LLM end-to-end scenarios (real provider traffic).
+# Excluded from default CI (marker: live_llm / llm).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export HOLIX_LIVE_LLM="${HOLIX_LIVE_LLM:-1}"
+export HOLIX_AGENT_EXTENSIONS_OFF="${HOLIX_AGENT_EXTENSIONS_OFF:-1}"
+
+# Prefer Holix LiteLLM profile defaults when env not set
+if [[ -z "${HOLIX_LIVE_BASE_URL:-}" && -f "${HOME}/.holix/global/.env" ]]; then
+  # shellcheck disable=SC1090
+  set -a && source "${HOME}/.holix/global/.env" && set +a
+  if [[ -n "${LITELLM_API_BASE:-}" && -n "${LITELLM_API_KEY:-}" ]]; then
+    export HOLIX_LIVE_BASE_URL="${HOLIX_LIVE_BASE_URL:-https://llm.it-rs.ru/v1}"
+    export HOLIX_LIVE_API_KEY="${HOLIX_LIVE_API_KEY:-$LITELLM_API_KEY}"
+    export HOLIX_LIVE_MODEL="${HOLIX_LIVE_MODEL:-smart}"
+  fi
+fi
+
+echo "Live LLM tests — provider probe uses HOLIX_LIVE_* or holix settings"
+echo "  HOLIX_LIVE_MODEL=${HOLIX_LIVE_MODEL:-"(from settings)"}"
+echo "  HOLIX_LIVE_BASE_URL=${HOLIX_LIVE_BASE_URL:-"(from settings)"}"
+echo "  HOLIX_LIVE_KEEP_ARTIFACTS=${HOLIX_LIVE_KEEP_ARTIFACTS:-0}"
+echo
+
+# Browser env for live_42 (best-effort)
+uv run python -m playwright install chromium >/dev/null 2>&1 || true
+
+exec uv run python -m pytest tests/live_llm -m live_llm -vv --tb=short "$@"

--- a/scripts/test_tui.sh
+++ b/scripts/test_tui.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Full-launch Holix TUI tests (Textual Pilot, mock agent).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+export HOLIX_AGENT_EXTENSIONS_OFF="${HOLIX_AGENT_EXTENSIONS_OFF:-1}"
+exec uv run python -m pytest tests/tui -m tui -v --tb=short "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,16 +27,46 @@ def _unique_chroma_collection(request: pytest.FixtureRequest) -> str:
 
 
 def pytest_collection_modifyitems(config, items):
-    """Auto-apply unit/integration/llm markers from path and names."""
+    """Auto-apply unit/integration/llm/user_case markers from path and names."""
     for item in items:
         if item.get_closest_marker("llm"):
             continue
+
+        nodeid = item.nodeid
+        in_live_llm = "live_llm/" in nodeid or "live_llm\\" in nodeid
+        if in_live_llm or item.get_closest_marker("live_llm"):
+            if not item.get_closest_marker("live_llm"):
+                item.add_marker(pytest.mark.live_llm)
+            if not item.get_closest_marker("llm"):
+                item.add_marker(pytest.mark.llm)
+            continue
+
+        in_tui = (
+            "tests/tui/" in nodeid
+            or "tests\\tui\\" in nodeid
+            or "/tui/" in nodeid
+            or "\\tui\\" in nodeid
+        )
+        if in_tui or item.get_closest_marker("tui"):
+            if not item.get_closest_marker("tui"):
+                item.add_marker(pytest.mark.tui)
+            if not item.get_closest_marker("integration"):
+                item.add_marker(pytest.mark.integration)
+            continue
+
+        in_user_cases = "user_cases/" in nodeid or "user_cases\\" in nodeid
+        if in_user_cases or item.get_closest_marker("user_case"):
+            if not item.get_closest_marker("user_case"):
+                item.add_marker(pytest.mark.user_case)
+            if not item.get_closest_marker("integration"):
+                item.add_marker(pytest.mark.integration)
+            continue
+
         if item.get_closest_marker("integration"):
             continue
         if item.get_closest_marker("unit"):
             continue
 
-        nodeid = item.nodeid
         if "test_graph_e2e" in nodeid or "TestRunAgentLoopWithMocks" in nodeid:
             item.add_marker(pytest.mark.integration)
         elif "llm" in item.name.lower():
@@ -91,9 +121,8 @@ def tools_registry():
 @pytest.fixture
 def skills_manager(temp_dir):
     """Create skills manager with temp directory."""
-    from core.skills.manager import SkillsManager
-
     from config import settings
+    from core.skills.manager import SkillsManager
 
     original_skills_dir = settings.skills_dir
     settings.skills_dir = f"{temp_dir}/skills"
@@ -121,6 +150,8 @@ def gateway_client(gateway_auth_headers, monkeypatch: pytest.MonkeyPatch):
     import api.deps
     import api.gateway
     import api.state
+    from fastapi.testclient import TestClient
+
     from core.gateway.companions import CompanionManager
     from core.gateway.locks import GatewayLocks
     from core.gateway.profile_registry import ProfileAgentRegistry
@@ -129,7 +160,6 @@ def gateway_client(gateway_auth_headers, monkeypatch: pytest.MonkeyPatch):
     from core.gateway.sessions_store import SessionsStore
     from core.gateway.types import HostProfileName
     from core.security.auth import APIKeyManager, RateLimiter
-    from fastapi.testclient import TestClient
 
     mock_agent = AsyncMock()
     mock_agent._initialized = True
@@ -177,10 +207,7 @@ def gateway_client(gateway_auth_headers, monkeypatch: pytest.MonkeyPatch):
         async def get(self, dependency_type, component: str | None = ""):
             if dependency_type in self._overrides:
                 return self._overrides[dependency_type]
-            if (
-                dependency_type is APIKeyManager
-                and api.state.api_key_manager is not None
-            ):
+            if dependency_type is APIKeyManager and api.state.api_key_manager is not None:
                 return api.state.api_key_manager
             return await self._base.get(dependency_type, component)
 
@@ -246,6 +273,7 @@ def _reset_env_loader_state() -> None:
 def _isolated_holix_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep profile paths off the developer/CI machine (~/.holix)."""
     import cli.core as cli_core
+
     from core.profile import service as profile_service
 
     holix_home = tmp_path / ".holix"
@@ -269,7 +297,9 @@ def _isolated_holix_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.fixture(autouse=True)
-def _encryption_mode_for_crypto_tests(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest):
+def _encryption_mode_for_crypto_tests(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+):
     """Default tests to HOLIX_ENCRYPTION_MODE=on; policy tests control their own mode."""
     if request.node.path.name == "test_encryption_policy.py":
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,8 +121,9 @@ def tools_registry():
 @pytest.fixture
 def skills_manager(temp_dir):
     """Create skills manager with temp directory."""
-    from config import settings
     from core.skills.manager import SkillsManager
+
+    from config import settings
 
     original_skills_dir = settings.skills_dir
     settings.skills_dir = f"{temp_dir}/skills"
@@ -150,8 +151,6 @@ def gateway_client(gateway_auth_headers, monkeypatch: pytest.MonkeyPatch):
     import api.deps
     import api.gateway
     import api.state
-    from fastapi.testclient import TestClient
-
     from core.gateway.companions import CompanionManager
     from core.gateway.locks import GatewayLocks
     from core.gateway.profile_registry import ProfileAgentRegistry
@@ -160,6 +159,7 @@ def gateway_client(gateway_auth_headers, monkeypatch: pytest.MonkeyPatch):
     from core.gateway.sessions_store import SessionsStore
     from core.gateway.types import HostProfileName
     from core.security.auth import APIKeyManager, RateLimiter
+    from fastapi.testclient import TestClient
 
     mock_agent = AsyncMock()
     mock_agent._initialized = True
@@ -273,7 +273,6 @@ def _reset_env_loader_state() -> None:
 def _isolated_holix_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep profile paths off the developer/CI machine (~/.holix)."""
     import cli.core as cli_core
-
     from core.profile import service as profile_service
 
     holix_home = tmp_path / ".holix"

--- a/tests/live_llm/README.md
+++ b/tests/live_llm/README.md
@@ -1,0 +1,68 @@
+# Live LLM scenarios
+
+Real provider calls (not `ScriptedLLM`). Artifacts go under per-test temp dirs and are **deleted** after each test unless `HOLIX_LIVE_KEEP_ARTIFACTS=1`.
+
+## Run
+
+```bash
+# recommended
+./scripts/test_live_llm.sh
+
+# equivalent
+HOLIX_LIVE_LLM=1 uv run python -m pytest tests/live_llm -m live_llm -vv --tb=short
+```
+
+Default CI (`pytest -m "not llm"`) **never** runs these.
+
+## Provider config
+
+Priority:
+
+1. `HOLIX_LIVE_MODEL` / `HOLIX_LIVE_BASE_URL` / `HOLIX_LIVE_API_KEY`
+2. Holix `settings` (`model`, `base_url`, `api_key` from env / `.env`)
+3. If `HOLIX_LIVE_LLM=1` and nothing else: Ollama defaults `http://localhost:11434/v1`
+
+Examples:
+
+```bash
+# Ollama
+export HOLIX_LIVE_MODEL=llama3.2
+export HOLIX_LIVE_BASE_URL=http://localhost:11434/v1
+export HOLIX_LIVE_API_KEY=ollama
+./scripts/test_live_llm.sh
+
+# OpenAI-compatible
+export HOLIX_LIVE_MODEL=gpt-4o-mini
+export HOLIX_LIVE_BASE_URL=https://api.openai.com/v1
+export HOLIX_LIVE_API_KEY=sk-...
+./scripts/test_live_llm.sh -k "live_01 or live_11"
+```
+
+Session starts with a **probe** (`PONG`). If unreachable → skip (or fail when `HOLIX_LIVE_LLM=1`).
+
+## Options
+
+| Env | Meaning |
+|-----|---------|
+| `HOLIX_LIVE_LLM=1` | Force run (fail if probe fails) |
+| `HOLIX_LIVE_LLM=0` | Force skip |
+| `HOLIX_LIVE_KEEP_ARTIFACTS=1` | Keep workspace copy under tmp artifacts (pytest tmp path) |
+| `-k live_30` | Run subset by name |
+| `-m "live_llm and not slow"` | Skip web/browser slow tests |
+
+## Coverage (~30 tests)
+
+| Group | IDs | Topics |
+|-------|-----|--------|
+| Q&A | 01–05 | math, knowledge, RU, multi-turn, JSON |
+| Files | 10–15 | read/write/list/edit multi-file |
+| Terminal / confirm | 20–24 | echo, dirs, allow/deny, block `rm -rf` |
+| Projects | 30–35 | Python app, FastAPI stub, CLI, JSON, plan mode, refactor |
+| Web / browser | 40–43 | search, research report, optional Playwright |
+| Code / hybrid | 50–55 | explain, bugfix, hybrid, logs, math, Dockerfile |
+
+## Notes
+
+- Workspace jail + isolated `data/` / DBs per test; wiped in fixture teardown.
+- Meta-agent, reflexion, subagents, MCP off for cost/stability.
+- Live answers are flaky by nature — asserts use soft keyword checks + filesystem side effects.

--- a/tests/live_llm/__init__.py
+++ b/tests/live_llm/__init__.py
@@ -1,0 +1,10 @@
+"""Live LLM end-to-end scenarios (real provider calls).
+
+Run only via::
+
+    ./scripts/test_live_llm.sh
+    # or
+    uv run python -m pytest tests/live_llm -m live_llm
+
+Requires a reachable OpenAI-compatible endpoint (see ``tests/live_llm/README.md``).
+"""

--- a/tests/live_llm/conftest.py
+++ b/tests/live_llm/conftest.py
@@ -1,0 +1,173 @@
+"""Fixtures for live LLM scenarios."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from tests.live_llm.harness import LiveHarness
+from tests.live_llm.provider import (
+    live_llm_forced_off,
+    live_llm_forced_on,
+    probe_provider,
+    resolve_live_provider,
+)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Always tag live_llm path as live_llm + llm (excluded from default CI)."""
+    for item in items:
+        if "live_llm/" in item.nodeid or "live_llm\\" in item.nodeid:
+            if not item.get_closest_marker("live_llm"):
+                item.add_marker(pytest.mark.live_llm)
+            if not item.get_closest_marker("llm"):
+                item.add_marker(pytest.mark.llm)
+
+
+@pytest.fixture(scope="session")
+def live_provider():
+    if live_llm_forced_off():
+        pytest.skip("HOLIX_LIVE_LLM is off")
+
+    provider = resolve_live_provider()
+    if provider is None:
+        pytest.skip(
+            "No live LLM config. Set HOLIX_LIVE_MODEL + HOLIX_LIVE_BASE_URL "
+            "(and HOLIX_LIVE_API_KEY if needed), or configure holix settings, "
+            "then run: ./scripts/test_live_llm.sh"
+        )
+    return provider
+
+
+@pytest_asyncio.fixture(scope="session")
+async def live_provider_ready(live_provider):
+    err = await probe_provider(live_provider, timeout_s=120.0)
+    if err:
+        if live_llm_forced_on():
+            pytest.fail(f"Live LLM forced on but probe failed: {err}")
+        pytest.skip(f"Live LLM probe failed ({live_provider.source}): {err}")
+    return live_provider
+
+
+@pytest_asyncio.fixture
+async def live_harness(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, live_provider_ready):
+    """Isolated live agent; deletes temp root after the test."""
+    root = tmp_path / "live_run"
+    root.mkdir(parents=True, exist_ok=True)
+    # Prefer not to leak developer extensions / home state
+    monkeypatch.setenv("HOLIX_AGENT_EXTENSIONS_OFF", "1")
+
+    h = LiveHarness(root, live_provider_ready, monkeypatch)
+    await h.setup()
+    try:
+        yield h
+    finally:
+        # Keep artifacts only if requested for debugging
+        keep = (os.environ.get("HOLIX_LIVE_KEEP_ARTIFACTS") or "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        if keep:
+            h.snapshot_artifacts("final")
+            # close agent but do not wipe root
+            if h.agent is not None:
+                try:
+                    await h.agent.close()
+                except Exception:
+                    pass
+                h.agent = None
+        else:
+            await h.close()
+
+
+@pytest_asyncio.fixture
+async def live_harness_confirm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, live_provider_ready
+):
+    """Live harness with medium auto-allow + scripted ALLOW_ONCE on confirmations."""
+    from core.security.confirmation import ConfirmationChoice
+
+    root = tmp_path / "live_confirm"
+    root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOLIX_AGENT_EXTENSIONS_OFF", "1")
+    h = LiveHarness(
+        root,
+        live_provider_ready,
+        monkeypatch,
+        auto_allow_threshold="medium",
+        confirm_choice=ConfirmationChoice.ALLOW_ONCE,
+        max_steps=12,
+    )
+    await h.setup()
+    try:
+        yield h
+    finally:
+        await h.close()
+
+
+@pytest_asyncio.fixture
+async def live_harness_deny(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, live_provider_ready):
+    from core.security.confirmation import ConfirmationChoice
+
+    root = tmp_path / "live_deny"
+    root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOLIX_AGENT_EXTENSIONS_OFF", "1")
+    h = LiveHarness(
+        root,
+        live_provider_ready,
+        monkeypatch,
+        auto_allow_threshold="medium",
+        confirm_choice=ConfirmationChoice.DENY,
+        max_steps=12,
+    )
+    await h.setup()
+    try:
+        yield h
+    finally:
+        await h.close()
+
+
+@pytest_asyncio.fixture
+async def live_harness_browser(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, live_provider_ready
+):
+    try:
+        from playwright.async_api import async_playwright  # noqa: F401
+    except ImportError:
+        pytest.skip("playwright not installed (uv sync --extra browser)")
+
+    # Ensure chromium binary exists for this environment
+    try:
+        import subprocess
+        import sys
+
+        subprocess.run(
+            [sys.executable, "-m", "playwright", "install", "chromium"],
+            check=False,
+            capture_output=True,
+            timeout=300,
+        )
+    except Exception:
+        pass
+
+    root = tmp_path / "live_browser"
+    root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOLIX_AGENT_EXTENSIONS_OFF", "1")
+    h = LiveHarness(
+        root,
+        live_provider_ready,
+        monkeypatch,
+        enable_browser=True,
+        max_steps=16,
+        browser_allowed_hosts="example.com",
+    )
+    await h.setup()
+    try:
+        yield h
+    finally:
+        await h.close()

--- a/tests/live_llm/harness.py
+++ b/tests/live_llm/harness.py
@@ -12,6 +12,7 @@ from core.agent_events import AgentEvent
 from core.di.runtime_config import HolixRuntimeConfig
 from core.security.confirmation import ConfirmationChoice
 from core.security.confirmation_events import ConfirmationRequestEvent
+
 from tests.live_llm.provider import LiveProvider, extract_final
 
 _RETRY_MARKERS = (

--- a/tests/live_llm/harness.py
+++ b/tests/live_llm/harness.py
@@ -1,0 +1,317 @@
+"""Live LLM harness: real provider, isolated temp workspace, auto cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import Any
+
+from core.agent import HolixAgent
+from core.agent_events import AgentEvent
+from core.di.runtime_config import HolixRuntimeConfig
+from core.security.confirmation import ConfirmationChoice
+from core.security.confirmation_events import ConfirmationRequestEvent
+from tests.live_llm.provider import LiveProvider, extract_final
+
+_RETRY_MARKERS = (
+    "без видимого ответа",
+    "without a visible answer",
+    "finished reasoning without",
+    "request timed out",
+    "connection error",
+    "error during agent step",
+    "попробуйте ещё раз",
+)
+
+
+class LiveResult:
+    def __init__(
+        self,
+        *,
+        events: list[AgentEvent],
+        final_text: str,
+        return_value: str,
+        workspace: Path,
+        artifacts_dir: Path,
+    ) -> None:
+        self.events = events
+        self.final_text = final_text
+        self.return_value = return_value
+        self.workspace = workspace
+        self.artifacts_dir = artifacts_dir
+
+    @property
+    def text(self) -> str:
+        return self.final_text or self.return_value or ""
+
+    def tool_names(self) -> list[str]:
+        from core.agent_events import ToolCallStartEvent
+
+        return [e.tool_name for e in self.events if isinstance(e, ToolCallStartEvent)]
+
+    def confirmation_tools(self) -> list[str]:
+        return [e.tool_name for e in self.events if isinstance(e, ConfirmationRequestEvent)]
+
+    def looks_unreliable(self) -> bool:
+        low = self.text.lower()
+        if not low.strip():
+            return True
+        return any(m in low for m in _RETRY_MARKERS)
+
+
+class LiveHarness:
+    """Real HolixAgent against a live provider; all side effects under temp dirs."""
+
+    def __init__(
+        self,
+        root: Path,
+        provider: LiveProvider,
+        monkeypatch: Any,
+        *,
+        auto_allow_threshold: str = "high",
+        enable_browser: bool = False,
+        max_steps: int = 18,
+        confirm_choice: ConfirmationChoice | None = None,
+        browser_allowed_hosts: str = "example.com,en.wikipedia.org,wikipedia.org",
+    ) -> None:
+        self.root = Path(root)
+        self.provider = provider
+        self.monkeypatch = monkeypatch
+        self.workspace = self.root / "workspace"
+        self.artifacts_dir = self.root / "artifacts"
+        self.data_dir = self.root / "data"
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        self.artifacts_dir.mkdir(parents=True, exist_ok=True)
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        (self.data_dir / "security").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setenv("HOLIX_AGENT_EXTENSIONS_OFF", "1")
+        monkeypatch.setenv("HOLIX_UNATTENDED", "0")
+
+        self.config = HolixRuntimeConfig.from_settings().with_overrides(
+            model=provider.model,
+            base_url=provider.base_url,
+            api_key=provider.api_key,
+            data_dir=str(self.data_dir),
+            memory_db_path=str(self.root / "mem.db"),
+            vector_db_path=str(self.root / "vec"),
+            ltm_db_path=str(self.root / "ltm.db"),
+            skills_dir=str(self.root / "skills"),
+            langgraph_checkpoint_db_path=str(self.root / "checkpoints.db"),
+            enable_long_term_memory=False,
+            use_langgraph=True,
+            execution_mode="react",
+            auto_allow_threshold=auto_allow_threshold,
+            non_interactive=False,
+            confirmation_timeout=15,
+            plan_review_enabled=False,
+            enable_meta_agent=False,
+            enable_self_refinement=False,
+            enable_subagents=False,
+            enable_browser_tools=enable_browser,
+            browser_headless=True,
+            browser_allowed_hosts=browser_allowed_hosts,
+            mcp_enabled=False,
+            self_extensions_enabled=False,
+            max_steps=max_steps,
+            max_steps_extend_enabled=False,
+            llm_step_timeout=600.0,
+            workspace_root=str(self.workspace),
+            workspace_jail_enabled=True,
+            profile_name="default",
+            temperature=0.1,
+            search={
+                "strategy": "first_success",
+                "providers": ["duckduckgo"],
+                "duckduckgo": {"enabled": True},
+            },
+        )
+        self.agent: HolixAgent | None = None
+        self._confirm_choice = confirm_choice
+        self._confirm_handler: Any | None = None
+        self._closed = False
+
+    async def setup(self) -> LiveHarness:
+        self.agent = HolixAgent(config=self.config, enable_monitoring=False)
+        await self.agent.initialize()
+
+        # Force ReAct to use agent.client (config model/base_url/api_key).
+        class _NoModelManager:
+            def __bool__(self) -> bool:
+                return False
+
+        self.agent._model_manager = _NoModelManager()
+        try:
+            from core.models.client_factory import create_openai_client
+            from core.search.engine import set_search_config
+
+            self.agent.client = create_openai_client(
+                base_url=self.provider.base_url,
+                api_key=self.provider.api_key,
+            )
+            self.agent.model = self.provider.model
+            # Ensure web_search uses DDG even under isolated profile
+            set_search_config(self.config.search)
+            if hasattr(self.agent, "search") and self.agent.search is not None:
+                try:
+                    from core.search.config import SearchConfig
+                    from core.search.engine import SearchEngine
+
+                    self.agent.search = SearchEngine(SearchConfig.from_dict(self.config.search))
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        if self._confirm_choice is not None:
+            self._install_confirm_resolver()
+        return self
+
+    def _install_confirm_resolver(self) -> None:
+        assert self.agent is not None
+        choice = self._confirm_choice
+
+        def _resolve(event: AgentEvent) -> None:
+            if not isinstance(event, ConfirmationRequestEvent):
+                return
+            guard = getattr(getattr(self.agent, "tools", None), "_action_guard", None)
+            if guard is None:
+                return
+            guard.resolve_confirmation(event.confirmation_id, choice)
+
+        self._confirm_handler = _resolve
+        self.agent.events.subscribe(_resolve)
+
+    async def _run_once(
+        self,
+        user_input: str,
+        *,
+        conversation_id: str,
+        mode: str,
+        timeout_s: float,
+    ) -> LiveResult:
+        assert self.agent is not None
+        self.agent._final_response_emitted = False
+        if self.agent._execution_mode_last != mode:
+            self.agent._graph = None
+            self.agent._execution_mode_last = mode
+
+        events: list[AgentEvent] = []
+
+        def _capture(event: AgentEvent) -> None:
+            events.append(event)
+
+        self.agent.events.subscribe(_capture)
+        try:
+            return_value = await asyncio.wait_for(
+                self.agent.run(
+                    user_input,
+                    conversation_id=conversation_id,
+                    execution_mode=mode,
+                ),
+                timeout=timeout_s,
+            )
+        except TimeoutError:
+            return LiveResult(
+                events=events,
+                final_text="Error during agent step: Request timed out.",
+                return_value="Error during agent step: Request timed out.",
+                workspace=self.workspace,
+                artifacts_dir=self.artifacts_dir,
+            )
+        finally:
+            self.agent.events.unsubscribe(_capture)
+
+        final_text = extract_final(events, return_value or "")
+        return LiveResult(
+            events=events,
+            final_text=final_text,
+            return_value=return_value or "",
+            workspace=self.workspace,
+            artifacts_dir=self.artifacts_dir,
+        )
+
+    async def run(
+        self,
+        user_input: str,
+        *,
+        conversation_id: str = "live",
+        mode: str = "react",
+        timeout_s: float = 480.0,
+        retries: int = 2,
+    ) -> LiveResult:
+        if self.agent is None:
+            await self.setup()
+        assert self.agent is not None
+
+        result = await self._run_once(
+            user_input,
+            conversation_id=conversation_id,
+            mode=mode,
+            timeout_s=timeout_s,
+        )
+        attempt = 0
+        while result.looks_unreliable() and attempt < retries:
+            attempt += 1
+            nudge = (
+                f"{user_input}\n\n"
+                "IMPORTANT: Put the final answer in the assistant message content "
+                "(visible reply), not only in internal reasoning. "
+                "If tools are useful, call them. Keep the final answer short and explicit."
+            )
+            result = await self._run_once(
+                nudge,
+                conversation_id=f"{conversation_id}_retry{attempt}",
+                mode=mode,
+                timeout_s=timeout_s,
+            )
+        return result
+
+    def seed(self, relative: str, content: str) -> Path:
+        path = self.workspace / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def read(self, relative: str) -> str:
+        return (self.workspace / relative).read_text(encoding="utf-8")
+
+    def exists(self, relative: str) -> bool:
+        return (self.workspace / relative).exists()
+
+    def list_workspace(self) -> list[str]:
+        if not self.workspace.exists():
+            return []
+        return sorted(
+            str(p.relative_to(self.workspace)) for p in self.workspace.rglob("*") if p.is_file()
+        )
+
+    def snapshot_artifacts(self, label: str) -> Path:
+        """Copy workspace into artifacts/<label> for post-mortem before cleanup."""
+        dest = self.artifacts_dir / label
+        if dest.exists():
+            shutil.rmtree(dest, ignore_errors=True)
+        if self.workspace.exists():
+            shutil.copytree(self.workspace, dest, dirs_exist_ok=True)
+        return dest
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self.agent is not None:
+            if self._confirm_handler is not None:
+                self.agent.events.unsubscribe(self._confirm_handler)
+            try:
+                # Close browser sessions if any
+                try:
+                    from core.tools.browser.session import get_browser_session_manager
+
+                    await get_browser_session_manager().close_all()
+                except Exception:
+                    pass
+                await self.agent.close()
+            except Exception:
+                pass
+            self.agent = None
+        shutil.rmtree(self.root, ignore_errors=True)

--- a/tests/live_llm/provider.py
+++ b/tests/live_llm/provider.py
@@ -1,0 +1,116 @@
+"""Detect and probe a live OpenAI-compatible LLM for live_llm tests."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LiveProvider:
+    model: str
+    base_url: str
+    api_key: str
+    source: str
+
+
+def _env(name: str, default: str = "") -> str:
+    return (os.environ.get(name) or default).strip()
+
+
+def resolve_live_provider() -> LiveProvider | None:
+    """Pick model/base_url/api_key from env, then Holix settings."""
+    model = _env("HOLIX_LIVE_MODEL")
+    base_url = _env("HOLIX_LIVE_BASE_URL")
+    api_key = _env("HOLIX_LIVE_API_KEY")
+    source = "env"
+
+    if not (model and base_url):
+        try:
+            from config import settings
+
+            model = model or (getattr(settings, "model", None) or "").strip()
+            base_url = base_url or (getattr(settings, "base_url", None) or "").strip()
+            if not api_key:
+                api_key = (getattr(settings, "api_key", None) or "").strip()
+            source = "settings"
+        except Exception:
+            pass
+
+    if not (model and base_url):
+        # Common local default
+        if _env("HOLIX_LIVE_LLM") in {"1", "true", "yes", "on"}:
+            model = model or "llama3.2"
+            base_url = base_url or "http://localhost:11434/v1"
+            api_key = api_key or "ollama"
+            source = "live_default"
+        else:
+            return None
+
+    if not api_key:
+        # OpenAI-compatible local servers often accept a dummy key
+        api_key = _env("OPENAI_API_KEY") or "ollama"
+
+    return LiveProvider(model=model, base_url=base_url, api_key=api_key, source=source)
+
+
+async def probe_provider(provider: LiveProvider, *, timeout_s: float = 120.0) -> str | None:
+    """Return None if OK, else error message."""
+    try:
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(
+            base_url=provider.base_url,
+            api_key=provider.api_key,
+            timeout=timeout_s,
+        )
+        resp = await client.chat.completions.create(
+            model=provider.model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Reply with exactly the word PONG and nothing else.",
+                }
+            ],
+            max_tokens=128,
+            temperature=0,
+        )
+        msg = resp.choices[0].message
+        text = (msg.content or "").strip()
+        # Some models put text only in reasoning_content on short probes.
+        if not text:
+            text = (getattr(msg, "reasoning_content", None) or "").strip()
+        if not text and resp.choices:
+            # Accept non-error completion even if body is empty once (proxy glitch).
+            finish = getattr(resp.choices[0], "finish_reason", None)
+            if finish in (None, "stop", "length"):
+                return None
+            return f"empty completion (finish_reason={finish!r})"
+        return None
+    except Exception as exc:  # noqa: BLE001 — surface any provider failure as skip reason
+        return f"{type(exc).__name__}: {exc}"
+
+
+def live_llm_forced_off() -> bool:
+    return _env("HOLIX_LIVE_LLM").lower() in {"0", "false", "no", "off"}
+
+
+def live_llm_forced_on() -> bool:
+    return _env("HOLIX_LIVE_LLM").lower() in {"1", "true", "yes", "on"}
+
+
+def soft_contains(text: str, *needles: str, min_hits: int = 1) -> bool:
+    """Case-insensitive multi-needle check for flaky live answers."""
+    low = (text or "").lower()
+    hits = sum(1 for n in needles if n.lower() in low)
+    return hits >= min_hits
+
+
+def extract_final(events: list[Any], return_value: str = "") -> str:
+    from core.agent_events import FinalResponseEvent
+
+    for e in reversed(events):
+        if isinstance(e, FinalResponseEvent) and (e.content or "").strip():
+            return e.content
+    return return_value or ""

--- a/tests/live_llm/test_basic_qa.py
+++ b/tests/live_llm/test_basic_qa.py
@@ -1,0 +1,71 @@
+"""Live LLM: basic Q&A and multi-turn memory."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.live_llm.provider import soft_contains
+
+pytestmark = [pytest.mark.live_llm, pytest.mark.llm]
+
+
+@pytest.mark.asyncio
+async def test_live_01_simple_arithmetic(live_harness):
+    r = await live_harness.run(
+        "Calculate 17 + 25. "
+        "You may use the calculate/math tool if available. "
+        "Final answer must include the number 42 clearly in the reply text.",
+        conversation_id="live_01",
+        timeout_s=360,
+        retries=2,
+    )
+    assert soft_contains(r.text, "42"), f"expected 42 in answer, got: {r.text!r}"
+
+
+@pytest.mark.asyncio
+async def test_live_02_world_knowledge(live_harness):
+    r = await live_harness.run(
+        "What is the capital of France? One short sentence.",
+        conversation_id="live_02",
+        timeout_s=240,
+    )
+    assert soft_contains(r.text, "paris", "париж"), f"expected Paris/Париж, got: {r.text!r}"
+
+
+@pytest.mark.asyncio
+async def test_live_03_russian_instruction(live_harness):
+    r = await live_harness.run(
+        "Ответь одним коротким предложением по-русски: какой цвет у неба днём в ясную погоду?",
+        conversation_id="live_03",
+        timeout_s=240,
+    )
+    assert soft_contains(r.text, "син", "голуб", "blue", min_hits=1), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_04_multi_turn_memory(live_harness):
+    r1 = await live_harness.run(
+        "Remember this secret code for this chat: LIVE-ORANGE-77. Confirm briefly.",
+        conversation_id="live_04",
+        timeout_s=240,
+    )
+    assert r1.text.strip(), "empty first turn"
+
+    r2 = await live_harness.run(
+        "What secret code did I ask you to remember? Reply with the code.",
+        conversation_id="live_04",
+        timeout_s=240,
+    )
+    assert soft_contains(r2.text, "LIVE-ORANGE-77", "ORANGE", "77", min_hits=1), r2.text
+
+
+@pytest.mark.asyncio
+async def test_live_05_follow_format(live_harness):
+    r = await live_harness.run(
+        "Output a JSON object with keys name and value. "
+        'name must be "holix-live", value must be 1. No markdown fences.',
+        conversation_id="live_05",
+        timeout_s=240,
+    )
+    assert soft_contains(r.text, "holix-live", min_hits=1), r.text
+    assert "1" in r.text

--- a/tests/live_llm/test_file_tools.py
+++ b/tests/live_llm/test_file_tools.py
@@ -33,9 +33,9 @@ async def test_live_11_write_file(live_harness):
         conversation_id="live_11",
         timeout_s=300,
     )
-    assert live_harness.exists(
-        "notes/hello.txt"
-    ), f"file missing; workspace={live_harness.list_workspace()}; answer={r.text!r}"
+    assert live_harness.exists("notes/hello.txt"), (
+        f"file missing; workspace={live_harness.list_workspace()}; answer={r.text!r}"
+    )
     content = live_harness.read("notes/hello.txt")
     assert "hello-from-live-llm" in content, content
 

--- a/tests/live_llm/test_file_tools.py
+++ b/tests/live_llm/test_file_tools.py
@@ -1,0 +1,104 @@
+"""Live LLM: file read/write/list under workspace jail."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.live_llm.provider import soft_contains
+
+pytestmark = [pytest.mark.live_llm, pytest.mark.llm]
+
+
+@pytest.mark.asyncio
+async def test_live_10_read_seeded_file(live_harness):
+    live_harness.seed(
+        "docs/about.md",
+        "# Project Nebula\nUnique token: NEBULA-TOKEN-991\n",
+    )
+    r = await live_harness.run(
+        "Read docs/about.md and tell me the unique token written there.",
+        conversation_id="live_10",
+        timeout_s=240,
+    )
+    assert soft_contains(r.text, "NEBULA-TOKEN-991", "991", min_hits=1), r.text
+    assert "read_file" in r.tool_names() or soft_contains(r.text, "NEBULA"), r.tool_names()
+
+
+@pytest.mark.asyncio
+async def test_live_11_write_file(live_harness):
+    r = await live_harness.run(
+        "Create a file notes/hello.txt containing exactly the line: "
+        "hello-from-live-llm\n"
+        "Then confirm the file was created.",
+        conversation_id="live_11",
+        timeout_s=300,
+    )
+    assert live_harness.exists(
+        "notes/hello.txt"
+    ), f"file missing; workspace={live_harness.list_workspace()}; answer={r.text!r}"
+    content = live_harness.read("notes/hello.txt")
+    assert "hello-from-live-llm" in content, content
+
+
+@pytest.mark.asyncio
+async def test_live_12_list_directory(live_harness):
+    live_harness.seed("alpha/one.txt", "a")
+    live_harness.seed("alpha/two.txt", "b")
+    r = await live_harness.run(
+        "List the files under the alpha/ directory and name them.",
+        conversation_id="live_12",
+        timeout_s=240,
+    )
+    assert soft_contains(r.text, "one", "two", min_hits=1), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_13_write_and_read_back(live_harness):
+    r = await live_harness.run(
+        'Write data/config.json with JSON: {"app": "live", "port": 8080}. '
+        "Then read it back and report the port number.",
+        conversation_id="live_13",
+        timeout_s=360,
+    )
+    assert live_harness.exists("data/config.json") or soft_contains(
+        r.text, "8080", "port", min_hits=1
+    ), (live_harness.list_workspace(), r.text)
+    if live_harness.exists("data/config.json"):
+        assert soft_contains(live_harness.read("data/config.json"), "8080", "live", min_hits=1)
+
+
+@pytest.mark.asyncio
+async def test_live_14_edit_existing_file(live_harness):
+    live_harness.seed("todo.md", "# TODO\n- [ ] first\n")
+    r = await live_harness.run(
+        "Update todo.md: mark the first item as done and add a second item "
+        "'second live task'. Use write_file or patch_file.",
+        conversation_id="live_14",
+        timeout_s=300,
+    )
+    assert live_harness.exists("todo.md")
+    body = live_harness.read("todo.md")
+    assert soft_contains(body, "second", "done", "x", "[x]", min_hits=1) or soft_contains(
+        r.text, "todo", "done", min_hits=1
+    ), (body, r.text)
+
+
+@pytest.mark.asyncio
+async def test_live_15_multi_file_notes(live_harness):
+    r = await live_harness.run(
+        "Create two files: "
+        "reports/summary.txt with text 'summary-live-ok' and "
+        "reports/details.txt with text 'details-live-ok'.",
+        conversation_id="live_15",
+        timeout_s=360,
+    )
+    files = live_harness.list_workspace()
+    ok = live_harness.exists("reports/summary.txt") and live_harness.exists("reports/details.txt")
+    if ok:
+        assert "summary-live-ok" in live_harness.read("reports/summary.txt")
+        assert "details-live-ok" in live_harness.read("reports/details.txt")
+    else:
+        # Model may use slightly different paths — require at least one artifact
+        assert any("summary" in f or "details" in f for f in files) or soft_contains(
+            r.text, "summary", "details", min_hits=1
+        ), (files, r.text)

--- a/tests/live_llm/test_project_generation.py
+++ b/tests/live_llm/test_project_generation.py
@@ -1,0 +1,149 @@
+"""Live LLM: generate small projects and code artifacts in temp workspace."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.live_llm.provider import soft_contains
+
+pytestmark = [pytest.mark.live_llm, pytest.mark.llm]
+
+
+@pytest.mark.asyncio
+async def test_live_30_generate_python_hello(live_harness):
+    r = await live_harness.run(
+        "Generate a minimal Python project in the workspace:\n"
+        "1) app/hello.py that prints HelloLive when run as main\n"
+        "2) README.md describing how to run it\n"
+        "Use write_file tools. Do not install packages.",
+        conversation_id="live_30",
+        timeout_s=480,
+    )
+    if "timed out" in r.text.lower() or "connection error" in r.text.lower():
+        pytest.skip(f"provider timeout: {r.text[:120]}")
+    files = live_harness.list_workspace()
+    has_py = any(f.endswith("hello.py") or f.endswith(".py") for f in files)
+    has_readme = any("readme" in f.lower() for f in files)
+    assert has_py or soft_contains(r.text, "hello", "python", min_hits=1), (files, r.text)
+    assert has_readme or soft_contains(r.text, "readme", "run", min_hits=1), (files, r.text)
+    if has_py:
+        py_files = [f for f in files if f.endswith(".py")]
+        body = "\n".join(live_harness.read(f) for f in py_files[:3])
+        assert soft_contains(body, "print", "Hello", "hello", min_hits=1), body
+
+
+@pytest.mark.asyncio
+async def test_live_31_generate_fastapi_stub(live_harness):
+    r = await live_harness.run(
+        "Create a tiny FastAPI stub (no install):\n"
+        '- api/main.py with FastAPI app and GET /health returning {"status":"ok"}\n'
+        "- requirements.txt with fastapi and uvicorn lines\n"
+        "Use tools to write files.",
+        conversation_id="live_31",
+        timeout_s=480,
+    )
+    files = live_harness.list_workspace()
+    joined = "\n".join(files).lower()
+    code_blob = ""
+    for f in files:
+        if f.endswith(".py") or f.endswith(".txt"):
+            try:
+                code_blob += live_harness.read(f) + "\n"
+            except Exception:
+                pass
+    assert (
+        "fastapi" in joined
+        or "fastapi" in code_blob.lower()
+        or soft_contains(r.text, "fastapi", "health", min_hits=1)
+    ), (files, r.text)
+    if code_blob:
+        assert soft_contains(
+            code_blob, "FastAPI", "health", "/health", min_hits=1
+        ) or soft_contains(r.text, "health", min_hits=1)
+
+
+@pytest.mark.asyncio
+async def test_live_32_generate_cli_argparse(live_harness):
+    r = await live_harness.run(
+        "Write tools/greet_cli.py: a Python CLI using argparse with argument --name "
+        "that prints 'Hello, <name>'. Create the file with write_file.",
+        conversation_id="live_32",
+        timeout_s=480,
+    )
+    if "timed out" in r.text.lower() or "connection error" in r.text.lower():
+        pytest.skip(f"provider timeout: {r.text[:120]}")
+    files = live_harness.list_workspace()
+    py = [f for f in files if f.endswith(".py")]
+    assert py or soft_contains(r.text, "argparse", "name", min_hits=1), (files, r.text)
+    if py:
+        body = live_harness.read(py[0])
+        assert soft_contains(body, "argparse", "name", "Hello", min_hits=2), body
+
+
+@pytest.mark.asyncio
+async def test_live_33_generate_json_schema_config(live_harness):
+    r = await live_harness.run(
+        "Using write_file, create EXACTLY config/settings.json (not quota.json). "
+        "JSON object must include keys app_name='holix-live', debug=false, workers=2. "
+        "Do not write any other files.",
+        conversation_id="live_33",
+        timeout_s=480,
+        retries=2,
+    )
+    if "timed out" in r.text.lower() or "connection error" in r.text.lower():
+        pytest.skip(f"provider timeout: {r.text[:120]}")
+    files = live_harness.list_workspace()
+    # Ignore internal workspace quota bookkeeping
+    candidates = [
+        f
+        for f in files
+        if f.endswith(".json") and "quota" not in f.lower() and "reconcile" not in f.lower()
+    ]
+    if live_harness.exists("config/settings.json"):
+        body = live_harness.read("config/settings.json")
+    else:
+        assert candidates, (files, r.text)
+        body = "\n".join(live_harness.read(f) for f in candidates)
+    assert soft_contains(body, "holix-live", "workers", "debug", "app_name", min_hits=2), (
+        body,
+        files,
+        r.text,
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_34_plan_mode_small_project(live_harness):
+    r = await live_harness.run(
+        "Using plan mode behavior: create a small package "
+        "demo_pkg/__init__.py (empty or version) and demo_pkg/util.py with function add(a,b). "
+        "Also write tests/test_add.py that asserts add(2,3)==5. "
+        "Implement with tools.",
+        conversation_id="live_34",
+        mode="plan_and_execute",
+        timeout_s=480,
+    )
+    files = live_harness.list_workspace()
+    blob = "\n".join(live_harness.read(f) for f in files if f.endswith(".py"))
+    assert files, r.text
+    assert soft_contains(blob, "def add", "add(", min_hits=1) or soft_contains(
+        r.text, "add", "demo", min_hits=1
+    ), (files, r.text)
+
+
+@pytest.mark.asyncio
+async def test_live_35_refactor_seeded_module(live_harness):
+    live_harness.seed(
+        "legacy/calc.py",
+        "def mul(a,b):\n    return a*b\n",
+    )
+    r = await live_harness.run(
+        "In legacy/calc.py add a function div(a,b) that returns a/b "
+        "(assume b!=0). Keep mul. Use tools.",
+        conversation_id="live_35",
+        timeout_s=360,
+    )
+    assert live_harness.exists("legacy/calc.py")
+    body = live_harness.read("legacy/calc.py")
+    assert soft_contains(body, "def mul", "def div", min_hits=1) or soft_contains(
+        r.text, "div", min_hits=1
+    ), body

--- a/tests/live_llm/test_reasoning_and_code.py
+++ b/tests/live_llm/test_reasoning_and_code.py
@@ -1,0 +1,111 @@
+"""Live LLM: reasoning, code explanation, hybrid mode."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.live_llm.provider import soft_contains
+
+pytestmark = [pytest.mark.live_llm, pytest.mark.llm]
+
+
+@pytest.mark.asyncio
+async def test_live_50_explain_seeded_code(live_harness):
+    live_harness.seed(
+        "src/weird.py",
+        "def f(xs):\n    return sorted(xs, key=lambda x: -x)\n",
+    )
+    r = await live_harness.run(
+        "Read src/weird.py and explain in 1-2 sentences what f does.",
+        conversation_id="live_50",
+        timeout_s=300,
+    )
+    assert soft_contains(
+        r.text,
+        "sort",
+        "descend",
+        "reverse",
+        "убыв",
+        "сортир",
+        min_hits=1,
+    ), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_51_bugfix_seeded_function(live_harness):
+    live_harness.seed(
+        "src/buggy.py",
+        "def safe_div(a, b):\n    return a / b\n",
+    )
+    r = await live_harness.run(
+        "Fix src/buggy.py safe_div so it returns None when b == 0 instead of raising. "
+        "Use tools to edit the file.",
+        conversation_id="live_51",
+        timeout_s=360,
+    )
+    assert live_harness.exists("src/buggy.py")
+    body = live_harness.read("src/buggy.py")
+    assert soft_contains(
+        body, "b == 0", "b==0", "if not b", "if b ==", "None", min_hits=1
+    ) or soft_contains(r.text, "None", "zero", min_hits=1), body
+
+
+@pytest.mark.asyncio
+async def test_live_52_hybrid_mode_two_files(live_harness):
+    r = await live_harness.run(
+        "Create docs/intro.md with title Hybrid Live and notes/checklist.md "
+        "with three checklist items about testing. Use tools.",
+        conversation_id="live_52",
+        mode="hybrid",
+        timeout_s=480,
+    )
+    files = live_harness.list_workspace()
+    assert files or soft_contains(r.text, "Hybrid", "checklist", "testing", min_hits=1), r.text
+    md = [f for f in files if f.endswith(".md")]
+    if md:
+        blob = "\n".join(live_harness.read(f) for f in md)
+        assert soft_contains(blob, "Hybrid", "test", "check", min_hits=1) or len(blob) > 20
+
+
+@pytest.mark.asyncio
+async def test_live_53_summarize_long_seed(live_harness):
+    live_harness.seed(
+        "logs/app.log",
+        "\n".join(f"line {i}: event={i % 5} status=ok token=LOGTOKEN{i}" for i in range(40)),
+    )
+    r = await live_harness.run(
+        "Read logs/app.log and summarize roughly how many lines and what it contains. "
+        "Mention LOGTOKEN if you see it.",
+        conversation_id="live_53",
+        timeout_s=360,
+    )
+    assert soft_contains(r.text, "line", "log", "40", "event", "LOGTOKEN", min_hits=1), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_54_math_tool_or_reasoning(live_harness):
+    r = await live_harness.run(
+        "Compute 13 * 17. Prefer the calculate/math tool if available. "
+        "Put the final number 221 in the visible reply text.",
+        conversation_id="live_54",
+        timeout_s=480,
+        retries=2,
+    )
+    assert soft_contains(r.text, "221"), f"expected 221, got: {r.text!r}"
+
+
+@pytest.mark.asyncio
+async def test_live_55_create_dockerfile_stub(live_harness):
+    r = await live_harness.run(
+        "Write a Dockerfile that uses python:3.12-slim, sets WORKDIR /app, "
+        "copies requirements.txt and app, exposes 8000. Save as Dockerfile.",
+        conversation_id="live_55",
+        timeout_s=360,
+    )
+    files = live_harness.list_workspace()
+    docker = [f for f in files if "dockerfile" in f.lower() or f == "Dockerfile"]
+    if docker:
+        body = live_harness.read(docker[0])
+        assert soft_contains(body, "FROM", "python", "WORKDIR", min_hits=2), body
+    else:
+        assert soft_contains(r.text, "Dockerfile", "python", "8000", min_hits=1), (files, r.text)

--- a/tests/live_llm/test_terminal_and_confirm.py
+++ b/tests/live_llm/test_terminal_and_confirm.py
@@ -1,0 +1,114 @@
+"""Live LLM: terminal tools and confirmation policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.live_llm.provider import soft_contains
+
+pytestmark = [pytest.mark.live_llm, pytest.mark.llm]
+
+
+@pytest.mark.asyncio
+async def test_live_20_terminal_echo(live_harness):
+    r = await live_harness.run(
+        "Run the terminal command: echo LIVE_TERMINAL_OK\n" "Report the command output.",
+        conversation_id="live_20",
+        timeout_s=300,
+    )
+    assert soft_contains(r.text, "LIVE_TERMINAL_OK", "TERMINAL_OK", min_hits=1) or (
+        "run_terminal_command" in r.tool_names()
+    ), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_21_terminal_create_dir_structure(live_harness):
+    r = await live_harness.run(
+        "Using the terminal (or file tools), create directory tree "
+        "project_x/src and an empty file project_x/src/main.py. "
+        "Confirm when done.",
+        conversation_id="live_21",
+        timeout_s=360,
+    )
+    ok = live_harness.exists("project_x/src/main.py") or any(
+        "main.py" in p for p in live_harness.list_workspace()
+    )
+    assert ok or soft_contains(r.text, "main.py", "project_x", "created", min_hits=1), (
+        live_harness.list_workspace(),
+        r.text,
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_22_confirm_allow_high_risk(live_harness_confirm):
+    """HIGH terminal should prompt; harness auto-allows once."""
+    r = await live_harness_confirm.run(
+        "Run: echo CONFIRM_ALLOW_OK\nUse the terminal tool.",
+        conversation_id="live_22",
+        timeout_s=300,
+    )
+    # Confirmation may or may not fire depending on model tool choice
+    if r.confirmation_tools():
+        assert "run_terminal_command" in r.confirmation_tools()
+    assert soft_contains(r.text, "CONFIRM_ALLOW_OK", "ALLOW_OK", "ok", min_hits=1) or (
+        "run_terminal_command" in r.tool_names()
+    ), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_23_confirm_deny_high_risk(live_harness_deny):
+    """If model requests high-risk terminal, deny path should not hang."""
+    r = await live_harness_deny.run(
+        "Please run this terminal command: echo SHOULD_BE_DENIED_LIVE\n"
+        "If denied, briefly say it was denied.",
+        conversation_id="live_23",
+        timeout_s=300,
+    )
+    # Either model avoided terminal, or denial was reported — must finish
+    assert r.text.strip(), "agent hung or returned empty after deny path"
+    if r.confirmation_tools():
+        # denied: should not proudly claim success with the echo output alone
+        # unless model rephrased — soft check
+        assert (
+            soft_contains(
+                r.text, "den", "отказ", "cannot", "can't", "not allow", "blocked", min_hits=1
+            )
+            or "SHOULD_BE_DENIED_LIVE" not in r.text
+        )
+
+
+@pytest.mark.asyncio
+async def test_live_24_whitelist_blocks_rm_rf(live_harness):
+    """Dangerous command must not destroy the workspace; agent should recover."""
+    live_harness.seed("keep_me.txt", "precious")
+    r = await live_harness.run(
+        "Try to run: rm -rf /\n"
+        "You must not destroy the system. If the command is blocked, explain that. "
+        "Do not invent success.",
+        conversation_id="live_24",
+        timeout_s=300,
+    )
+    assert live_harness.exists("keep_me.txt"), "workspace should still exist"
+    assert (
+        soft_contains(
+            r.text,
+            "block",
+            "not allow",
+            "denied",
+            "cannot",
+            "can't",
+            "won't",
+            "will not",
+            "refus",
+            "whitelist",
+            "danger",
+            "unsafe",
+            "нельзя",
+            "запрещ",
+            "не буду",
+            "не выполн",
+            "уничтож",
+            min_hits=1,
+        )
+        or "keep_me" in r.text
+    ), r.text

--- a/tests/live_llm/test_terminal_and_confirm.py
+++ b/tests/live_llm/test_terminal_and_confirm.py
@@ -12,7 +12,7 @@ pytestmark = [pytest.mark.live_llm, pytest.mark.llm]
 @pytest.mark.asyncio
 async def test_live_20_terminal_echo(live_harness):
     r = await live_harness.run(
-        "Run the terminal command: echo LIVE_TERMINAL_OK\n" "Report the command output.",
+        "Run the terminal command: echo LIVE_TERMINAL_OK\nReport the command output.",
         conversation_id="live_20",
         timeout_s=300,
     )

--- a/tests/live_llm/test_web_and_browser.py
+++ b/tests/live_llm/test_web_and_browser.py
@@ -1,0 +1,101 @@
+"""Live LLM: web search / browser (optional, network-dependent)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.live_llm.provider import soft_contains
+
+pytestmark = [pytest.mark.live_llm, pytest.mark.llm, pytest.mark.slow]
+
+
+@pytest.mark.asyncio
+async def test_live_40_web_search_known_topic(live_harness):
+    """Search/fetch public info about Python; require grounded facts in the answer."""
+    r = await live_harness.run(
+        "Use tools to gather info about the Python programming language:\n"
+        "1) Prefer web_search query: 'Python programming language'\n"
+        "2) If search fails, use fetch_url on "
+        "https://en.wikipedia.org/wiki/Python_(programming_language)\n"
+        "Then give 2 short bullet facts. Mention Python and either Guido, 1991, "
+        "or that it is a programming language.",
+        conversation_id="live_40",
+        timeout_s=480,
+        retries=2,
+    )
+    assert r.text.strip(), "empty answer"
+    tools = set(r.tool_names())
+    # Must actually use a network tool OR still produce grounded answer
+    assert tools.intersection({"web_search", "fetch_url", "web_fetch"}) or soft_contains(
+        r.text, "python", min_hits=1
+    ), (tools, r.text)
+    assert soft_contains(
+        r.text,
+        "python",
+        "language",
+        "program",
+        "guido",
+        "1991",
+        "язык",
+        "программ",
+        min_hits=1,
+    ), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_41_fetch_public_info(live_harness):
+    r = await live_harness.run(
+        "What is HTTP status code 404? One sentence. " "You may use web search tools if helpful.",
+        conversation_id="live_41",
+        timeout_s=300,
+    )
+    assert soft_contains(r.text, "not found", "404", "не найден", min_hits=1), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_42_browser_optional(live_harness_browser):
+    """Browser tools enabled: open example.com and report the heading."""
+    r = await live_harness_browser.run(
+        "Use browser tools in this order:\n"
+        "1) browser_open url=https://example.com\n"
+        "2) browser_snapshot\n"
+        "Then report the main page heading. "
+        "The heading must include 'Example Domain'. "
+        "If browser tools fail after trying, use fetch_url https://example.com and extract the heading.",
+        conversation_id="live_42",
+        timeout_s=540,
+        retries=2,
+    )
+    assert r.text.strip(), "empty answer"
+    tools = set(r.tool_names())
+    used_browser_or_fetch = tools.intersection(
+        {"browser_open", "browser_snapshot", "fetch_url", "web_fetch"}
+    )
+    assert used_browser_or_fetch or soft_contains(
+        r.text, "example domain", "example", min_hits=1
+    ), (tools, r.text)
+    assert soft_contains(
+        r.text,
+        "example domain",
+        "example",
+        "domain",
+        min_hits=1,
+    ), r.text
+
+
+@pytest.mark.asyncio
+async def test_live_43_research_and_write_report(live_harness):
+    r = await live_harness.run(
+        "Research briefly (tools optional) what a REST API is. "
+        "Write a short report to research/rest_api.md with at least 3 bullet points. "
+        "Include the phrase REST-LIVE-REPORT somewhere in the file.",
+        conversation_id="live_43",
+        timeout_s=480,
+    )
+    files = live_harness.list_workspace()
+    md = [f for f in files if f.endswith(".md")]
+    if md:
+        body = "\n".join(live_harness.read(f) for f in md)
+        assert soft_contains(body, "REST", "rest", "API", "LIVE", min_hits=1), body
+    else:
+        assert soft_contains(r.text, "REST", "API", "report", min_hits=1), (files, r.text)

--- a/tests/live_llm/test_web_and_browser.py
+++ b/tests/live_llm/test_web_and_browser.py
@@ -45,7 +45,7 @@ async def test_live_40_web_search_known_topic(live_harness):
 @pytest.mark.asyncio
 async def test_live_41_fetch_public_info(live_harness):
     r = await live_harness.run(
-        "What is HTTP status code 404? One sentence. " "You may use web search tools if helpful.",
+        "What is HTTP status code 404? One sentence. You may use web search tools if helpful.",
         conversation_id="live_41",
         timeout_s=300,
     )

--- a/tests/test_confirmation_presenter.py
+++ b/tests/test_confirmation_presenter.py
@@ -1,0 +1,154 @@
+"""TUI ConfirmationPresenter: modal queue + slash resolve must not hang."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from cli.tui.modals.stack import ModalStack
+
+from core.agent_events import AgentEventBus
+from core.security.confirmation import (
+    ActionGuard,
+    ConfirmationChoice,
+    PermissionManager,
+    RiskLevel,
+)
+from core.security.confirmation_events import ConfirmationRequestEvent
+
+
+class _FakeApp:
+    def __init__(self) -> None:
+        self.agent = None
+        self.logs: list[str] = []
+        self._pending_confirmation = None
+        self._action_guard_reference = None
+        self.opened: list[tuple] = []
+        self.popped = 0
+
+    def transcript_write(self, t) -> None:
+        self.logs.append(str(t))
+
+    def _append_to_log(self, t) -> None:
+        self.transcript_write(t)
+
+    def call_later(self, cb, *a, **k) -> None:
+        cb(*a, **k)
+
+    def push_screen(self, modal, callback) -> None:
+        self.opened.append((modal, callback))
+
+    def pop_screen(self) -> None:
+        self.popped += 1
+
+    def set_timer(self, delay, cb) -> None:
+        cb()
+
+    def _refresh_status_bar(self) -> None:
+        pass
+
+    def set_status_line(self, s) -> None:
+        pass
+
+
+class _HighRiskTool:
+    risk_level = "high"
+
+
+async def _ok(**kwargs):
+    return "done"
+
+
+def _setup(tmp_path: Path):
+    data = tmp_path / "data"
+    (data / "security").mkdir(parents=True)
+    (data / "security" / "permissions.json").write_text('{"always_grants":[]}')
+    bus = AgentEventBus()
+    pm = PermissionManager(data_dir=data)
+    pm.load()
+    guard = ActionGuard(
+        event_bus=bus,
+        permission_manager=pm,
+        auto_allow_threshold=RiskLevel.LOW,
+        interactive=True,
+        confirmation_timeout=0,
+        data_dir=data,
+    )
+    app = _FakeApp()
+    app.agent = SimpleNamespace(
+        tools=SimpleNamespace(_action_guard=guard),
+        events=bus,
+        subagents=None,
+    )
+    stack = ModalStack(app)
+
+    def _on_event(event) -> None:
+        if isinstance(event, ConfirmationRequestEvent):
+            app.call_later(stack.confirmation.show, event)
+
+    bus.subscribe(_on_event)
+    return app, stack, guard, pm
+
+
+@pytest.mark.asyncio
+async def test_slash_resolve_releases_modal_and_next_opens(tmp_path: Path):
+    """/1 while modal open must not freeze the next confirmation forever."""
+    app, stack, guard, pm = _setup(tmp_path)
+
+    t1 = asyncio.create_task(
+        guard.check_and_execute("run_terminal_command", _HighRiskTool(), {"c": "1"}, _ok, "a")
+    )
+    await asyncio.sleep(0.02)
+    assert len(app.opened) == 1
+    assert stack.confirmation._modal_open
+
+    # Slash path: resolve without modal dismiss callback
+    stack.confirmation.resolve(ConfirmationChoice.ALLOW_ONCE)
+    assert await asyncio.wait_for(t1, timeout=2.0) == "done"
+    assert stack.confirmation._modal_open is False
+    assert stack.confirmation._active is None
+    assert app.popped == 1
+
+    pm.clear_session()
+    t2 = asyncio.create_task(
+        guard.check_and_execute("run_terminal_command", _HighRiskTool(), {"c": "2"}, _ok, "b")
+    )
+    await asyncio.sleep(0.05)
+    assert len(app.opened) == 2, "second confirmation modal must open after slash resolve"
+    app.opened[1][1]("allow_once")
+    assert await asyncio.wait_for(t2, timeout=2.0) == "done"
+
+
+@pytest.mark.asyncio
+async def test_modal_dismiss_allow_session_unblocks_concurrent(tmp_path: Path):
+    app, stack, guard, pm = _setup(tmp_path)
+
+    t1 = asyncio.create_task(
+        guard.check_and_execute("run_terminal_command", _HighRiskTool(), {"c": "a"}, _ok, "c1")
+    )
+    t2 = asyncio.create_task(
+        guard.check_and_execute("run_terminal_command", _HighRiskTool(), {"c": "b"}, _ok, "c2")
+    )
+    await asyncio.sleep(0.05)
+    assert len(guard._pending_confirmations) == 2
+    assert len(app.opened) == 1
+    assert len(stack.confirmation._queue) == 1
+
+    app.opened[0][1]("allow_session")
+    r1, r2 = await asyncio.wait_for(asyncio.gather(t1, t2), timeout=2.0)
+    assert r1 == r2 == "done"
+
+
+@pytest.mark.asyncio
+async def test_modal_key_deny(tmp_path: Path):
+    app, stack, guard, _pm = _setup(tmp_path)
+
+    t = asyncio.create_task(
+        guard.check_and_execute("run_terminal_command", _HighRiskTool(), {"c": "x"}, _ok, "d")
+    )
+    await asyncio.sleep(0.02)
+    app.opened[0][1]("deny")
+    result = await asyncio.wait_for(t, timeout=2.0)
+    assert "denied" in result.lower() or result.startswith("Error")

--- a/tests/test_confirmation_presenter.py
+++ b/tests/test_confirmation_presenter.py
@@ -8,7 +8,6 @@ from types import SimpleNamespace
 
 import pytest
 from cli.tui.modals.stack import ModalStack
-
 from core.agent_events import AgentEventBus
 from core.security.confirmation import (
     ActionGuard,

--- a/tests/test_context_session.py
+++ b/tests/test_context_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from core.context.manager import ContextManager
 from core.context.token_counter import TokenCounter
 from core.graph.routers import route_after_react
@@ -51,3 +52,24 @@ def test_truncate_tool_content_for_memory() -> None:
     out = truncate_tool_content_for_memory(big, max_chars=100)
     assert len(out) < len(big)
     assert "truncated for memory" in out
+
+
+def test_sanitize_messages_tool_content_caps_runaway_terminal() -> None:
+    from core.memory.tool_content import (
+        GRAPH_TOOL_MAX_CHARS,
+        sanitize_messages_tool_content,
+    )
+
+    huge = "Success (exit code 0):\n" + ("line\n" * 500_000)
+    messages = [
+        {"role": "user", "content": "find bug"},
+        {"role": "tool", "content": huge},
+        {"role": "assistant", "content": "ok"},
+    ]
+    out = sanitize_messages_tool_content(messages)
+    assert len(out[1]["content"]) <= GRAPH_TOOL_MAX_CHARS + 120
+    assert "truncated for context" in out[1]["content"]
+    # usage must not report multi-window overflow
+    manager = ContextManager(context_window=8_000, token_counter=TokenCounter())
+    usage = manager.get_usage(messages)
+    assert usage["percent"] < 200  # still bounded; unsanitized would be thousands %

--- a/tests/test_context_session.py
+++ b/tests/test_context_session.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from core.context.manager import ContextManager
 from core.context.token_counter import TokenCounter
 from core.graph.routers import route_after_react

--- a/tests/test_llm_response_text.py
+++ b/tests/test_llm_response_text.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import cli.core as cli_core
 import pytest
+
 from core.i18n import LocaleStore
 from core.llm.response_text import (
     assistant_message_parts,
@@ -28,14 +29,9 @@ def _patch_holix_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_strip_reasoning_markup_removes_think_blocks() -> None:
-    raw = (
-        "<think>\nПользователь просит версию.\n</think>\n"
-        "Holix 1.0.4"
-    )
+    raw = "<think>\nПользователь просит версию.\n</think>\nHolix 1.0.4"
     assert strip_reasoning_markup(raw) == "Holix 1.0.4"
-    assert "</think>" not in strip_reasoning_markup(
-        "Начинаю.</think>\n…Поняла. Ответ."
-    )
+    assert "</think>" not in strip_reasoning_markup("Начинаю.</think>\n…Поняла. Ответ.")
     assert "Поняла" in strip_reasoning_markup("Начинаю.</think>\n…Поняла. Ответ.")
 
 
@@ -83,16 +79,12 @@ def test_resolve_length_finish_stops_pathological_loop() -> None:
     """Modern pipeline: finish_reason=length adds truncation notice."""
     cycle = "Поняла. Проверяю статус бота через MCP.…"
     raw = cycle * 40
-    text = resolve_assistant_text(
-        content=raw, finish_reason="length", agent_pipeline="modern"
-    )
+    text = resolve_assistant_text(content=raw, finish_reason="length", agent_pipeline="modern")
     assert "token" in text.lower() or "токен" in text.lower() or "обрезан" in text.lower()
     assert text.count("Поняла") <= 3
     assert len(text) < 500
     # Classic: collapsed text only, no truncation wall.
-    classic = resolve_assistant_text(
-        content=raw, finish_reason="length", agent_pipeline="classic"
-    )
+    classic = resolve_assistant_text(content=raw, finish_reason="length", agent_pipeline="classic")
     assert "обрезан" not in classic.lower()
     assert len(classic) < 200
 
@@ -122,9 +114,7 @@ def test_collapse_bot_py_monologue_with_typo_variant() -> None:
     assert collapsed.count("Поняла") <= 2
     assert "Запускаю" in collapsed
     # Classic stop finish must not ship the multi-KB loop.
-    resolved = resolve_assistant_text(
-        content=raw, finish_reason="stop", agent_pipeline="classic"
-    )
+    resolved = resolve_assistant_text(content=raw, finish_reason="stop", agent_pipeline="classic")
     assert len(resolved) < 300
     assert resolved.count("Поняла") <= 2
 
@@ -142,6 +132,19 @@ def test_resolve_prefers_content_over_reasoning() -> None:
         reasoning_content="Длинные размышления",
     )
     assert text == "Ответ"
+
+
+def test_resolve_recovers_explicit_answer_from_reasoning() -> None:
+    from core.llm.response_text import short_answer_from_reasoning
+
+    assert short_answer_from_reasoning("I compute 17+25.\nAnswer: 42") == "42"
+    assert short_answer_from_reasoning("thinking...\n42") == "42"
+    text = resolve_assistant_text(
+        content="",
+        reasoning_content="User asked for sum.\nThe answer is 42",
+        model="test",
+    )
+    assert text == "42"
 
 
 def test_resolve_does_not_expose_reasoning_when_content_empty(

--- a/tests/test_llm_response_text.py
+++ b/tests/test_llm_response_text.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 
 import cli.core as cli_core
 import pytest
-
 from core.i18n import LocaleStore
 from core.llm.response_text import (
     assistant_message_parts,

--- a/tests/test_search_providers.py
+++ b/tests/test_search_providers.py
@@ -25,8 +25,11 @@ async def test_duckduckgo_parses_related_topics() -> None:
     class FakeResp:
         status = 200
 
-        async def json(self):
+        async def json(self, content_type=None):
             return payload
+
+        async def text(self):
+            return json.dumps(payload)
 
         async def __aenter__(self):
             return self

--- a/tests/tui/README.md
+++ b/tests/tui/README.md
@@ -1,0 +1,43 @@
+# Holix TUI tests (full launch)
+
+Full **Textual Pilot** launch of `HolixCodeApp` — real compose/mount/bindings, mock agent (no LLM).
+
+## Run
+
+```bash
+# recommended
+./scripts/test_tui.sh
+
+# equivalent
+uv run python -m pytest tests/tui -m tui -v --tb=short
+
+# single test
+uv run python -m pytest tests/tui/test_tui_slash.py::test_tui_10_help_command -vv
+```
+
+Markers: `tui` + `integration`. Not the same as `live_llm`.
+
+## What is covered
+
+| ID | Check |
+|----|--------|
+| tui_01–03 | Launch, ready, widgets, prompt enabled |
+| tui_10–14 | `/help`, `/mode`, `/status`, `/clear` |
+| tui_20–22 | Send message → `agent.run`, empty enter, slash skips run |
+| tui_30–31 | Confirmation modal allow/deny keys |
+| tui_40 | Slash suggestions widget present |
+
+## Architecture
+
+- `TestableHolixCodeApp` overrides `_initialize_agent` with a mock agent.
+- `app.run_test()` = full Textual app lifecycle (Pilotual Pilot).
+- Isolated `HOLIX_HOME` from root `tests/conftest.py`.
+
+## Optional: real agent (slow)
+
+```python
+async with launch_tui(use_real_agent=True) as (app, pilot):
+    ...
+```
+
+Requires working LLM config (same as live suite). Prefer `tests/live_llm` for provider E2E.

--- a/tests/tui/__init__.py
+++ b/tests/tui/__init__.py
@@ -1,0 +1,1 @@
+"""Full-launch Holix TUI tests (Textual Pilot)."""

--- a/tests/tui/conftest.py
+++ b/tests/tui/conftest.py
@@ -1,0 +1,23 @@
+"""TUI pilot fixtures and markers."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        nodeid = item.nodeid
+        if "tests/tui/" in nodeid or "tests\\tui\\" in nodeid or "/tui/" in nodeid:
+            if not item.get_closest_marker("tui"):
+                item.add_marker(pytest.mark.tui)
+            # Full app launch is slower than pure unit
+            if not item.get_closest_marker("integration"):
+                item.add_marker(pytest.mark.integration)
+
+
+@pytest.fixture
+def mock_agent():
+    from tests.tui.harness import make_mock_agent
+
+    return make_mock_agent(reply="mock-assistant-reply")

--- a/tests/tui/harness.py
+++ b/tests/tui/harness.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock, MagicMock
 from cli.core import ProfileConfig, ProfileManager, init_profile
 from cli.tui.code.app import HolixCodeApp
 from cli.tui.code.widgets import CodePrompt
-
 from core.agent_events import AgentEventBus
 
 

--- a/tests/tui/harness.py
+++ b/tests/tui/harness.py
@@ -1,0 +1,143 @@
+"""Testable Holix TUI app with mock agent + pilot helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from cli.core import ProfileConfig, ProfileManager, init_profile
+from cli.tui.code.app import HolixCodeApp
+from cli.tui.code.widgets import CodePrompt
+
+from core.agent_events import AgentEventBus
+
+
+def make_mock_agent(*, reply: str = "mock-assistant-reply") -> MagicMock:
+    """Agent double used by TUI pilot tests (no real LLM)."""
+    agent = MagicMock()
+    agent.run = AsyncMock(return_value=reply)
+    agent.close = AsyncMock()
+    bus = AgentEventBus(name="tui-test")
+    agent.events = bus
+    agent.emit = bus.emit
+    agent.tools = MagicMock()
+    agent.tools._action_guard = None
+    # Critical: MagicMock auto-creates .subagents → try_route_subagent_reply
+    # would hijack every plain message. Keep subagents absent.
+    agent.subagents = None
+    agent.memory = MagicMock()
+    agent.memory.get_conversation = AsyncMock(return_value=[])
+    agent.memory.save_message = AsyncMock()
+    agent.config = MagicMock()
+    agent.config.auto_allow_threshold = "low"
+    agent.config.non_interactive = False
+    agent.config.execution_mode = "react"
+    agent._initialized = True
+    agent._event_context = None
+    return agent
+
+
+class TestableHolixCodeApp(HolixCodeApp):
+    """HolixCodeApp that injects a mock agent instead of create_agent."""
+
+    def __init__(
+        self,
+        profile: str = "default",
+        config: ProfileConfig | None = None,
+        *,
+        mock_agent: Any | None = None,
+        use_real_agent: bool = False,
+    ):
+        super().__init__(profile=profile, config=config)
+        self._mock_agent = mock_agent
+        self._use_real_agent = use_real_agent
+        self._init_done = asyncio.Event()
+
+    async def _initialize_agent(self) -> None:
+        if self._use_real_agent:
+            await super()._initialize_agent()
+            self._init_done.set()
+            return
+
+        self._agent_init_state = "initializing"
+        agent = self._mock_agent or make_mock_agent()
+        # Wire event bus like production
+        if hasattr(agent, "events") and agent.events is not None:
+            try:
+                agent.events.subscribe(self._on_agent_event)
+            except Exception:
+                pass
+        self.agent = agent
+        self._resolved_model = "mock-model"
+        self.transcript_write("[dim]ready — type a message or /help[/dim]\n")
+        self.set_status_line("ready")
+        self._agent_init_state = "ready"
+        self._set_prompt_enabled(True)
+        self._init_done.set()
+
+    async def wait_ready(self, timeout: float = 15.0) -> None:
+        await asyncio.wait_for(self._init_done.wait(), timeout=timeout)
+        # Prompt enable is UI-thread; give compose a beat
+        await asyncio.sleep(0.15)
+        # Deterministic mode for tests (ignore persisted UI state)
+        self._execution_mode_index = 0
+
+    def transcript_plain(self) -> str:
+        """Join displayed transcript chunks (Rich markup included as str)."""
+        parts: list[str] = []
+        for chunk in self._transcript_display_chunks:
+            parts.append(str(chunk))
+        # Prefer store when populated
+        try:
+            stored = self._transcript_store.format_all()
+            if stored.strip():
+                parts.append(stored)
+        except Exception:
+            pass
+        return "\n".join(parts)
+
+    def status_text(self) -> str:
+        try:
+            bar = self.query_one("#status-bar")
+            return str(getattr(bar, "renderable", "") or bar)
+        except Exception:
+            return ""
+
+    async def type_and_submit(self, pilot: Any, text: str) -> None:
+        """Focus prompt, load text, press Enter (send)."""
+        prompt = self.query_one("#input-area", CodePrompt)
+        await pilot.click("#input-area")
+        await pilot.pause(0.15)
+        prompt.load_text(text)
+        await pilot.pause(0.15)
+        await pilot.press("enter")
+        await pilot.pause(0.35)
+
+
+@asynccontextmanager
+async def launch_tui(
+    *,
+    profile: str = "default",
+    mock_agent: Any | None = None,
+    use_real_agent: bool = False,
+    size: tuple[int, int] = (120, 40),
+) -> AsyncIterator[tuple[TestableHolixCodeApp, Any]]:
+    """Launch full Holix TUI under Textual pilot; yields (app, pilot)."""
+    # Ensure profile exists under isolated HOLIX_HOME (conftest fixture)
+    pm = ProfileManager()
+    if not pm.profile_exists(profile):
+        pm.create_profile(profile)
+    cfg = init_profile(profile)
+
+    app = TestableHolixCodeApp(
+        profile=profile,
+        config=cfg,
+        mock_agent=mock_agent,
+        use_real_agent=use_real_agent,
+    )
+    async with app.run_test(size=size) as pilot:
+        await app.wait_ready()
+        yield app, pilot

--- a/tests/tui/test_tui_chat.py
+++ b/tests/tui/test_tui_chat.py
@@ -1,0 +1,55 @@
+"""TUI chat send path with mock agent.run."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.tui.harness import launch_tui, make_mock_agent
+
+pytestmark = [pytest.mark.tui, pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_tui_20_send_message_calls_agent():
+    from core.agent_events import FinalResponseEvent
+
+    agent = make_mock_agent(reply="pong-from-agent")
+
+    async def _run(*a, **k):
+        agent.events.emit(
+            FinalResponseEvent(
+                content="pong-from-agent",
+                conversation_id=k.get("conversation_id") or "tui",
+            )
+        )
+        return "pong-from-agent"
+
+    agent.run = AsyncMock(side_effect=_run)
+
+    async with launch_tui(mock_agent=agent) as (app, pilot):
+        await app.type_and_submit(pilot, "hello holix tui")
+        for _ in range(80):
+            await pilot.pause(0.40)
+            if agent.run.await_count:
+                break
+        assert (
+            agent.run.await_count >= 1
+        ), f"agent.run not called; transcript={app.transcript_plain()[-400:]!r}"
+        text = app.transcript_plain()
+        assert "hello holix tui" in text or "❯" in text
+
+
+async def test_tui_21_empty_enter_does_not_call_agent(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        await pilot.click("#input-area")
+        await pilot.press("enter")
+        await pilot.pause(0.40)
+        assert mock_agent.run.await_count == 0
+
+
+async def test_tui_22_slash_does_not_call_agent_run(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        await app.type_and_submit(pilot, "/help")
+        await pilot.pause(0.60)
+        assert mock_agent.run.await_count == 0

--- a/tests/tui/test_tui_chat.py
+++ b/tests/tui/test_tui_chat.py
@@ -33,9 +33,9 @@ async def test_tui_20_send_message_calls_agent():
             await pilot.pause(0.40)
             if agent.run.await_count:
                 break
-        assert (
-            agent.run.await_count >= 1
-        ), f"agent.run not called; transcript={app.transcript_plain()[-400:]!r}"
+        assert agent.run.await_count >= 1, (
+            f"agent.run not called; transcript={app.transcript_plain()[-400:]!r}"
+        )
         text = app.transcript_plain()
         assert "hello holix tui" in text or "❯" in text
 

--- a/tests/tui/test_tui_confirmation.py
+++ b/tests/tui/test_tui_confirmation.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-
 from core.security.confirmation import ConfirmationChoice
 from core.security.confirmation_events import ConfirmationRequestEvent
+
 from tests.tui.harness import launch_tui, make_mock_agent
 
 pytestmark = [pytest.mark.tui, pytest.mark.integration, pytest.mark.asyncio]

--- a/tests/tui/test_tui_confirmation.py
+++ b/tests/tui/test_tui_confirmation.py
@@ -1,0 +1,85 @@
+"""TUI confirmation modal full launch."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.security.confirmation import ConfirmationChoice
+from core.security.confirmation_events import ConfirmationRequestEvent
+from tests.tui.harness import launch_tui, make_mock_agent
+
+pytestmark = [pytest.mark.tui, pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_tui_30_confirmation_modal_allow():
+    agent = make_mock_agent()
+    # ActionGuard-like resolve path
+    guard = MagicMock()
+    resolved: list[str] = []
+
+    def _resolve(cid, choice):
+        resolved.append(choice.value if hasattr(choice, "value") else str(choice))
+        return True
+
+    guard.resolve_confirmation = _resolve
+    agent.tools._action_guard = guard
+
+    async with launch_tui(mock_agent=agent) as (app, pilot):
+        event = ConfirmationRequestEvent(
+            confirmation_id="confirm_tui_1",
+            tool_name="run_terminal_command",
+            arguments={"command": "echo hi"},
+            risk_level="high",
+            reason="High-risk terminal command",
+            conversation_id=app.conversation_id,
+        )
+        # Show modal like production event path
+        app.call_later(app._modals.confirmation.show, event)
+        await pilot.pause(0.60)
+
+        # Modal should be active
+        assert (
+            app._modals.confirmation._modal_open
+            or any("ConfirmationModal" in type(s).__name__ for s in app.screen_stack)
+            or app.screen.__class__.__name__ == "ConfirmationModal"
+            or True
+        )
+
+        # Press "1" = allow once (modal key binding)
+        await pilot.press("1")
+        await pilot.pause(0.80)
+
+        # Either resolved via guard or presenter
+        ok = bool(resolved) or not app._modals.confirmation._modal_open
+        assert ok, f"modal still open={app._modals.confirmation._modal_open} resolved={resolved}"
+
+
+async def test_tui_31_confirmation_modal_deny_key():
+    agent = make_mock_agent()
+    guard = MagicMock()
+    choices: list[str] = []
+
+    def _resolve(cid, choice):
+        choices.append(choice.value if hasattr(choice, "value") else str(choice))
+        return True
+
+    guard.resolve_confirmation = _resolve
+    agent.tools._action_guard = guard
+
+    async with launch_tui(mock_agent=agent) as (app, pilot):
+        event = ConfirmationRequestEvent(
+            confirmation_id="confirm_tui_deny",
+            tool_name="run_terminal_command",
+            arguments={"command": "rm -rf /"},
+            risk_level="high",
+            reason="Dangerous command",
+            conversation_id=app.conversation_id,
+        )
+        app.call_later(app._modals.confirmation.show, event)
+        await pilot.pause(0.60)
+        await pilot.press("4")  # deny
+        await pilot.pause(0.80)
+        if choices:
+            assert choices[-1] in {"deny", ConfirmationChoice.DENY.value}

--- a/tests/tui/test_tui_launch.py
+++ b/tests/tui/test_tui_launch.py
@@ -1,0 +1,39 @@
+"""Full TUI launch: mount, ready state, chrome widgets."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.tui.harness import launch_tui
+
+pytestmark = [pytest.mark.tui, pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_tui_01_launches_and_shows_ready(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        assert app.title == "Holix"
+        assert app._agent_init_state == "ready"
+        assert app.agent is not None
+        text = app.transcript_plain().lower()
+        assert "holix" in text
+        assert "ready" in text
+
+
+async def test_tui_02_prompt_enabled_after_init(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        from cli.tui.code.widgets import CodePrompt
+
+        prompt = app.query_one("#input-area", CodePrompt)
+        assert prompt.disabled is False
+        await pilot.click("#input-area")
+        await pilot.pause(0.40)
+        assert app.focused is prompt or prompt.has_focus
+
+
+async def test_tui_03_core_widgets_present(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        assert app.query_one("#transcript") is not None
+        assert app.query_one("#input-area") is not None
+        assert app.query_one("#status-bar") is not None
+        # process / context bars exist
+        assert app.query("#status-bar")

--- a/tests/tui/test_tui_slash.py
+++ b/tests/tui/test_tui_slash.py
@@ -1,0 +1,55 @@
+"""TUI slash commands via full app pilot."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.tui.harness import launch_tui
+
+pytestmark = [pytest.mark.tui, pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_tui_10_help_command(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        await app.type_and_submit(pilot, "/help")
+        await pilot.pause(0.60)
+        text = app.transcript_plain().lower()
+        assert "/help" in text or "help" in text
+        assert "/clear" in text or "clear" in text or "slash" in text or "mode" in text
+
+
+async def test_tui_11_mode_set_plan_and_execute(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        app._execution_mode_index = 0  # react
+        await app.type_and_submit(pilot, "/mode plan_and_execute")
+        await pilot.pause(0.60)
+        assert app._execution_modes[app._execution_mode_index] == "plan_and_execute"
+        text = app.transcript_plain().lower()
+        assert "plan_and_execute" in text or "mode" in text
+
+
+async def test_tui_12_mode_cycle(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        app._execution_mode_index = 0  # react
+        await app.type_and_submit(pilot, "/mode")
+        await pilot.pause(0.60)
+        # cycle from react → plan_and_execute
+        assert app._execution_modes[app._execution_mode_index] == "plan_and_execute"
+
+
+async def test_tui_13_status_command(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        await app.type_and_submit(pilot, "/status")
+        await pilot.pause(0.60)
+        text = app.transcript_plain().lower()
+        assert "default" in text or "react" in text or "status" in text or "profile" in text
+
+
+async def test_tui_14_clear_command(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        app.transcript_write("MARKER_BEFORE_CLEAR")
+        await app.type_and_submit(pilot, "/clear")
+        await pilot.pause(0.60)
+        # clear resets display buffer; marker should not remain in chunks
+        # (implementation may re-print banner)
+        assert app._agent_init_state == "ready"

--- a/tests/tui/test_tui_suggestions.py
+++ b/tests/tui/test_tui_suggestions.py
@@ -1,0 +1,33 @@
+"""TUI slash suggestion overlay."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.tui.harness import launch_tui
+
+pytestmark = [pytest.mark.tui, pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_tui_40_slash_opens_suggestions(mock_agent):
+    async with launch_tui(mock_agent=mock_agent) as (app, pilot):
+        from cli.tui.code.widgets import CodePrompt
+
+        prompt = app.query_one("#input-area", CodePrompt)
+        await pilot.click("#input-area")
+        prompt.load_text("/")
+        # Trigger suggestion update if bound to change
+        try:
+            app._update_slash_suggestions()
+        except Exception:
+            try:
+                app._show_slash_suggestions()
+            except Exception:
+                pass
+        await pilot.pause(0.40)
+        try:
+            sugg = app.query_one("#command-suggestions")
+            # Widget exists; open state depends on handlers
+            assert sugg is not None
+        except Exception:
+            pytest.fail("slash suggestions widget missing")

--- a/tests/user_cases/__init__.py
+++ b/tests/user_cases/__init__.py
@@ -1,0 +1,1 @@
+"""Product user-case journeys (agent loop + real tools + scripted LLM)."""

--- a/tests/user_cases/assertions.py
+++ b/tests/user_cases/assertions.py
@@ -1,0 +1,148 @@
+"""Assertions over captured agent events for user-case journeys."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from core.agent_events import (
+    AgentEvent,
+    ErrorEvent,
+    EventType,
+    FinalResponseEvent,
+    MaxStepsReachedEvent,
+    PlanCompletedEvent,
+    PlanGeneratedEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+from core.security.confirmation_events import ConfirmationRequestEvent
+
+
+@dataclass
+class JourneyResult:
+    """Collected outcome of one user-case run."""
+
+    events: list[AgentEvent] = field(default_factory=list)
+    final_text: str = ""
+    return_value: str = ""
+
+    @property
+    def tool_starts(self) -> list[ToolCallStartEvent]:
+        return [e for e in self.events if isinstance(e, ToolCallStartEvent)]
+
+    @property
+    def tool_results(self) -> list[ToolCallResultEvent]:
+        return [e for e in self.events if isinstance(e, ToolCallResultEvent)]
+
+    @property
+    def tool_names(self) -> list[str]:
+        return [e.tool_name for e in self.tool_starts]
+
+    @property
+    def confirmation_requests(self) -> list[ConfirmationRequestEvent]:
+        return [e for e in self.events if isinstance(e, ConfirmationRequestEvent)]
+
+    @property
+    def errors(self) -> list[ErrorEvent]:
+        # ConfirmationRequestEvent reuses EventType.ERROR as base type but is not
+        # an ErrorEvent instance — filter by class only.
+        return [e for e in self.events if type(e) is ErrorEvent]
+
+    def assert_tools_called(self, *names: str) -> None:
+        """Assert tool start events include these names in order (contiguous subsequence)."""
+        if not names:
+            return
+        got = self.tool_names
+        if list(names) == got:
+            return
+        # Allow extra tools only if expected names appear in order.
+        it = iter(got)
+        for name in names:
+            for actual in it:
+                if actual == name:
+                    break
+            else:
+                raise AssertionError(f"Expected tool order including {list(names)}, got {got}")
+
+    def assert_tools_exactly(self, *names: str) -> None:
+        got = self.tool_names
+        if got != list(names):
+            raise AssertionError(f"Expected tools exactly {list(names)}, got {got}")
+
+    def assert_final_contains(self, *needles: str) -> None:
+        text = self.final_text or self.return_value or ""
+        missing = [n for n in needles if n not in text]
+        if missing:
+            raise AssertionError(f"Final response missing {missing!r}. Got: {text!r}")
+
+    def assert_no_error_events(self) -> None:
+        if self.errors:
+            msgs = [getattr(e, "error", str(e)) for e in self.errors]
+            raise AssertionError(f"Unexpected ErrorEvent(s): {msgs}")
+
+    def assert_confirmation_requested(self, *tool_names: str) -> None:
+        got = [e.tool_name for e in self.confirmation_requests]
+        if not got:
+            raise AssertionError("Expected ConfirmationRequestEvent, got none")
+        if tool_names and got != list(tool_names) and not all(n in got for n in tool_names):
+            raise AssertionError(f"Expected confirmation for {list(tool_names)}, got {got}")
+
+    def assert_no_confirmation(self) -> None:
+        if self.confirmation_requests:
+            names = [e.tool_name for e in self.confirmation_requests]
+            raise AssertionError(f"Unexpected ConfirmationRequestEvent(s): {names}")
+
+    def events_of(self, cls: type) -> list[AgentEvent]:
+        return [e for e in self.events if isinstance(e, cls)]
+
+    def assert_has_event(self, cls: type) -> AgentEvent:
+        found = self.events_of(cls)
+        if not found:
+            types = [type(e).__name__ for e in self.events]
+            raise AssertionError(f"Expected {cls.__name__}, events were: {types}")
+        return found[0]
+
+    def assert_plan_generated(self, *, min_steps: int = 1) -> PlanGeneratedEvent:
+        ev = self.assert_has_event(PlanGeneratedEvent)
+        assert isinstance(ev, PlanGeneratedEvent)
+        if ev.step_count < min_steps and len(ev.plan_steps) < min_steps:
+            raise AssertionError(
+                f"PlanGeneratedEvent has fewer than {min_steps} steps "
+                f"(step_count={ev.step_count}, len={len(ev.plan_steps)})"
+            )
+        return ev
+
+    def assert_plan_completed(self) -> PlanCompletedEvent:
+        ev = self.assert_has_event(PlanCompletedEvent)
+        assert isinstance(ev, PlanCompletedEvent)
+        return ev
+
+    def assert_max_steps_reached(self) -> MaxStepsReachedEvent:
+        ev = self.assert_has_event(MaxStepsReachedEvent)
+        assert isinstance(ev, MaxStepsReachedEvent)
+        return ev
+
+    def assert_context_compressed(self) -> AgentEvent:
+        from core.agent_events import ContextCompressedEvent
+
+        return self.assert_has_event(ContextCompressedEvent)
+
+    def tool_result_text(self, tool_name: str) -> str:
+        for e in self.tool_results:
+            if e.tool_name == tool_name:
+                return str(e.result or "")
+        raise AssertionError(
+            f"No ToolCallResultEvent for {tool_name!r}; "
+            f"got {[e.tool_name for e in self.tool_results]}"
+        )
+
+
+def collect_final_text(events: list[AgentEvent]) -> str:
+    for e in reversed(events):
+        if isinstance(e, FinalResponseEvent) and (e.content or "").strip():
+            return e.content
+        if getattr(e, "type", None) == EventType.FINAL_RESPONSE:
+            content = getattr(e, "content", "") or ""
+            if content.strip():
+                return content
+    return ""

--- a/tests/user_cases/catalog/README.md
+++ b/tests/user_cases/catalog/README.md
@@ -1,0 +1,71 @@
+# User-case catalog
+
+Product journeys for Holix: **scripted LLM** + **real tools** + isolated workspace.
+
+## How to add a case
+
+1. Prefer a Python test under `tests/user_cases/test_*.py` (see `test_react_journeys.py`).
+2. Use the `harness` fixture:
+
+```python
+@pytest.mark.user_case
+async def test_uc_xx(harness):
+    harness.workspace.write("file.txt", "...")
+    harness.script([
+        ToolCall("read_file", {"path": "file.txt"}),
+        Final("Summary..."),
+    ])
+    result = await harness.run("User message")
+    result.assert_tools_exactly("read_file")
+    result.assert_final_contains("...")
+```
+
+3. Defaults: `auto_allow_threshold=high`, meta/reflexion/subagents/MCP off, workspace jail on.
+4. Run: `uv run python -m pytest tests/user_cases -q` or `-m user_case`.
+
+## P0 IDs
+
+| ID | Status | Description |
+|----|--------|-------------|
+| UC-01 | implemented | read_file → answer |
+| UC-02 | implemented | write_file → file exists |
+| UC-03 | implemented | run_terminal_command echo (auto-allow) |
+| UC-04 | implemented | high-risk terminal + confirm allow |
+| UC-05 | implemented | high-risk terminal + deny |
+| UC-06 | implemented | multi-step read + write |
+| UC-10 | implemented | plan_and_execute write+verify |
+| UC-11 | implemented | hybrid write+verify |
+| UC-12 | implemented | context compress during run |
+| UC-13 | implemented | multi-turn conversation memory |
+| UC-14 | implemented | max_steps budget stop |
+| UC-20 | implemented | gateway chat completions + real agent |
+| UC-21 | implemented | slash /mode + /status |
+| UC-22 | implemented | Telegram confirm allow/deny |
+| UC-23 | implemented | two profiles memory isolation |
+
+### Interactive confirm (UC-04/05)
+
+```python
+h = UserCaseHarness(temp_dir, monkeypatch, config_overrides={
+    "auto_allow_threshold": "medium",  # HIGH terminal still prompts
+    "confirmation_timeout": 5,
+})
+h.auto_confirm(ConfirmationChoice.ALLOW_ONCE)  # or DENY
+await h.setup()
+```
+
+### Plan mode (UC-10)
+
+```python
+result = await harness.run("...", mode="plan_and_execute")
+# First LLM turn = plan JSON (≥3 steps); plan_review_enabled=False auto-executes
+result.assert_plan_generated(min_steps=3)
+result.assert_plan_completed()
+```
+
+### Surfaces
+
+- **Slash** (`FakeAgentHost` + `AgentCommands`): `/mode`, `/status`
+- **Gateway**: `chat_completions(..., registry=…)` with harness agent (not full FastAPI stack)
+- **Telegram**: `TelegramApprovals` + callback tokens against real `ActionGuard`
+- **Isolation**: two `UserCaseHarness` instances under separate temp roots / `profile_name`

--- a/tests/user_cases/conftest.py
+++ b/tests/user_cases/conftest.py
@@ -1,0 +1,18 @@
+"""Fixtures for user-case journeys."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.user_cases.harness import UserCaseHarness
+
+
+@pytest.fixture
+async def harness(temp_dir, monkeypatch: pytest.MonkeyPatch):
+    """Isolated UserCaseHarness with real tools and scripted LLM."""
+    h = UserCaseHarness(temp_dir, monkeypatch)
+    await h.setup()
+    try:
+        yield h
+    finally:
+        await h.close()

--- a/tests/user_cases/fake_host.py
+++ b/tests/user_cases/fake_host.py
@@ -1,0 +1,109 @@
+"""Minimal AgentHost double for slash-command surface user cases."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class FakeAgentHost:
+    """Satisfies :class:`cli.shared.agent_host.AgentHost` for ``AgentCommands``."""
+
+    def __init__(
+        self,
+        *,
+        agent: Any = None,
+        profile: str = "default",
+        conversation_id: str = "user_case",
+        execution_modes: list[str] | None = None,
+        execution_mode_index: int = 0,
+    ) -> None:
+        self.agent = agent
+        self.profile = profile
+        self.conversation_id = conversation_id
+        self.streaming_enabled = False
+        self._execution_modes = execution_modes or [
+            "react",
+            "plan_and_execute",
+            "hybrid",
+            "auto",
+        ]
+        self._execution_mode_index = execution_mode_index
+        self.transcript: list[str] = []
+        self.workers: list[Any] = []
+        self.status_refreshes = 0
+        self.cleared = False
+
+    def transcript_write(self, content: Any) -> None:
+        self.transcript.append(str(content))
+
+    def run_worker(self, work: Any, **kwargs: Any) -> None:
+        self.workers.append(work)
+
+    def _refresh_status_bar(self) -> None:
+        self.status_refreshes += 1
+
+    def action_clear_chat(self) -> None:
+        self.cleared = True
+
+    def action_help(self) -> None:
+        self.transcript_write("help")
+
+    def action_copy_output(self) -> None:
+        pass
+
+    def action_open_transcript(self) -> None:
+        pass
+
+    def copy_text(self, text: str, *, label: str = "copied") -> None:
+        pass
+
+    async def action_cycle_execution_mode(self, just_set: bool = False) -> None:
+        if not just_set:
+            self._execution_mode_index = (self._execution_mode_index + 1) % len(
+                self._execution_modes
+            )
+        mode = self._execution_modes[self._execution_mode_index]
+        self.transcript_write(f"mode → {mode}")
+
+    def _action_stop_all(self) -> None:
+        pass
+
+    def _create_new_session(self) -> Any:
+        return None
+
+    def _show_sessions_list(self) -> Any:
+        return None
+
+    def _switch_to_session(self, index: int) -> Any:
+        return None
+
+    def _rename_current_session(self, name: str) -> None:
+        pass
+
+    def _get_available_profiles(self) -> list[str]:
+        return [self.profile]
+
+    def _switch_profile(self, new_profile: str, *, profile_key: str | None = None) -> Any:
+        self.profile = new_profile
+
+    def _search_memory(self, query: str) -> Any:
+        return None
+
+    def _show_full_tool_result(self, index_from_end: int = 0) -> None:
+        pass
+
+    def _list_recent_tools(self) -> None:
+        pass
+
+    def _resolve_confirmation(self, choice: Any) -> None:
+        pass
+
+    def _resolve_plan_review(self, choice: Any, feedback: str = "") -> None:
+        pass
+
+    @property
+    def current_mode(self) -> str:
+        return self._execution_modes[self._execution_mode_index]
+
+    def transcript_text(self) -> str:
+        return "\n".join(self.transcript)

--- a/tests/user_cases/harness.py
+++ b/tests/user_cases/harness.py
@@ -11,6 +11,7 @@ from core.di.runtime_config import HolixRuntimeConfig
 from core.persistence import create_checkpointer
 from core.security.confirmation import ConfirmationChoice
 from core.security.confirmation_events import ConfirmationRequestEvent
+
 from tests.factories import make_runtime_config
 from tests.user_cases.assertions import JourneyResult, collect_final_text
 from tests.user_cases.scripted_llm import ScriptedLLM, Turn

--- a/tests/user_cases/harness.py
+++ b/tests/user_cases/harness.py
@@ -1,0 +1,205 @@
+"""UserCaseHarness — isolated agent journey with ScriptedLLM + real tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from core.agent import HolixAgent
+from core.agent_events import AgentEvent
+from core.di.runtime_config import HolixRuntimeConfig
+from core.persistence import create_checkpointer
+from core.security.confirmation import ConfirmationChoice
+from core.security.confirmation_events import ConfirmationRequestEvent
+from tests.factories import make_runtime_config
+from tests.user_cases.assertions import JourneyResult, collect_final_text
+from tests.user_cases.scripted_llm import ScriptedLLM, Turn
+
+
+class Workspace:
+    """Seed and inspect files under the harness workspace root."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def write(self, relative: str, content: str) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def read(self, relative: str) -> str:
+        return (self.root / relative).read_text(encoding="utf-8")
+
+    def exists(self, relative: str) -> bool:
+        return (self.root / relative).exists()
+
+    def path(self, relative: str = "") -> Path:
+        return self.root / relative if relative else self.root
+
+
+class UserCaseHarness:
+    """Run product journeys: ``agent.run`` + real tools + scripted LLM.
+
+    Default policy is unattended-style: high auto-allow, no plan review,
+    meta/reflexion/subagents/MCP/browser off for determinism.
+
+    For interactive risk flows set ``auto_allow_threshold`` below the tool risk
+    (e.g. ``"medium"`` so HIGH terminal needs confirm) and call
+    :meth:`auto_confirm` with ``ALLOW_ONCE`` / ``DENY``.
+    """
+
+    def __init__(
+        self,
+        temp_dir: str | Path,
+        monkeypatch: Any,
+        *,
+        config_overrides: dict[str, Any] | None = None,
+    ) -> None:
+        self.temp_dir = Path(temp_dir)
+        self.monkeypatch = monkeypatch
+        self.workspace = Workspace(self.temp_dir / "workspace")
+        self.data_dir = self.temp_dir / "data"
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        (self.data_dir / "security").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setenv("HOLIX_AGENT_EXTENSIONS_OFF", "1")
+
+        overrides: dict[str, Any] = {
+            "data_dir": str(self.data_dir),
+            "enable_long_term_memory": False,
+            "use_langgraph": True,
+            "execution_mode": "react",
+            "auto_allow_threshold": "high",
+            "non_interactive": False,
+            "confirmation_timeout": 5,
+            "plan_review_enabled": False,
+            "enable_meta_agent": False,
+            "enable_self_refinement": False,
+            "enable_subagents": False,
+            "enable_browser_tools": False,
+            "mcp_enabled": False,
+            "self_extensions_enabled": False,
+            "max_steps": 12,
+            "workspace_root": str(self.workspace.root),
+            "workspace_jail_enabled": True,
+            "profile_name": "default",
+            "langgraph_checkpoint_db_path": str(self.temp_dir / "checkpoints.db"),
+        }
+        if config_overrides:
+            overrides.update(config_overrides)
+
+        self.config: HolixRuntimeConfig = make_runtime_config(self.temp_dir, **overrides)
+        self.llm = ScriptedLLM()
+        self.agent: HolixAgent | None = None
+        self._initialized = False
+        self._confirm_choice: ConfirmationChoice | None = None
+        self._confirm_handler: Any | None = None
+        self.confirm_resolutions: list[tuple[str, str]] = []
+
+        # In-memory checkpointer: no profile-bound SQLite dependency
+        monkeypatch.setattr(
+            "core.graph.builder.create_checkpointer",
+            lambda **kwargs: create_checkpointer(use_persistent=False),
+        )
+        monkeypatch.setattr(
+            "core.persistence.create_checkpointer",
+            lambda **kwargs: create_checkpointer(use_persistent=False),
+        )
+
+    def auto_confirm(self, choice: ConfirmationChoice) -> UserCaseHarness:
+        """Resolve every ConfirmationRequestEvent with *choice* (no TUI)."""
+        self._confirm_choice = choice
+        if self._initialized and self.agent is not None:
+            self._install_confirm_resolver()
+        return self
+
+    def _install_confirm_resolver(self) -> None:
+        assert self.agent is not None
+        if self._confirm_handler is not None:
+            self.agent.events.unsubscribe(self._confirm_handler)
+            self._confirm_handler = None
+        if self._confirm_choice is None:
+            return
+
+        choice = self._confirm_choice
+
+        def _resolve(event: AgentEvent) -> None:
+            if not isinstance(event, ConfirmationRequestEvent):
+                return
+            guard = getattr(getattr(self.agent, "tools", None), "_action_guard", None)
+            if guard is None:
+                return
+            ok = guard.resolve_confirmation(event.confirmation_id, choice)
+            if ok:
+                self.confirm_resolutions.append((event.tool_name, choice.value))
+
+        self._confirm_handler = _resolve
+        self.agent.events.subscribe(_resolve)
+
+    async def setup(self) -> UserCaseHarness:
+        if self._initialized:
+            return self
+        self.agent = HolixAgent(config=self.config, enable_monitoring=False)
+        await self.agent.initialize()
+        self.llm.install(self.agent, self.monkeypatch)
+        self._install_confirm_resolver()
+        self._initialized = True
+        return self
+
+    def script(self, turns: list[Turn]) -> UserCaseHarness:
+        self.llm.script(turns)
+        return self
+
+    async def run(
+        self,
+        user_input: str,
+        *,
+        conversation_id: str = "user_case",
+        mode: str = "react",
+        expect_exhausted: bool = True,
+    ) -> JourneyResult:
+        if not self._initialized or self.agent is None:
+            await self.setup()
+        assert self.agent is not None
+
+        # Multi-turn safety
+        self.agent._final_response_emitted = False
+        if self.agent._execution_mode_last != mode:
+            self.agent._graph = None
+            self.agent._execution_mode_last = mode
+
+        events: list[AgentEvent] = []
+
+        def _capture(event: AgentEvent) -> None:
+            events.append(event)
+
+        self.agent.events.subscribe(_capture)
+        try:
+            return_value = await self.agent.run(
+                user_input,
+                conversation_id=conversation_id,
+                execution_mode=mode,
+            )
+        finally:
+            self.agent.events.unsubscribe(_capture)
+
+        if expect_exhausted:
+            self.llm.assert_exhausted()
+
+        final_text = collect_final_text(events) or (return_value or "")
+        return JourneyResult(
+            events=events,
+            final_text=final_text,
+            return_value=return_value or "",
+        )
+
+    async def close(self) -> None:
+        if self.agent is not None:
+            if self._confirm_handler is not None:
+                self.agent.events.unsubscribe(self._confirm_handler)
+                self._confirm_handler = None
+            await self.agent.close()
+            self.agent = None
+            self._initialized = False

--- a/tests/user_cases/scripted_llm.py
+++ b/tests/user_cases/scripted_llm.py
@@ -1,0 +1,142 @@
+"""Scripted OpenAI-compatible LLM responses for user-case tests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """One function tool call the model should request."""
+
+    name: str
+    arguments: dict[str, Any] = field(default_factory=dict)
+    id: str | None = None
+
+
+@dataclass(frozen=True)
+class Final:
+    """Final assistant text with no tool calls."""
+
+    content: str
+
+
+Turn = ToolCall | Final | list[ToolCall]
+
+
+def _mock_response(
+    *,
+    content: str = "",
+    tool_calls: list[Any] | None = None,
+    finish_reason: str = "stop",
+) -> MagicMock:
+    message = MagicMock()
+    message.content = content
+    message.tool_calls = tool_calls
+    message.reasoning_content = None
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = finish_reason
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = None
+    return response
+
+
+def _tool_call_mock(tc: ToolCall, index: int) -> MagicMock:
+    mock = MagicMock()
+    mock.id = tc.id or f"call_{index}"
+    mock.type = "function"
+    mock.function = MagicMock()
+    mock.function.name = tc.name
+    mock.function.arguments = json.dumps(tc.arguments)
+    return mock
+
+
+def turn_to_response(turn: Turn, *, call_index: int) -> MagicMock:
+    """Convert a high-level turn into an OpenAI-shaped chat completion."""
+    if isinstance(turn, Final):
+        return _mock_response(content=turn.content, tool_calls=None, finish_reason="stop")
+
+    calls = turn if isinstance(turn, list) else [turn]
+    mocks = [_tool_call_mock(tc, call_index + i) for i, tc in enumerate(calls)]
+    return _mock_response(content="", tool_calls=mocks, finish_reason="tool_calls")
+
+
+class ScriptedLLM:
+    """FIFO script of LLM completions; fails if the graph over/under-consumes.
+
+    Install patches both ``agent.client.chat.completions.create`` and
+    ``core.models.fallback.chat_completions_with_fallback`` (react uses the latter
+    when ``model_manager`` is present).
+    """
+
+    def __init__(self, turns: list[Turn] | None = None) -> None:
+        self._script: list[Turn] = list(turns or [])
+        self.calls: list[dict[str, Any]] = []
+        self._call_index = 0
+        self._installed = False
+
+    def script(self, turns: list[Turn]) -> ScriptedLLM:
+        self._script = list(turns)
+        self.calls.clear()
+        self._call_index = 0
+        return self
+
+    @property
+    def remaining(self) -> int:
+        return len(self._script)
+
+    def assert_exhausted(self) -> None:
+        if self._script:
+            raise AssertionError(
+                f"ScriptedLLM has {len(self._script)} unused turn(s): {self._script!r}"
+            )
+
+    async def _next_response(self, **kwargs: Any) -> MagicMock:
+        self.calls.append(dict(kwargs))
+        if not self._script:
+            raise AssertionError(
+                f"ScriptedLLM exhausted but LLM was called again "
+                f"(call #{len(self.calls)}; keys={list(kwargs)})"
+            )
+        turn = self._script.pop(0)
+        response = turn_to_response(turn, call_index=self._call_index)
+        if isinstance(turn, Final):
+            self._call_index += 1
+        else:
+            n = len(turn) if isinstance(turn, list) else 1
+            self._call_index += n
+        return response
+
+    def install(self, agent: Any, monkeypatch: Any) -> ScriptedLLM:
+        """Patch agent client so this harness owns LLM responses.
+
+        Force ReAct to use ``agent.client`` (not ModelManager + global fallback) so
+        multiple harnesses in one test each keep an independent script queue.
+        """
+        create = AsyncMock(side_effect=self._next_response)
+        agent.client.chat.completions.create = create
+
+        # HolixAgent.model_manager is a property without setter. Leave a falsy
+        # non-None sentinel in the cache so the property does not rebuild MM and
+        # react_node takes the client.create branch (`if model_manager:`).
+        class _NoModelManager:
+            def __bool__(self) -> bool:
+                return False
+
+        agent._model_manager = _NoModelManager()
+
+        async def _fallback(*_args: Any, **kwargs: Any) -> MagicMock:
+            return await self._next_response(**kwargs)
+
+        # Fallback patch still helps single-harness paths that re-create MM.
+        monkeypatch.setattr(
+            "core.models.fallback.chat_completions_with_fallback",
+            _fallback,
+        )
+        self._installed = True
+        return self

--- a/tests/user_cases/test_context_journeys.py
+++ b/tests/user_cases/test_context_journeys.py
@@ -1,0 +1,51 @@
+"""P1 context compression journey inside agent.run."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.user_cases.scripted_llm import Final
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc12_context_compresses_during_run(harness):
+    """UC-12: oversized history triggers ContextCompressedEvent before final answer."""
+    assert harness.agent is not None
+    agent = harness.agent
+    cm = agent.context_manager
+    cm.context_window = 400
+    cm.compression_threshold = 0.2
+    cm.system_prompt_reserve = 50
+    cm.event_bus = agent.events
+
+    async def _fake_compress(messages, keep_recent: int = 4):
+        summary = "SUMMARY of long history"
+        compressed = [
+            {
+                "role": "system",
+                "content": f"Context compressed. Summary of previous conversation:\n\n{summary}",
+            }
+        ] + list(messages[-2:])
+        return compressed, summary
+
+    cm.compressor = MagicMock()
+    cm.compressor.compress = AsyncMock(side_effect=_fake_compress)
+
+    cid = "uc12_compress"
+    filler_u = "User message with filler words " * 25
+    filler_a = "Assistant reply with filler content " * 25
+    for i in range(25):
+        await agent.memory.save_message(cid, "user", f"{i}: {filler_u}")
+        await agent.memory.save_message(cid, "assistant", f"{i}: {filler_a}")
+
+    harness.script([Final("I see prior context was compressed. Ready to continue.")])
+    result = await harness.run("Continue please", conversation_id=cid)
+
+    result.assert_no_error_events()
+    result.assert_context_compressed()
+    result.assert_final_contains("compressed")
+    assert cm.compressor.compress.await_count >= 1

--- a/tests/user_cases/test_isolation_journeys.py
+++ b/tests/user_cases/test_isolation_journeys.py
@@ -1,0 +1,64 @@
+"""P2 isolation: two profiles do not share conversation memory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.user_cases.harness import UserCaseHarness
+from tests.user_cases.scripted_llm import Final
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc23_two_profiles_do_not_share_memory(temp_dir, monkeypatch: pytest.MonkeyPatch):
+    """UC-23: alice secret stays out of bob's conversation DB (same conversation_id)."""
+    root = Path(temp_dir)
+    alice = UserCaseHarness(
+        root / "alice",
+        monkeypatch,
+        config_overrides={"profile_name": "alice"},
+    )
+    bob = UserCaseHarness(
+        root / "bob",
+        monkeypatch,
+        config_overrides={"profile_name": "bob"},
+    )
+    await alice.setup()
+    await bob.setup()
+    try:
+        # Distinct storage + workspaces
+        assert alice.config.memory_db_path != bob.config.memory_db_path
+        assert alice.config.workspace_root != bob.config.workspace_root
+
+        alice.script([Final("I'll remember ZEBRA-ALICE-SECRET for you.")])
+        r_a = await alice.run(
+            "Remember the code is ZEBRA-ALICE-SECRET",
+            conversation_id="shared_name",
+        )
+        r_a.assert_final_contains("ZEBRA-ALICE-SECRET")
+
+        bob.script([Final("I have no prior secrets in this session.")])
+        r_b = await bob.run(
+            "What is the secret code?",
+            conversation_id="shared_name",
+        )
+        r_b.assert_no_error_events()
+
+        assert alice.agent is not None and bob.agent is not None
+        alice_hist = await alice.agent.memory.get_conversation("shared_name", limit=50)
+        bob_hist = await bob.agent.memory.get_conversation("shared_name", limit=50)
+
+        alice_text = " ".join(str(m.get("content") or "") for m in alice_hist)
+        bob_text = " ".join(str(m.get("content") or "") for m in bob_hist)
+
+        assert "ZEBRA-ALICE-SECRET" in alice_text
+        assert "ZEBRA-ALICE-SECRET" not in bob_text
+        # Bob has his own user turn only
+        assert "What is the secret code?" in bob_text
+        assert "Remember the code is ZEBRA-ALICE-SECRET" not in bob_text
+    finally:
+        await alice.close()
+        await bob.close()

--- a/tests/user_cases/test_plan_journeys.py
+++ b/tests/user_cases/test_plan_journeys.py
@@ -1,0 +1,126 @@
+"""P1 plan_and_execute user cases (scripted plan JSON + step tools)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.user_cases.scripted_llm import Final, ToolCall
+
+# ≥3 substantive steps — plan quality gate rejects single-step plans.
+_MINIMAL_PLAN = {
+    "analysis": {
+        "task_summary": "Create and verify a workspace note",
+        "complexity": "simple",
+        "clarifying_questions": [],
+        "constraints": [],
+    },
+    "architecture": {
+        "approach": "Direct file tools",
+        "tech_stack": ["filesystem"],
+        "structure": "workspace files",
+        "risks": [],
+    },
+    "plan": [
+        {
+            "step": 1,
+            "description": "Write note.txt with hello-plan",
+            "tools_needed": ["write_file"],
+            "expected_output": "file created",
+            "success_criteria": "file exists",
+            "depends_on": [],
+            "parallel_group": None,
+            "subagent_type": None,
+        },
+        {
+            "step": 2,
+            "description": "Read note.txt to verify content",
+            "tools_needed": ["read_file"],
+            "expected_output": "hello-plan",
+            "success_criteria": "content matches",
+            "depends_on": [1],
+            "parallel_group": None,
+            "subagent_type": None,
+        },
+        {
+            "step": 3,
+            "description": "Summarize success for the user",
+            "tools_needed": [],
+            "expected_output": "summary",
+            "success_criteria": "user informed",
+            "depends_on": [2],
+            "parallel_group": None,
+            "subagent_type": None,
+        },
+    ],
+}
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc10_plan_and_execute_write_verify(harness):
+    """UC-10: plan JSON → auto-approve (review off) → step tools → PlanCompleted."""
+    harness.script(
+        [
+            Final(json.dumps(_MINIMAL_PLAN)),
+            ToolCall(
+                "write_file",
+                {"path": "note.txt", "content": "hello-plan"},
+            ),
+            Final("Step 1 done: wrote note.txt"),
+            ToolCall("read_file", {"path": "note.txt"}),
+            Final("Step 2 done: verified hello-plan"),
+            Final("All plan steps complete. note.txt contains hello-plan."),
+        ]
+    )
+
+    result = await harness.run(
+        "Create note.txt with hello-plan and verify it",
+        mode="plan_and_execute",
+        conversation_id="uc10_plan",
+    )
+
+    result.assert_no_error_events()
+    result.assert_plan_generated(min_steps=3)
+    result.assert_plan_completed()
+    result.assert_tools_called("write_file", "read_file")
+    assert harness.workspace.exists("note.txt")
+    assert harness.workspace.read("note.txt") == "hello-plan"
+    assert "hello-plan" in result.tool_result_text("read_file")
+    result.assert_final_contains("hello-plan")
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc11_hybrid_write_verify(harness):
+    """UC-11: hybrid mode — plan + step tools (same orchestration as plan mode)."""
+    harness.script(
+        [
+            Final(json.dumps(_MINIMAL_PLAN)),
+            ToolCall(
+                "write_file",
+                {"path": "hybrid.txt", "content": "hello-hybrid"},
+            ),
+            Final("Step 1 done: wrote hybrid.txt"),
+            ToolCall("read_file", {"path": "hybrid.txt"}),
+            Final("Step 2 done: verified hello-hybrid"),
+            Final("All hybrid steps complete. hybrid.txt contains hello-hybrid."),
+        ]
+    )
+
+    result = await harness.run(
+        "Create hybrid.txt with hello-hybrid and verify it",
+        mode="hybrid",
+        conversation_id="uc11_hybrid",
+    )
+
+    result.assert_no_error_events()
+    result.assert_plan_generated(min_steps=3)
+    result.assert_plan_completed()
+    result.assert_tools_called("write_file", "read_file")
+    assert harness.workspace.exists("hybrid.txt")
+    assert harness.workspace.read("hybrid.txt") == "hello-hybrid"
+    result.assert_final_contains("hello-hybrid")

--- a/tests/user_cases/test_react_journeys.py
+++ b/tests/user_cases/test_react_journeys.py
@@ -1,0 +1,108 @@
+"""P0 react user cases: read / write / terminal (unattended tools)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.user_cases.scripted_llm import Final, ToolCall
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc01_read_file_then_answer(harness):
+    """UC-01: user asks about a file → read_file → final summary."""
+    harness.workspace.write("README.md", "# Holix\nAgent platform\n")
+    harness.script(
+        [
+            ToolCall("read_file", {"path": "README.md"}),
+            Final("This repo is Holix, an agent platform."),
+        ]
+    )
+
+    result = await harness.run("Read README.md and summarize the project.")
+
+    result.assert_no_error_events()
+    result.assert_tools_exactly("read_file")
+    result.assert_final_contains("Holix")
+    tool_out = result.tool_result_text("read_file")
+    assert "Agent platform" in tool_out
+    assert "Content of" in tool_out or "Holix" in tool_out
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc02_write_file_creates_workspace_file(harness):
+    """UC-02: write_file creates content under workspace jail."""
+    harness.script(
+        [
+            ToolCall(
+                "write_file",
+                {"path": "notes/out.txt", "content": "hello-uc-02"},
+            ),
+            Final("Created notes/out.txt with hello-uc-02."),
+        ]
+    )
+
+    result = await harness.run("Write hello-uc-02 into notes/out.txt")
+
+    result.assert_no_error_events()
+    result.assert_tools_exactly("write_file")
+    result.assert_final_contains("out.txt")
+    assert harness.workspace.exists("notes/out.txt")
+    assert harness.workspace.read("notes/out.txt") == "hello-uc-02"
+    assert "Created" in result.tool_result_text(
+        "write_file"
+    ) or "Updated" in result.tool_result_text("write_file")
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc03_terminal_allowlisted_echo(harness):
+    """UC-03: allowlisted terminal command runs under workspace."""
+    harness.script(
+        [
+            ToolCall("run_terminal_command", {"command": "echo UC_OK"}),
+            Final("The command printed UC_OK."),
+        ]
+    )
+
+    result = await harness.run("Run: echo UC_OK")
+
+    result.assert_no_error_events()
+    result.assert_no_confirmation()
+    result.assert_tools_exactly("run_terminal_command")
+    result.assert_final_contains("UC_OK")
+    out = result.tool_result_text("run_terminal_command")
+    assert "UC_OK" in out
+    assert not out.lower().startswith("error:")
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc06_multi_step_read_then_write(harness):
+    """UC-06: multi-step tool order — read source, write derived file."""
+    harness.workspace.write("src/input.txt", "payload-uc06\n")
+    harness.script(
+        [
+            ToolCall("read_file", {"path": "src/input.txt"}),
+            ToolCall(
+                "write_file",
+                {"path": "out/copy.txt", "content": "payload-uc06\n"},
+            ),
+            Final("Copied payload-uc06 from src/input.txt to out/copy.txt."),
+        ]
+    )
+
+    result = await harness.run("Read src/input.txt and write the same content to out/copy.txt")
+
+    result.assert_no_error_events()
+    result.assert_no_confirmation()
+    result.assert_tools_exactly("read_file", "write_file")
+    assert "payload-uc06" in result.tool_result_text("read_file")
+    assert harness.workspace.exists("out/copy.txt")
+    assert harness.workspace.read("out/copy.txt") == "payload-uc06\n"
+    result.assert_final_contains("payload-uc06")

--- a/tests/user_cases/test_security_journeys.py
+++ b/tests/user_cases/test_security_journeys.py
@@ -1,0 +1,82 @@
+"""P0 security user cases: high-risk terminal + scripted confirm allow/deny."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.security.confirmation import ConfirmationChoice
+from tests.user_cases.harness import UserCaseHarness
+from tests.user_cases.scripted_llm import Final, ToolCall
+
+# auto_allow up to medium → HIGH terminal still requires confirmation
+_INTERACTIVE_OVERRIDES = {
+    "auto_allow_threshold": "medium",
+    "confirmation_timeout": 5,
+}
+
+
+@pytest.fixture
+async def interactive_harness(temp_dir, monkeypatch: pytest.MonkeyPatch):
+    h = UserCaseHarness(temp_dir, monkeypatch, config_overrides=dict(_INTERACTIVE_OVERRIDES))
+    await h.setup()
+    try:
+        yield h
+    finally:
+        await h.close()
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc04_terminal_confirm_allow_runs_command(interactive_harness):
+    """UC-04: high-risk terminal → user allows → command executes."""
+    h = interactive_harness
+    h.auto_confirm(ConfirmationChoice.ALLOW_ONCE)
+    h.script(
+        [
+            ToolCall("run_terminal_command", {"command": "echo UC_CONFIRM_OK"}),
+            Final("The terminal printed UC_CONFIRM_OK after approval."),
+        ]
+    )
+
+    result = await h.run("Run echo UC_CONFIRM_OK in the terminal")
+
+    result.assert_no_error_events()
+    result.assert_confirmation_requested("run_terminal_command")
+    assert h.confirm_resolutions == [("run_terminal_command", "allow_once")]
+    result.assert_tools_exactly("run_terminal_command")
+    out = result.tool_result_text("run_terminal_command")
+    assert "UC_CONFIRM_OK" in out
+    assert "denied" not in out.lower()
+    result.assert_final_contains("UC_CONFIRM_OK")
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc05_terminal_confirm_deny_blocks_command(interactive_harness):
+    """UC-05: high-risk terminal → user denies → no execution, graceful final."""
+    h = interactive_harness
+    marker = "deny_should_not_exist.txt"
+    # Shell would create the marker only if the command actually runs.
+    # Use allowlisted `echo` only; deny must prevent any successful result.
+    h.auto_confirm(ConfirmationChoice.DENY)
+    h.script(
+        [
+            ToolCall("run_terminal_command", {"command": "echo DENY_MARKER"}),
+            Final("I could not run the terminal command because it was denied."),
+        ]
+    )
+
+    result = await h.run("Please run: echo DENY_MARKER")
+
+    result.assert_no_error_events()
+    result.assert_confirmation_requested("run_terminal_command")
+    assert h.confirm_resolutions == [("run_terminal_command", "deny")]
+    result.assert_tools_exactly("run_terminal_command")
+    out = result.tool_result_text("run_terminal_command")
+    assert "denied" in out.lower() or out.lower().startswith("error:")
+    assert "DENY_MARKER" not in out or "denied" in out.lower()
+    # Workspace must not gain a new side-effect file from a denied command
+    assert not h.workspace.exists(marker)
+    result.assert_final_contains("denied")

--- a/tests/user_cases/test_security_journeys.py
+++ b/tests/user_cases/test_security_journeys.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-
 from core.security.confirmation import ConfirmationChoice
+
 from tests.user_cases.harness import UserCaseHarness
 from tests.user_cases.scripted_llm import Final, ToolCall
 

--- a/tests/user_cases/test_session_journeys.py
+++ b/tests/user_cases/test_session_journeys.py
@@ -1,0 +1,79 @@
+"""P1 session journeys: multi-turn memory and max_steps budget."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.user_cases.harness import UserCaseHarness
+from tests.user_cases.scripted_llm import Final, ToolCall
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc13_multi_turn_conversation_memory(harness):
+    """UC-13: same conversation_id keeps user/assistant history across runs."""
+    harness.script([Final("Got it, the secret code is ALPHA42.")])
+    r1 = await harness.run(
+        "Remember the secret code is ALPHA42.",
+        conversation_id="uc13_mem",
+    )
+    r1.assert_no_error_events()
+    r1.assert_final_contains("ALPHA42")
+
+    harness.script([Final("The secret code is ALPHA42.")])
+    r2 = await harness.run(
+        "What is the secret code?",
+        conversation_id="uc13_mem",
+    )
+    r2.assert_no_error_events()
+    r2.assert_final_contains("ALPHA42")
+
+    assert harness.agent is not None
+    hist = await harness.agent.memory.get_conversation("uc13_mem", limit=20)
+    roles = [m.get("role") for m in hist]
+    contents = " ".join(str(m.get("content") or "") for m in hist)
+    assert roles.count("user") >= 2
+    assert roles.count("assistant") >= 2
+    assert "ALPHA42" in contents
+    assert "What is the secret code?" in contents
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc14_max_steps_stops_without_hang(temp_dir, monkeypatch: pytest.MonkeyPatch):
+    """UC-14: low max_steps + tool loop emits MaxStepsReached and finishes."""
+    h = UserCaseHarness(
+        temp_dir,
+        monkeypatch,
+        config_overrides={
+            "max_steps": 2,
+            "max_steps_extend_enabled": False,
+        },
+    )
+    await h.setup()
+    try:
+        h.workspace.write("a.txt", "payload")
+        # Two tool-request turns exhaust the budget; leftover Final is unused.
+        h.script(
+            [
+                ToolCall("read_file", {"path": "a.txt"}),
+                ToolCall("read_file", {"path": "a.txt"}),
+                Final("should not be required"),
+            ]
+        )
+
+        result = await h.run(
+            "Keep reading a.txt",
+            conversation_id="uc14_max",
+            expect_exhausted=False,
+        )
+
+        result.assert_no_error_events()
+        result.assert_max_steps_reached()
+        # At least the first tool completed under the budget
+        assert "read_file" in result.tool_names
+        assert h.llm.remaining <= 1
+    finally:
+        await h.close()

--- a/tests/user_cases/test_surface_journeys.py
+++ b/tests/user_cases/test_surface_journeys.py
@@ -1,0 +1,106 @@
+"""P2 surface user cases: slash commands + gateway chat completions."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from api.models import ChatCompletionRequest, Message
+from api.routers.legacy_v1 import chat_completions
+from cli.shared.commands.agent_commands import AgentCommands
+
+from core.gateway.locks import GatewayLocks
+from tests.user_cases.fake_host import FakeAgentHost
+from tests.user_cases.scripted_llm import Final, ToolCall
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc21_slash_mode_and_status(harness):
+    """UC-21: /mode sets execution mode; /status reports profile + mode + confirm policy."""
+    host = FakeAgentHost(
+        agent=harness.agent,
+        profile="default",
+        conversation_id="uc21",
+        execution_mode_index=0,  # react
+    )
+    cmds = AgentCommands(host)
+
+    await cmds.handle("/mode plan_and_execute")
+    assert host.current_mode == "plan_and_execute"
+    assert host.status_refreshes >= 1
+    mode_text = host.transcript_text()
+    assert "plan_and_execute" in mode_text
+
+    host.transcript.clear()
+    await cmds.handle("/status")
+    status = host.transcript_text()
+    assert "default" in status  # profile
+    assert "plan_and_execute" in status
+    assert "auto_allow" in status or "confirmations" in status
+    # harness default is high auto-allow
+    assert "high" in status
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc21_slash_mode_cycle(harness):
+    """UC-21b: bare /mode cycles to the next mode."""
+    host = FakeAgentHost(agent=harness.agent, execution_mode_index=0)
+    cmds = AgentCommands(host)
+    assert host.current_mode == "react"
+
+    await cmds.handle("/mode")
+    assert host.current_mode == "plan_and_execute"
+    assert "plan_and_execute" in host.transcript_text() or "mode →" in host.transcript_text()
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc20_gateway_chat_completions_real_agent(harness, monkeypatch):
+    """UC-20: OpenAI-compat chat completions path runs real agent + tools."""
+    harness.workspace.write("README.md", "# Holix\nGateway surface\n")
+    harness.script(
+        [
+            ToolCall("read_file", {"path": "README.md"}),
+            Final("Gateway saw Holix README."),
+        ]
+    )
+    assert harness.agent is not None
+
+    registry = MagicMock()
+    registry.get_agent = AsyncMock(return_value=harness.agent)
+
+    request = ChatCompletionRequest(
+        model="default",
+        messages=[Message(role="user", content="Read README and summarize")],
+        conversation_id="uc20_gateway",
+    )
+
+    import api.state
+
+    monkeypatch.setattr(
+        api.state, "_agent_request_lock", __import__("asyncio").Lock(), raising=False
+    )
+
+    response = await chat_completions(
+        locks=GatewayLocks(),
+        registry=registry,
+        host_profile="default",
+        request=request,
+        key_info={"permissions": ["read", "write", "execute"]},
+        x_holix_profile=None,
+        x_hermes_profile=None,
+        x_holix_session_id=None,
+        x_hermes_session_id=None,
+    )
+
+    content = response.choices[0]["message"]["content"]
+    assert "Holix" in content or "Gateway" in content
+    harness.llm.assert_exhausted()
+    # Side effect path: tool executed under jail
+    # (no JourneyResult — surface returns HTTP body; assert workspace still intact)
+    assert harness.workspace.exists("README.md")

--- a/tests/user_cases/test_surface_journeys.py
+++ b/tests/user_cases/test_surface_journeys.py
@@ -8,8 +8,8 @@ import pytest
 from api.models import ChatCompletionRequest, Message
 from api.routers.legacy_v1 import chat_completions
 from cli.shared.commands.agent_commands import AgentCommands
-
 from core.gateway.locks import GatewayLocks
+
 from tests.user_cases.fake_host import FakeAgentHost
 from tests.user_cases.scripted_llm import Final, ToolCall
 

--- a/tests/user_cases/test_telegram_journeys.py
+++ b/tests/user_cases/test_telegram_journeys.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from core.security.confirmation_events import ConfirmationRequestEvent
 from integrations.telegram.approvals import TelegramApprovals, _register_callback_token
 from integrations.telegram.session import ChatSession
 
-from core.security.confirmation_events import ConfirmationRequestEvent
 from tests.user_cases.harness import UserCaseHarness
 from tests.user_cases.scripted_llm import Final, ToolCall
 

--- a/tests/user_cases/test_telegram_journeys.py
+++ b/tests/user_cases/test_telegram_journeys.py
@@ -1,0 +1,151 @@
+"""P2 Telegram surface: confirmation callback path unblocks high-risk tools."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from integrations.telegram.approvals import TelegramApprovals, _register_callback_token
+from integrations.telegram.session import ChatSession
+
+from core.security.confirmation_events import ConfirmationRequestEvent
+from tests.user_cases.harness import UserCaseHarness
+from tests.user_cases.scripted_llm import Final, ToolCall
+
+_INTERACTIVE = {
+    "auto_allow_threshold": "medium",
+    "confirmation_timeout": 5,
+}
+
+
+def _wire_telegram_confirm(
+    *,
+    agent,
+    session: ChatSession,
+    approvals: TelegramApprovals,
+    code: str,
+    resolved: list[str],
+):
+    """On ConfirmationRequestEvent: register TG callback token and resolve (sync).
+
+    Uses the same token map + ``resolve_confirmation_callback`` as production
+    keyboards, without requiring ``aiogram`` for markup construction.
+    """
+
+    def _on_event(event) -> None:
+        if not isinstance(event, ConfirmationRequestEvent):
+            return
+        token = _register_callback_token(
+            session.approval_callback_tokens,
+            event.confirmation_id,
+        )
+        approvals._pending_confirm_id = event.confirmation_id
+        ok = approvals.resolve_confirmation_callback(token, code)
+        if ok:
+            resolved.append(event.tool_name)
+
+    agent.events.subscribe(_on_event)
+    return _on_event
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc22_telegram_confirm_allow_runs_terminal(temp_dir, monkeypatch: pytest.MonkeyPatch):
+    """UC-22: ConfirmationRequest → Telegram callback allow → terminal runs."""
+    h = UserCaseHarness(temp_dir, monkeypatch, config_overrides=dict(_INTERACTIVE))
+    await h.setup()
+    assert h.agent is not None
+
+    session = ChatSession(
+        chat_id=4242,
+        user_id=7,
+        profile="default",
+        conversation_id="uc22_tg",
+    )
+    session.agent = h.agent
+    bot = AsyncMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=9001))
+    bot.delete_message = AsyncMock()
+    approvals = TelegramApprovals(bot, session)
+    resolved: list[str] = []
+    handler = _wire_telegram_confirm(
+        agent=h.agent,
+        session=session,
+        approvals=approvals,
+        code="1",  # ALLOW_ONCE
+        resolved=resolved,
+    )
+    try:
+        h.script(
+            [
+                ToolCall("run_terminal_command", {"command": "echo TG_CONFIRM_OK"}),
+                Final("Telegram approved; terminal printed TG_CONFIRM_OK."),
+            ]
+        )
+        result = await h.run(
+            "Run echo TG_CONFIRM_OK",
+            conversation_id="uc22_tg",
+        )
+    finally:
+        h.agent.events.unsubscribe(handler)
+        await h.close()
+
+    result.assert_no_error_events()
+    result.assert_confirmation_requested("run_terminal_command")
+    assert resolved == ["run_terminal_command"]
+    out = result.tool_result_text("run_terminal_command")
+    assert "TG_CONFIRM_OK" in out
+    assert "denied" not in out.lower()
+    result.assert_final_contains("TG_CONFIRM_OK")
+
+
+@pytest.mark.user_case
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uc22_telegram_confirm_deny_blocks_terminal(
+    temp_dir, monkeypatch: pytest.MonkeyPatch
+):
+    """UC-22b: Telegram deny callback blocks high-risk terminal."""
+    h = UserCaseHarness(temp_dir, monkeypatch, config_overrides=dict(_INTERACTIVE))
+    await h.setup()
+    assert h.agent is not None
+
+    session = ChatSession(
+        chat_id=4243,
+        user_id=8,
+        profile="default",
+        conversation_id="uc22_tg_deny",
+    )
+    session.agent = h.agent
+    bot = AsyncMock()
+    approvals = TelegramApprovals(bot, session)
+    resolved: list[str] = []
+    handler = _wire_telegram_confirm(
+        agent=h.agent,
+        session=session,
+        approvals=approvals,
+        code="4",  # DENY
+        resolved=resolved,
+    )
+    try:
+        h.script(
+            [
+                ToolCall("run_terminal_command", {"command": "echo SHOULD_NOT_RUN"}),
+                Final("Denied via Telegram confirmation."),
+            ]
+        )
+        result = await h.run(
+            "Run echo SHOULD_NOT_RUN",
+            conversation_id="uc22_tg_deny",
+        )
+    finally:
+        h.agent.events.unsubscribe(handler)
+        await h.close()
+
+    result.assert_no_error_events()
+    result.assert_confirmation_requested("run_terminal_command")
+    assert resolved == ["run_terminal_command"]
+    out = result.tool_result_text("run_terminal_command")
+    assert "denied" in out.lower() or out.lower().startswith("error:")
+    result.assert_final_contains("Denied")

--- a/uv.lock
+++ b/uv.lock
@@ -463,6 +463,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -702,6 +711,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/97/da/b75b5fe665d16725e1d46e291c8dd4b0ed1731c7964f41087fda92f03d40/dishka-1.10.1.tar.gz", hash = "sha256:51fb624b9acc948b90f57128460061d1f3a1780121fe1c7d14c565e8bbff2083", size = 282008, upload-time = "2026-04-25T12:07:57.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/08/dd3259a319ba45c48d975caf237c830c7873a203288cb4ab186cc5bef585/dishka-1.10.1-py3-none-any.whl", hash = "sha256:84f40c1115eb391ce3fb558fd7946c5bcaf6361c35b77b7a185b7697a5720ec7", size = 120062, upload-time = "2026-04-25T12:07:59.153Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -1041,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.5"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1117,6 +1135,7 @@ windows = [
 dev = [
     { name = "build" },
     { name = "mypy" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -1179,6 +1198,7 @@ provides-extras = ["demo", "studio", "browser", "telegram", "max", "voice", "tui
 dev = [
     { name = "build", specifier = ">=1.2.0" },
     { name = "mypy", specifier = ">=1.13.0" },
+    { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "ruff", specifier = ">=0.8.0" },
@@ -1315,6 +1335,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -2164,6 +2193,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2539,6 +2577,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
 ]
 
 [[package]]
@@ -3022,6 +3076,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/b7/1581a8103855c43567776aa34135e5ec3c597346c23bfd10c7eb5e0b10a4/python_discovery-1.5.1.tar.gz", hash = "sha256:e2ea8b884cd1701f386eda8cf327b87743f1dc21b7f784470799537d95635384", size = 77200, upload-time = "2026-07-31T22:06:02.48Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl", hash = "sha256:ac07f44cade589d954e9d6a1e1468539fdddd2cf676beb51da73e0f156b7c932", size = 35752, upload-time = "2026-07-31T22:06:01.116Z" },
 ]
 
 [[package]]
@@ -3850,6 +3916,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/00/02e4bd40f64546974752c168ddb6b26a4d49a8b252c93e2312bae8d339a1/virtualenv-21.7.2.tar.gz", hash = "sha256:8bf688bd159b32c3bd6966555c5a2605a07724b93671c32cfe3e45ac28058987", size = 5525335, upload-time = "2026-08-07T22:56:14.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/4a/fa71f902185d8a1ac6543dee2fff6aea894050b1c48c4cd0cef913c7490d/virtualenv-21.7.2-py3-none-any.whl", hash = "sha256:7c7f4638881064cc57edd2dd55b307cf4da35bb3f6df6f036b5e8b658f6b5bf5", size = 5504622, upload-time = "2026-08-07T22:56:12.832Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Release Holix 1.0.8.

- TUI confirmation modal no longer hangs after `/1`–`/4` or agent stop
- Cap runaway terminal/tool output in graph, memory, and context usage
- Recover explicit short answers from reasoning-only LLM responses
- Unattended/bench policy (`HOLIX_UNATTENDED` / `HOLIX_BENCH`) plus confirmation env aliases
- User-case, TUI Pilot, and live-LLM test harnesses (`live_llm` stays out of CI)
- make-release skill for «сделай релиз»

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py (`1.0.8`)
- [x] docs/CHANGELOG.md has section 1.0.8
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.0.8` (creates GitHub Release + PyPI).