### PR TITLE
Holix 1.0.10

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"

--- a/config.py
+++ b/config.py
@@ -137,6 +137,11 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("HOLIX_SUBAGENT_SUPERVISOR_COOLDOWN_S"),
         description="Minimum seconds between interventions for the same job",
     )
+    subagent_supervisor_loop_cooldown_s: float = Field(
+        default=8.0,
+        validation_alias=AliasChoices("HOLIX_SUBAGENT_SUPERVISOR_LOOP_COOLDOWN_S"),
+        description="Minimum seconds between loop-break guidance for the same job",
+    )
 
     # Agent response pipeline: classic ≈1.0.2 (default) | modern anti-monologue
     agent_pipeline: str = Field(

--- a/core/agent.py
+++ b/core/agent.py
@@ -341,26 +341,44 @@ class HolixAgent:
         except Exception:
             pass
         # Register MCP tools (if configured in profile/runtime). Non-fatal.
+        # Fill popular-catalog defs for assigned-but-not-installed servers
+        # (e.g. context7 on python-coder) so process-mode children inherit them.
         mcp_count = 0
-        if getattr(self.config, "mcp_enabled", True) and getattr(self.config, "mcp_servers", None):
+        if getattr(self.config, "mcp_enabled", True):
             try:
-                mcp_count = await self.tools.register_mcp(
-                    self.config.mcp_servers,
-                    getattr(self.config, "mcp_assignments", None),
-                    slot="main",
-                    ready_timeout=mcp_ready_timeout,
+                from core.mcp.assign import fill_assigned_mcp_servers
+
+                assignments = getattr(self.config, "mcp_assignments", None)
+                servers = fill_assigned_mcp_servers(
+                    getattr(self.config, "mcp_servers", None),
+                    assignments,
                 )
+                if servers != (getattr(self.config, "mcp_servers", None) or {}):
+                    try:
+                        self.config = self.config.with_overrides(mcp_servers=servers)
+                    except Exception:
+                        try:
+                            self.config.mcp_servers = servers  # type: ignore[misc]
+                        except Exception:
+                            pass
+                if servers:
+                    mcp_count = await self.tools.register_mcp(
+                        servers,
+                        assignments,
+                        slot="main",
+                        ready_timeout=mcp_ready_timeout,
+                    )
             except Exception as e:
                 self.emit(ThinkingEvent(message=f"MCP init warning: {e}"))
-        self.emit(ThinkingEvent(
-            message=f"Registered {len(self.tools.tools)} tools: {', '.join(self.tools.get_tool_names())}"
-            + (f" (+{mcp_count} MCP)" if mcp_count else "")
-        ))
+        self.emit(
+            ThinkingEvent(
+                message=f"Registered {len(self.tools.tools)} tools: {', '.join(self.tools.get_tool_names())}"
+                + (f" (+{mcp_count} MCP)" if mcp_count else "")
+            )
+        )
 
         self.skills.load_all_skills(defer_index=defer_skill_index)
-        self.emit(ThinkingEvent(
-            message=f"Loaded {len(self.skills.all_skills)} skills"
-        ))
+        self.emit(ThinkingEvent(message=f"Loaded {len(self.skills.all_skills)} skills"))
 
         if hasattr(self.memory, "set_skills_manager"):
             self.memory.set_skills_manager(self.skills)
@@ -435,9 +453,7 @@ class HolixAgent:
         loaded = result.get("loaded") or []
         self.emit(
             ThinkingEvent(
-                message=(
-                    f"Agent extensions reloaded: {', '.join(loaded) if loaded else '(none)'}"
-                )
+                message=(f"Agent extensions reloaded: {', '.join(loaded) if loaded else '(none)'}")
             )
         )
         return result
@@ -479,6 +495,12 @@ class HolixAgent:
             mcp_servers = getattr(self.config, "mcp_servers", {}) or {}
         if mcp_assignments is None:
             mcp_assignments = getattr(self.config, "mcp_assignments", {}) or {}
+        try:
+            from core.mcp.assign import fill_assigned_mcp_servers
+
+            mcp_servers = fill_assigned_mcp_servers(mcp_servers, mcp_assignments)
+        except Exception:
+            mcp_servers = dict(mcp_servers or {})
 
         # Cleanup old MCP
         try:

--- a/core/agent_execution.py
+++ b/core/agent_execution.py
@@ -114,7 +114,9 @@ async def run_agent_loop(
         logger.warning(f"Memory search failed: {e}")
 
     # Build system prompt
-    tools_desc = format_tools_description(agent.tools.get_schemas())
+    tools_desc = format_tools_description(
+        agent.tools.get_schemas(for_agent_slot=getattr(agent, "agent_slot", "main"))
+    )
     agent_config = getattr(agent, "config", None)
     profile_name = getattr(agent_config, "profile_name", None)
     persona_name = getattr(agent, "studio_agent_type", None)
@@ -193,7 +195,7 @@ async def run_agent_loop(
                             factory=lambda cfg, llm_client: llm_client.chat.completions.create(
                                 model=cfg.model,
                                 messages=api_messages,
-                                tools=agent.tools.get_schemas(),
+                                tools=agent.tools.get_schemas(for_agent_slot=agent_slot),
                                 tool_choice="auto",
                                 temperature=temperature,
                                 stream=True,
@@ -376,7 +378,7 @@ async def run_agent_loop(
                             primary_override=primary_override,
                             on_switch=_on_fallback_switch,
                             messages=api_messages,
-                            tools=agent.tools.get_schemas(),
+                            tools=agent.tools.get_schemas(for_agent_slot=agent_slot),
                             tool_choice="auto",
                             temperature=temperature,
                         )
@@ -384,7 +386,7 @@ async def run_agent_loop(
                         response = await client.chat.completions.create(
                             model=model,
                             messages=api_messages,
-                            tools=agent.tools.get_schemas(),
+                            tools=agent.tools.get_schemas(for_agent_slot=agent_slot),
                             tool_choice="auto",
                             temperature=temperature,
                         )

--- a/core/config_utils.py
+++ b/core/config_utils.py
@@ -80,22 +80,42 @@ def resolve_env_refs(value: Any) -> Any:
 
 from pathlib import Path
 
-_LOCAL_SYSTEM_KEYS: frozenset[str] = frozenset({
-    "model", "base_url", "api_key", "temperature", "max_steps",
-    "max_steps_extend_enabled", "max_steps_extend_by",
-    "max_steps_max_extensions", "max_steps_hard_cap",
-    "subagent_supervisor_enabled", "subagent_supervisor_poll_s",
-    "subagent_supervisor_idle_s", "subagent_supervisor_max_interventions",
-    "subagent_supervisor_cooldown_s",
-    "providers", "agent_models", "default_provider",
-    "auto_allow_threshold", "non_interactive", "confirmation_timeout",
-    "plan_review_enabled", "plan_review_timeout",
-    "enable_subagents", "enable_meta_agent", "enable_self_refinement",
-    "agent_pipeline",
-    "enable_evolution", "context_window",
-    # security-ish that must stay global
-    "api_key_pepper", "require_auth",
-})
+_LOCAL_SYSTEM_KEYS: frozenset[str] = frozenset(
+    {
+        "model",
+        "base_url",
+        "api_key",
+        "temperature",
+        "max_steps",
+        "max_steps_extend_enabled",
+        "max_steps_extend_by",
+        "max_steps_max_extensions",
+        "max_steps_hard_cap",
+        "subagent_supervisor_enabled",
+        "subagent_supervisor_poll_s",
+        "subagent_supervisor_idle_s",
+        "subagent_supervisor_max_interventions",
+        "subagent_supervisor_cooldown_s",
+        "subagent_supervisor_loop_cooldown_s",
+        "providers",
+        "agent_models",
+        "default_provider",
+        "auto_allow_threshold",
+        "non_interactive",
+        "confirmation_timeout",
+        "plan_review_enabled",
+        "plan_review_timeout",
+        "enable_subagents",
+        "enable_meta_agent",
+        "enable_self_refinement",
+        "agent_pipeline",
+        "enable_evolution",
+        "context_window",
+        # security-ish that must stay global
+        "api_key_pepper",
+        "require_auth",
+    }
+)
 
 
 def _path_is_dir(path: Path) -> bool:
@@ -125,6 +145,7 @@ def load_local_overlay(cwd: str | None = None) -> dict[str, Any]:
         return {}
     try:
         import yaml  # lazy
+
         with open(cfg_file, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         return resolve_env_refs(data)

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -490,7 +490,12 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
             },
             messages_patch,
         )
-    tools = agent.tools.get_schemas() if agent and hasattr(agent, "tools") else []
+    agent_slot = getattr(agent, "agent_slot", "main") if agent else "main"
+    tools = (
+        agent.tools.get_schemas(for_agent_slot=agent_slot)
+        if agent and hasattr(agent, "tools")
+        else []
+    )
     tool_choice = resolve_tool_choice(state, messages, tools=tools)
     temperature = 0.7
     if agent and hasattr(agent, "config"):
@@ -512,8 +517,6 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
             },
             messages_patch,
         )
-
-    agent_slot = getattr(agent, "agent_slot", "main") if agent else "main"
     model_manager = getattr(agent, "model_manager", None) if agent else None
     primary_override = getattr(agent, "active_model_config", None) if agent else None
     llm_timeout_s = _llm_step_timeout_s(agent)
@@ -1535,7 +1538,8 @@ def _build_system_prompt_from_state(state: HolixGraphState, agent=None) -> str:
     # Format tools
     tools_desc = ""
     if agent and hasattr(agent, "tools"):
-        tools_desc = format_tools_description(agent.tools.get_schemas())
+        slot = getattr(agent, "agent_slot", "main")
+        tools_desc = format_tools_description(agent.tools.get_schemas(for_agent_slot=slot))
 
     # Format skills
     skills_formatted = ""

--- a/core/mcp/assign.py
+++ b/core/mcp/assign.py
@@ -1,0 +1,129 @@
+"""Resolve which MCP servers a slot may use, and fill missing popular configs."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def assigned_mcp_names(assignments: dict[str, list[str]] | None) -> list[str]:
+    """Unique server names mentioned in any agent-slot allow-list."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for lst in (assignments or {}).values():
+        for raw in lst or []:
+            name = str(raw or "").strip()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+def servers_for_slot(
+    assignments: dict[str, list[str]] | None,
+    slot: str,
+    *,
+    installed: list[str] | None = None,
+) -> list[str] | None:
+    """Allow-list for a slot.
+
+    ``None`` → inherit all installed servers.
+    ``[]`` → none.
+    ``[...]`` → only those names.
+    """
+    assigns = assignments or {}
+    key = (slot or "main").strip().lower() or "main"
+    if key in assigns:
+        return [str(s).strip() for s in (assigns.get(key) or []) if str(s).strip()]
+    return None if installed is None else list(installed)
+
+
+def mcp_tool_allowed(
+    tool_name: str,
+    *,
+    slot: str,
+    assignments: dict[str, list[str]] | None,
+) -> bool:
+    """True if ``mcp_<server>_…`` may be shown to ``slot``."""
+    name = str(tool_name or "")
+    if not name.startswith("mcp_"):
+        return True
+    allowed = servers_for_slot(assignments, slot)
+    if allowed is None:
+        return True
+    return any(name.startswith(f"mcp_{srv}_") for srv in allowed)
+
+
+def mcp_defs_for_names(
+    servers: dict[str, Any] | None,
+    names: list[str] | None,
+) -> dict[str, Any]:
+    """Installed + popular-catalog defs for the given server names only."""
+    wanted = [str(n).strip() for n in (names or []) if str(n).strip()]
+    if not wanted:
+        return {}
+    filled = fill_assigned_mcp_servers(servers, {"_": wanted})
+    return {name: filled[name] for name in wanted if name in filled}
+
+
+def mcp_server_incomplete(cfg: Any) -> bool:
+    """True when a saved MCP entry cannot be launched (no command / URL)."""
+    if not isinstance(cfg, dict) or not cfg:
+        return True
+    transport = str(cfg.get("transport") or "stdio").strip().lower()
+    if transport in {"sse", "http", "streamable-http"}:
+        return not str(cfg.get("url") or "").strip()
+    return not str(cfg.get("command") or "").strip()
+
+
+def _merge_env(popular_env: dict[str, Any], existing_env: dict[str, Any]) -> dict[str, Any]:
+    env = dict(popular_env or {})
+    for key, val in dict(existing_env or {}).items():
+        if str(val or "").strip():
+            env[key] = val
+    for key, val in list(env.items()):
+        if str(val or "").strip():
+            continue
+        from_env = os.environ.get(key, "")
+        if from_env.strip():
+            env[key] = from_env
+    return env
+
+
+def fill_assigned_mcp_servers(
+    servers: dict[str, Any] | None,
+    assignments: dict[str, list[str]] | None,
+) -> dict[str, Any]:
+    """Copy ``servers`` and add/complete popular-catalog configs for assigned names."""
+    out: dict[str, Any] = dict(servers or {})
+    to_fill = [
+        name
+        for name in assigned_mcp_names(assignments)
+        if name not in out or mcp_server_incomplete(out.get(name))
+    ]
+    if not to_fill:
+        return out
+    try:
+        from core.mcp.installer import build_config_from_popular
+        from core.mcp.popular import get_popular_by_key
+    except Exception:
+        return out
+    for name in to_fill:
+        pop = get_popular_by_key(name)
+        if pop is None:
+            continue
+        try:
+            cfg = dict(build_config_from_popular(pop, {}) or {})
+        except Exception:
+            continue
+        existing = out.get(name) if isinstance(out.get(name), dict) else {}
+        env = _merge_env(dict(cfg.get("env") or {}), dict((existing or {}).get("env") or {}))
+        if env:
+            cfg["env"] = env
+        if existing and existing.get("default_risk_level") not in (None, ""):
+            cfg["default_risk_level"] = existing.get("default_risk_level")
+        cfg.setdefault("_source", "popular")
+        cfg["_auto_from_assignment"] = True
+        out[name] = cfg
+    return out

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -62,10 +62,47 @@ class MCPManager:
         self._last_errors: dict[str, str] = {}
         self._connected = False
         self._lock = asyncio.Lock()
+        # Optional sync callback(name) after list_tools (or failure). Used to
+        # harvest adapters when a slow npx server becomes ready after timeout.
+        self.on_tools_ready: Any = None
 
     @property
     def available_servers(self) -> list[str]:
         return list(self._configs.keys())
+
+    def server_status(self) -> list[dict[str, Any]]:
+        """Per-server ready/error/tool-count snapshot for /mcp tools."""
+        rows: list[dict[str, Any]] = []
+        for name in self._configs:
+            ready = bool(self._ready_events.get(name) and self._ready_events[name].is_set())
+            rows.append(
+                {
+                    "name": name,
+                    "ready": ready,
+                    "connected": name in self._sessions,
+                    "tools": len(self._discovered_tools.get(name) or []),
+                    "error": self._last_errors.get(name) or "",
+                }
+            )
+        return rows
+
+    def _mark_ready(
+        self,
+        name: str,
+        tools: list[dict[str, Any]],
+        error: str | None = None,
+    ) -> None:
+        self._discovered_tools[name] = tools
+        if error:
+            self._last_errors[name] = error
+        ev = self._ready_events.setdefault(name, asyncio.Event())
+        ev.set()
+        cb = self.on_tools_ready
+        if callable(cb):
+            try:
+                cb(name)
+            except Exception:
+                logger.debug("on_tools_ready failed for %s", name, exc_info=True)
 
     async def connect_all(self) -> None:
         if not MCP_AVAILABLE:
@@ -142,16 +179,10 @@ class MCPManager:
                                         or {"type": "object", "properties": {}},
                                     }
                                 )
-                            self._discovered_tools[name] = tools
-                            # Signal ready for waiters
-                            ev = self._ready_events.setdefault(name, asyncio.Event())
-                            ev.set()
+                            self._mark_ready(name, tools)
                         except Exception as disc_err:
                             logger.warning("MCP tool discovery failed for %s: %s", name, disc_err)
-                            self._discovered_tools[name] = []
-                            self._last_errors[name] = f"discovery: {disc_err}"
-                            ev = self._ready_events.setdefault(name, asyncio.Event())
-                            ev.set()  # signal even on discovery failure so waiters unblock
+                            self._mark_ready(name, [], error=f"discovery: {disc_err}")
                         # Park until cancelled. Use a simple event that never sets.
                         await asyncio.Event().wait()
             else:  # sse
@@ -185,15 +216,10 @@ class MCPManager:
                                         or {"type": "object", "properties": {}},
                                     }
                                 )
-                            self._discovered_tools[name] = tools
-                            ev = self._ready_events.setdefault(name, asyncio.Event())
-                            ev.set()
+                            self._mark_ready(name, tools)
                         except Exception as disc_err:
                             logger.warning("MCP tool discovery failed for %s: %s", name, disc_err)
-                            self._discovered_tools[name] = []
-                            self._last_errors[name] = f"discovery: {disc_err}"
-                            ev = self._ready_events.setdefault(name, asyncio.Event())
-                            ev.set()
+                            self._mark_ready(name, [], error=f"discovery: {disc_err}")
                         await asyncio.Event().wait()
         except asyncio.CancelledError:
             logger.info("MCP keeper for %s cancelled (normal shutdown)", name)
@@ -203,9 +229,7 @@ class MCPManager:
 
             msg = format_mcp_error(exc)
             logger.error("MCP keeper for %s failed: %s", name, msg)
-            self._last_errors[name] = msg
-            ev = self._ready_events.setdefault(name, asyncio.Event())
-            ev.set()
+            self._mark_ready(name, [], error=msg)
         finally:
             self._sessions.pop(name, None)
             self._discovered_tools.pop(name, None)

--- a/core/models/menu.py
+++ b/core/models/menu.py
@@ -68,9 +68,7 @@ def build_models_menu(profile: str) -> ModelsMenuState:
         if key in seen:
             continue
         seen.add(key)
-        presets.append(
-            ModelChoice(slot_id=name, label=name, provider=mc.provider, model=mc.model)
-        )
+        presets.append(ModelChoice(slot_id=name, label=name, provider=mc.provider, model=mc.model))
 
     providers: list[ProviderMenu] = []
     for pname, pdata in sorted((cfg.providers or {}).items()):
@@ -79,10 +77,8 @@ def build_models_menu(profile: str) -> ModelsMenuState:
         for mid in pdata.get("available_models") or []:
             if mid and mid not in models:
                 models.append(mid)
-        if default_model and default_model not in models:
-            models.insert(0, default_model)
-        if not models and default_model:
-            models = [default_model]
+        # Do not inject default_model if it is not in the live available list —
+        # that re-surfaces stale aliases (qwen3.8-27b-mac1, etc.).
         if models:
             providers.append(
                 ProviderMenu(

--- a/core/models/setup_helpers.py
+++ b/core/models/setup_helpers.py
@@ -106,9 +106,7 @@ def resolve_preset_api_key_interactive(
         return preset.api_key_placeholder
 
     out = console or Console()
-    out.print(
-        f"[dim]Set {preset.api_key_env} in .env or enter key now to list models.[/dim]"
-    )
+    out.print(f"[dim]Set {preset.api_key_env} in .env or enter key now to list models.[/dim]")
     entered = Prompt.ask(
         f"API key ({preset.api_key_env})",
         password=True,
@@ -131,7 +129,11 @@ def resolve_api_key_for_preset(
     """Pick API key: explicit value, live env, or ${ENV} placeholder for YAML."""
     if custom_key is not None and custom_key.strip():
         return custom_key.strip()
-    if use_env_value and preset.api_key_env in os.environ and os.environ[preset.api_key_env].strip():
+    if (
+        use_env_value
+        and preset.api_key_env in os.environ
+        and os.environ[preset.api_key_env].strip()
+    ):
         return preset.api_key_placeholder
     if preset.auth_type == "none":
         return "EMPTY" if preset.id == "vllm" else "ollama"
@@ -148,7 +150,9 @@ def prompt_host_for_preset(preset: ProviderPreset, *, console: Any = None) -> st
     if preset.host_env and os.environ.get(preset.host_env, "").strip():
         base = resolve_preset_base_url(preset)
         if console:
-            console.print(f"[dim]Using {preset.host_env}={os.environ[preset.host_env].strip()}[/dim]")
+            console.print(
+                f"[dim]Using {preset.host_env}={os.environ[preset.host_env].strip()}[/dim]"
+            )
         return base
 
     default_hint = f"{preset.default_host}:{preset.default_port}"
@@ -333,15 +337,18 @@ def build_provider_entry(
             ctx = m.get("context_length")
             if mid and ctx:
                 model_contexts[mid] = int(ctx)
-
-    for mid in preset.popular_models:
-        if mid not in available:
-            available.append(mid)
+    else:
+        # Probe failed or skipped — fall back to the catalog shortlist only.
+        for mid in preset.popular_models:
+            if mid not in available:
+                available.append(mid)
 
     if not available and preset.default_model:
         available = [preset.default_model]
 
-    resolved_default = default_model or preset.default_model or (available[0] if available else None)
+    resolved_default = (
+        default_model or preset.default_model or (available[0] if available else None)
+    )
     resolved_url = base_url or preset.base_url
     meta = merge_provider_metadata(preset.default_metadata(), metadata_extra)
     if preset.configurable_host and preset.host_env:
@@ -357,6 +364,33 @@ def build_provider_entry(
         metadata=meta,
     )
     return cfg.model_dump()
+
+
+def apply_live_model_ids(provider_data: dict[str, Any], live_ids: list[str]) -> dict[str, Any]:
+    """Replace catalog lists with ids the provider actually returned.
+
+    Drops stale ``user_visible_models`` / ``premium_models`` / default that
+    are not in the live ``/v1/models`` set.
+    """
+    out = dict(provider_data or {})
+    live: list[str] = []
+    seen: set[str] = set()
+    for raw in live_ids:
+        mid = str(raw or "").strip()
+        if not mid or mid in seen:
+            continue
+        seen.add(mid)
+        live.append(mid)
+    out["available_models"] = live
+    live_set = set(live)
+    for key in ("user_visible_models", "premium_models"):
+        if key not in out:
+            continue
+        out[key] = [str(m).strip() for m in (out.get(key) or []) if str(m).strip() in live_set]
+    default = str(out.get("default_model") or "").strip()
+    if default and default not in live_set:
+        out["default_model"] = live[0] if live else ""
+    return out
 
 
 async def add_preset_to_config(

--- a/core/runtime/introspect_signals.py
+++ b/core/runtime/introspect_signals.py
@@ -18,7 +18,8 @@ _INTROSPECT_RE = re.compile(
     r"|import\s+inspect\b"
     r"|\bdis\.dis\b"
     r"|__code__"
-    r"|__(?:name|doc|annotations|defaults|kwdefaults|qualname|module|"
+    # Not ``__name__``: ``type(exc).__name__`` is normal error handling.
+    r"|__(?:doc|annotations|defaults|kwdefaults|qualname|module|"
     r"dict|mro|globals|func__)__"
     r"|python\d*\s+-c\b[^;\n]*\b(?:dir|vars|type|help|getattr|hasattr)\s*\(",
     re.I,

--- a/core/runtime/introspect_signals.py
+++ b/core/runtime/introspect_signals.py
@@ -1,0 +1,101 @@
+"""Detect terminal loops that only introspect libraries instead of writing code.
+
+``inspect.getsource(DadataClient.suggest)`` then ``.geolocate`` then ``.close``
+are not identical signatures, so the generic tool-loop detector misses them.
+The agent can burn a full step budget without ever calling write_file.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from core.runtime.test_run_signals import extract_command
+
+_INTROSPECT_RE = re.compile(
+    r"inspect\.(?:getsource|getmembers|signature|getfile|getsourcelines|"
+    r"getmro|getmodule)\b"
+    r"|import\s+inspect\b"
+    r"|\bdis\.dis\b"
+    r"|__code__"
+    r"|__(?:name|doc|annotations|defaults|kwdefaults|qualname|module|"
+    r"dict|mro|globals|func__)__"
+    r"|python\d*\s+-c\b[^;\n]*\b(?:dir|vars|type|help|getattr|hasattr)\s*\(",
+    re.I,
+)
+
+# Any ``python -c`` that imports a module is a REPL probe, not implementation.
+_PYTHON_C_IMPORT = re.compile(
+    r"\bpython\d*\s+-c\b[\s\S]{0,4000}\b(?:import|from)\s+\w+",
+    re.I,
+)
+
+_TERMINAL = frozenset({"terminal", "run_terminal_command", "code_executor", "execute_python"})
+_WRITE = frozenset({"write_file", "delete_file"})
+
+INTROSPECT_REFUSAL = (
+    "Error: Library introspection is blocked "
+    "(python -c, inspect.getsource, dir/type/__code__/__doc__). "
+    "That is not implementation and will not be executed.\n"
+    "Required next tool: **write_file**. Create the project files now "
+    "(pyproject.toml, package, routers, tests).\n"
+    "DaData: `DadataAsync(token, secret)` / `DadataClient` — "
+    "`suggest(name, query)`, `geolocate`, `iplocate`, `find_by_id`. "
+    "Do not probe the installed package again."
+)
+
+
+def is_introspect_command(command: str) -> bool:
+    text = command or ""
+    if _INTROSPECT_RE.search(text):
+        return True
+    return bool(_PYTHON_C_IMPORT.search(text))
+
+
+def is_introspect_code(code: str) -> bool:
+    """Same gate for execute_python / code_executor snippets."""
+    text = code or ""
+    if _INTROSPECT_RE.search(text):
+        return True
+    if re.search(r"\b(?:import|from)\s+inspect\b", text):
+        return True
+    if re.search(r"\b(?:import|from)\s+dadata\b", text, re.I):
+        return True
+    return False
+
+
+def is_introspect_trace(trace: dict[str, Any]) -> bool:
+    name = str(trace.get("name") or "").strip().lower()
+    if name not in _TERMINAL:
+        return False
+    blob = trace.get("arguments") or trace.get("details") or ""
+    if name in {"code_executor", "execute_python"}:
+        text = str(blob)
+        if text.startswith("{") or text.startswith("["):
+            try:
+                import json
+
+                obj = json.loads(text)
+                if isinstance(obj, dict):
+                    text = str(obj.get("code") or obj.get("expression") or text)
+            except Exception:
+                pass
+        return is_introspect_code(text)
+    return is_introspect_command(extract_command(blob))
+
+
+def introspect_loop(
+    traces: list[dict[str, Any]] | None,
+    *,
+    min_hits: int = 3,
+    lookback: int = 8,
+) -> bool:
+    """True when the last terminal calls are all library introspection."""
+    recent = list(traces or [])[-lookback:]
+    if any(str(t.get("name") or "").strip().lower() in _WRITE for t in recent):
+        return False
+    terms = [t for t in recent if str(t.get("name") or "").strip().lower() in _TERMINAL]
+    if len(terms) < min_hits:
+        return False
+    last = terms[-min_hits:]
+    return all(is_introspect_trace(t) for t in last)

--- a/core/runtime/service_detect.py
+++ b/core/runtime/service_detect.py
@@ -1,0 +1,381 @@
+"""Classify shell commands as a one-shot job vs a long-running service.
+
+Regex can never cover every language and wrapper. Two layers:
+
+1. **Static** — high-confidence launch verbs at a *segment head*
+   (``cargo run``, ``go run``, ``java -jar``, ``dotnet run``, …).
+   Mentions inside ``grep`` / ``pip list`` are ignored.
+2. **Runtime** — after the process has been running for ~60s, look at the
+   process tree. A TCP LISTEN socket is the language-agnostic signal that
+   this is a server, not ``cargo test`` / ``mvn package`` / a long compile.
+
+A long job that never binds (train loop, ``sleep``, hung compile) is left
+alone. A pytest suite that happens to bind a fixture port is treated as a
+one-shot and is not promoted.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+from core.platform_compat import IS_WINDOWS
+
+# Default: give compiles / test suites a minute before we peek inside.
+_DEFAULT_WATCH_AFTER = 60.0
+_DEFAULT_WATCH_INTERVAL = 10.0
+
+# Prefixes that are not the launched binary (env, wrappers).
+_LAUNCH_PREFIX = re.compile(
+    r"^(?:"
+    r"[\w.]+=\S+\s+"
+    r"|export\s+[\w.]+=\S+\s+"
+    r"|sudo\s+(?:-\w\s+)*"
+    r"|nohup\s+"
+    r"|exec\s+"
+    r"|command\s+"
+    r"|time\s+"
+    r"|nice\s+"
+    r"|env\s+(?:-[\w]+\s+|[\w.]+=\S+\s+)*"
+    r")*",
+    re.I,
+)
+
+# Segments that only inspect / filter / build / test — never a server start.
+_INSPECT_HEAD = re.compile(
+    r"^(?:"
+    r"grep|egrep|fgrep|rg|ag|ack|"
+    r"head|tail|wc|cat|less|more|bat|"
+    r"awk|sed|cut|sort|uniq|tr|"
+    r"echo|printf|"
+    r"which|type|whereis|"
+    r"ls|lsof|pgrep|pkill|kill|killall|fuser|"
+    r"ps|top|htop|"
+    r"pip\d*\s+(?:list|show|freeze|index|search|install|uninstall)|"
+    r"python\d*\s+-m\s+pip\s+"
+    r"(?:list|show|freeze|index|search|install)|"
+    r"uv\s+pip\s+(?:list|show|freeze|install)|"
+    r"(?:npm|pnpm|yarn)\s+(?:ls|list|install|ci|"
+    r"(?:run\s+)?(?:test|build|lint|typecheck|check|ci))\b|"
+    r"npx\s+(?:tsc|eslint|jest|vitest|prettier)\b|"
+    r"ruff|pytest|py\.test|mypy|black|isort|coverage|"
+    r"python\d*\s+-m\s+(?:pytest|unittest|mypy|ruff|compileall)\b|"
+    r"cargo\s+(?:-\S+\s+)*(?:build|test|check|clippy|fmt|bench|doc|clean|update|fetch)\b|"
+    r"go\s+(?:-\S+\s+)*(?:test|build|vet|fmt|mod|generate|install)\b|"
+    r"(?:[\w./-]+/)?(?:mvn|mvnw)\b(?!.*(?:spring-boot:run|quarkus:dev))"
+    r".*\b(?:test|package|compile|install|verify|clean|dependency:)\b|"
+    r"(?:[\w./-]+/)?gradlew?\s+(?:-\S+\s+)*(?:test|build|check|assemble|clean)\b|"
+    r"dotnet\s+(?:-\S+\s+)*(?:test|build|restore|publish|clean|pack)\b|"
+    r"cmake\b|ctest\b|"
+    r"(?:g\+\+|gcc|clang\+\+|clang|rustc|javac)(?:\s|$)|"
+    r"make\s+(?:all|test|check|clean|install|build)\b"
+    r")",
+    re.I,
+)
+
+# Launch verb at the start of a segment (after prefixes).
+_LAUNCH_HEAD = re.compile(
+    r"^(?:"
+    r"(?:[\w./-]+/)?(?:uvicorn|gunicorn|hypercorn|daphne)\b|"
+    r"python\d*\s+-m\s+uvicorn\b|"
+    r"python\d*\s+-m\s+http\.server\b|"
+    r"python\d*\s+-m\s+(?!pip\b|pytest\b|ruff\b|venv\b|compileall\b|http\.server\b)"
+    r"[\w.]+\.main\b|"
+    r"python\d*(?:\s+-\w+(?:=\S+)?)*\s+(?!-m\b)(?:\./|\S+/)?main\.py\b|"
+    r"python\d*\s+\S*manage\.py\s+runserver\b|"
+    r"fastapi\s+run\b|"
+    r"flask\s+run\b|"
+    r"(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:dev|start|serve)\b|"
+    r"next\s+dev\b|"
+    r"nuxt\s+dev\b|"
+    r"vite\b(?!\s+build\b)|"
+    r"nodemon\b|"
+    r"python\d*\s+\S*bot\.py\b|"
+    r"python\d*\s+-m\s+integrations\.telegram\b|"
+    r"telegram_channel_publisher\b|"
+    # Rust / Go / Java / C# / JVM build tools / PHP / Ruby / Elixir
+    r"cargo\s+run\b|"
+    r"cargo\s+watch\b|"
+    r"go\s+run\b|"
+    r"java\s+(?:-\S+\s+)*-jar\b|"
+    r"(?:[\w./-]+/)?(?:mvn|mvnw)\s+.*spring-boot:run\b|"
+    r"(?:[\w./-]+/)?(?:mvn|mvnw)\s+.*quarkus:dev\b|"
+    r"(?:[\w./-]+/)?gradlew?\s+.*bootRun\b|"
+    r"(?:[\w./-]+/)?gradlew?\s+.*quarkusDev\b|"
+    r"dotnet\s+run\b|"
+    r"dotnet\s+watch\b|"
+    r"php\s+artisan\s+serve\b|"
+    r"php\s+-S\b|"
+    r"(?:bundle\s+exec\s+)?(?:rails\s+(?:s|server)\b|puma\b|rackup\b)|"
+    r"mix\s+phx\.server\b|"
+    r"hugo\s+server\b|"
+    r"jekyll\s+serve\b|"
+    r"caddy\s+run\b"
+    r")",
+    re.I,
+)
+
+_COMPOSE_UP = re.compile(
+    r"^(?:[\w./-]+/)?docker(?:-compose|\s+compose)\s+up\b",
+    re.I,
+)
+_COMPOSE_DETACH = re.compile(r"(?:^|\s)(?:-d|--detach)\b", re.I)
+
+_LSOF_LISTEN_PORT = re.compile(r":(\d{2,5})(?:\s+\(LISTEN\)|\s|$)")
+
+
+def service_watch_after() -> float:
+    raw = os.environ.get("HOLIX_SERVICE_WATCH_AFTER")
+    if raw and str(raw).strip():
+        try:
+            return max(0.05, float(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_WATCH_AFTER
+
+
+def service_watch_interval() -> float:
+    raw = os.environ.get("HOLIX_SERVICE_WATCH_INTERVAL")
+    if raw and str(raw).strip():
+        try:
+            return max(0.05, float(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_WATCH_INTERVAL
+
+
+def split_shell_segments(command: str) -> list[str]:
+    """Split on ; && || | & newline, keeping quoted spans intact."""
+    parts: list[str] = []
+    buf: list[str] = []
+    quote = ""
+    i = 0
+    text = command or ""
+    while i < len(text):
+        ch = text[i]
+        if quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = ""
+            i += 1
+            continue
+        if ch in {"'", '"'}:
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == "\n" or ch == ";":
+            parts.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        if ch == "&" and i + 1 < len(text) and text[i + 1] == "&":
+            parts.append("".join(buf))
+            buf = []
+            i += 2
+            continue
+        if ch == "|" and i + 1 < len(text) and text[i + 1] == "|":
+            parts.append("".join(buf))
+            buf = []
+            i += 2
+            continue
+        if ch in {"|", "&"}:
+            parts.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def segment_head(segment: str) -> str:
+    """Drop env assignments / wrappers so the real binary is first."""
+    text = (segment or "").strip()
+    while True:
+        nxt = _LAUNCH_PREFIX.sub("", text, count=1)
+        if nxt == text:
+            break
+        text = nxt.lstrip()
+    return text
+
+
+def _is_compose_up_foreground(head: str) -> bool:
+    return bool(_COMPOSE_UP.match(head) and not _COMPOSE_DETACH.search(head))
+
+
+def _is_launch_head(head: str) -> bool:
+    if not head:
+        return False
+    if _LAUNCH_HEAD.match(head):
+        return True
+    return _is_compose_up_foreground(head)
+
+
+def is_untracked_long_running_command(command: str) -> bool:
+    """True when some *executable segment* starts a server/bot.
+
+    Quoted strings, grep patterns, and ``pip list`` are ignored so mentioning
+    ``uvicorn`` is not treated as launching it.
+    """
+    for raw in split_shell_segments(command or ""):
+        head = segment_head(raw)
+        if not head or _INSPECT_HEAD.match(head):
+            continue
+        if _is_launch_head(head):
+            return True
+    return False
+
+
+def is_long_oneshot_job(command: str) -> bool:
+    """True when every real segment is a build/test/inspect command.
+
+    Used by the runtime watchdog so ``cargo test`` / ``mvn package`` that
+    happen to bind a fixture port are not promoted to a background service.
+    """
+    saw_any = False
+    for raw in split_shell_segments(command or ""):
+        head = segment_head(raw)
+        if not head:
+            continue
+        saw_any = True
+        if _INSPECT_HEAD.match(head):
+            continue
+        return False
+    return saw_any
+
+
+def _pid_tree(root_pid: int) -> list[int]:
+    if root_pid <= 0:
+        return []
+    found = [root_pid]
+    seen = {root_pid}
+    try:
+        import psutil
+
+        proc = psutil.Process(root_pid)
+        for child in proc.children(recursive=True):
+            if child.pid not in seen:
+                seen.add(child.pid)
+                found.append(child.pid)
+        return found
+    except Exception:
+        pass
+
+    queue = [root_pid]
+    while queue:
+        parent = queue.pop()
+        try:
+            result = subprocess.run(
+                ["pgrep", "-P", str(parent)],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            break
+        for token in (result.stdout or "").split():
+            if not token.isdigit():
+                continue
+            pid = int(token)
+            if pid in seen:
+                continue
+            seen.add(pid)
+            found.append(pid)
+            queue.append(pid)
+    return found
+
+
+def _ports_from_lsof_text(text: str) -> list[int]:
+    ports: list[int] = []
+    seen: set[int] = set()
+    for line in (text or "").splitlines():
+        if line.startswith("COMMAND"):
+            continue
+        for match in _LSOF_LISTEN_PORT.finditer(line):
+            try:
+                port = int(match.group(1))
+            except (TypeError, ValueError):
+                continue
+            if 1 <= port <= 65535 and port not in seen:
+                seen.add(port)
+                ports.append(port)
+    return ports
+
+
+def listen_ports_for_pid_tree(root_pid: int) -> list[int]:
+    """TCP LISTEN ports owned by ``root_pid`` or any descendant (best effort)."""
+    if root_pid <= 0 or IS_WINDOWS:
+        return []
+    pids = _pid_tree(root_pid) or [root_pid]
+    pid_csv = ",".join(str(p) for p in pids[:64])
+    try:
+        result = subprocess.run(
+            ["lsof", "-nP", "-a", "-p", pid_csv, "-iTCP", "-sTCP:LISTEN"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        ports = _ports_from_lsof_text(result.stdout or "")
+        if ports:
+            return ports
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    # Fallback: all listeners, keep rows whose PID is in our tree.
+    tree = set(pids)
+    try:
+        result = subprocess.run(
+            ["lsof", "-nP", "-iTCP", "-sTCP:LISTEN"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    ports: list[int] = []
+    seen: set[int] = set()
+    for line in (result.stdout or "").splitlines():
+        if line.startswith("COMMAND"):
+            continue
+        cols = line.split()
+        if len(cols) < 2 or not cols[1].isdigit():
+            continue
+        if int(cols[1]) not in tree:
+            continue
+        for match in _LSOF_LISTEN_PORT.finditer(line):
+            try:
+                port = int(match.group(1))
+            except (TypeError, ValueError):
+                continue
+            if 1 <= port <= 65535 and port not in seen:
+                seen.add(port)
+                ports.append(port)
+    return ports
+
+
+def should_promote_foreground_service(
+    command: str,
+    *,
+    pid: int,
+    elapsed_s: float,
+    listen_ports: list[int] | None = None,
+) -> tuple[bool, list[int]]:
+    """Decide whether a still-running foreground command is a service.
+
+    ``listen_ports`` may be injected by tests. Otherwise the live process
+    tree is inspected.
+    """
+    if elapsed_s < service_watch_after():
+        return False, []
+    if is_long_oneshot_job(command):
+        return False, []
+    ports = list(listen_ports) if listen_ports is not None else listen_ports_for_pid_tree(pid)
+    if ports:
+        return True, ports
+    return False, []

--- a/core/runtime/step_budget.py
+++ b/core/runtime/step_budget.py
@@ -73,7 +73,9 @@ class StepBudgetPolicy:
             enabled = True
         return cls(
             enabled=bool(enabled),
-            extend_by=max(1, int(getattr(cfg, "max_steps_extend_by", DEFAULT_EXTEND_BY) or DEFAULT_EXTEND_BY)),
+            extend_by=max(
+                1, int(getattr(cfg, "max_steps_extend_by", DEFAULT_EXTEND_BY) or DEFAULT_EXTEND_BY)
+            ),
             max_extensions=max(
                 0,
                 int(
@@ -82,7 +84,9 @@ class StepBudgetPolicy:
                 ),
             ),
             hard_cap=max(0, int(getattr(cfg, "max_steps_hard_cap", DEFAULT_HARD_CAP) or 0)),
-            lookback=max(3, int(getattr(cfg, "max_steps_lookback", DEFAULT_LOOKBACK) or DEFAULT_LOOKBACK)),
+            lookback=max(
+                3, int(getattr(cfg, "max_steps_lookback", DEFAULT_LOOKBACK) or DEFAULT_LOOKBACK)
+            ),
         )
 
 
@@ -121,6 +125,25 @@ def _tool_signature(name: str, arguments: Any = None) -> str:
     return f"{(name or '').strip().lower()}::{_norm_args(arguments)}"
 
 
+def identical_tool_loop(
+    tool_calls_log: list[dict[str, Any]] | None,
+    *,
+    lookback: int = DEFAULT_LOOKBACK,
+) -> bool:
+    """True when the same tool+args signature repeats 3× in a row (or 3 of last 4)."""
+    traces = collect_tool_traces(tool_calls_log=tool_calls_log, lookback=lookback)
+    sigs = [str(t.get("signature") or "") for t in traces if t.get("signature")]
+    return _signatures_loop(sigs)
+
+
+def _signatures_loop(sigs: list[str]) -> bool:
+    if len(sigs) >= 3 and sigs[-1] and sigs[-1] == sigs[-2] == sigs[-3]:
+        return True
+    if len(sigs) >= 4 and sigs[-1] and sigs[-4:].count(sigs[-1]) >= 3:
+        return True
+    return False
+
+
 def _looks_like_error(text: str) -> bool:
     low = (text or "").strip().lower()
     if not low:
@@ -136,6 +159,9 @@ def _looks_like_progress(text: str) -> bool:
         return False
     if _looks_like_error(low):
         return False
+    # Identical rewrite is not progress even though the summary says "Updated".
+    if "no content changes" in low:
+        return False
     if any(m in low for m in _PROGRESS_MARKERS):
         return True
     # Non-trivial payload without error markers counts as progress
@@ -144,6 +170,7 @@ def _looks_like_progress(text: str) -> bool:
 
 def _token_overlap(a: str, b: str) -> float:
     """Jaccard-ish overlap on alphanumeric tokens (relevance proxy)."""
+
     def toks(s: str) -> set[str]:
         return {t for t in re.findall(r"[a-zA-Zа-яА-Я0-9_]{3,}", (s or "").lower()) if t}
 
@@ -305,28 +332,38 @@ def evaluate_step_budget(
         lookback=pol.lookback,
     )
 
+    from core.runtime.introspect_signals import (
+        introspect_loop,
+        is_introspect_trace,
+    )
+
     sigs = [t.get("signature") or "" for t in traces if t.get("signature")]
     unique_sigs = {s for s in sigs if s}
     error_count = sum(1 for t in traces if t.get("is_error"))
     progress_count = sum(
-        1 for t in traces if _looks_like_progress(str(t.get("result") or ""))
+        1
+        for t in traces
+        if _looks_like_progress(str(t.get("result") or "")) and not is_introspect_trace(t)
     )
     recent_names = " ".join(str(t.get("name") or "") for t in traces)
     recent_results = " ".join(str(t.get("result") or "")[:200] for t in traces)
-    relevance = max(
-        _token_overlap(task, recent_names),
-        _token_overlap(task, recent_results),
-    ) if task else 0.0
+    relevance = (
+        max(
+            _token_overlap(task, recent_names),
+            _token_overlap(task, recent_results),
+        )
+        if task
+        else 0.0
+    )
 
-    # Detect tight loops: same signature thrice in a row (or 3+ of last 4)
-    loop_hit = False
-    if len(sigs) >= 3:
-        if sigs[-1] and sigs[-1] == sigs[-2] == sigs[-3]:
-            loop_hit = True
-        elif len(sigs) >= 4:
-            last4 = sigs[-4:]
-            if last4 and last4.count(last4[-1]) >= 3:
-                loop_hit = True
+    loop_hit = _signatures_loop([str(s) for s in sigs])
+    from core.runtime.test_run_signals import tests_already_green_loop
+
+    green_repeat = tests_already_green_loop(traces)
+    inspect_repeat = introspect_loop(traces)
+    from core.runtime.write_signals import noop_write_loop
+
+    noop_writes = noop_write_loop(traces)
 
     signals = {
         "pending_tools": len(pending),
@@ -335,6 +372,9 @@ def evaluate_step_budget(
         "error_count": error_count,
         "progress_count": progress_count,
         "loop_hit": loop_hit,
+        "tests_green_repeat": green_repeat,
+        "inspect_repeat": inspect_repeat,
+        "noop_write_repeat": noop_writes,
         "relevance": round(relevance, 3),
         "extensions_used": ext_used,
         "hard_cap": hard,
@@ -345,6 +385,36 @@ def evaluate_step_budget(
         return StepBudgetDecision(
             extend=False,
             reason="hung: repeated identical tool calls (loop)",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    if green_repeat:
+        return StepBudgetDecision(
+            extend=False,
+            reason="tests already passed — re-running is not progress",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    if inspect_repeat:
+        return StepBudgetDecision(
+            extend=False,
+            reason="hung: inspect.getsource / python -c introspection is not progress",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    if noop_writes:
+        return StepBudgetDecision(
+            extend=False,
+            reason="hung: write_file with no content changes is not progress",
             status="hung",
             extensions_used=ext_used,
             new_max_steps=ms,
@@ -405,10 +475,7 @@ def evaluate_step_budget(
     new_max = ms + extra
     return StepBudgetDecision(
         extend=True,
-        reason=(
-            f"working with relevant progress; +{extra} steps "
-            f"({sc}/{ms} → max {new_max})"
-        ),
+        reason=(f"working with relevant progress; +{extra} steps ({sc}/{ms} → max {new_max})"),
         status="working",
         extra_steps=extra,
         new_max_steps=new_max,

--- a/core/runtime/test_run_signals.py
+++ b/core/runtime/test_run_signals.py
@@ -1,0 +1,85 @@
+"""Detect passing automated tests so we don't treat re-runs as progress."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+_TEST_CMD_RE = re.compile(
+    r"\b("
+    r"pytest|py\.test|python\d*\s+-m\s+pytest|unittest|"
+    r"npm\s+test|npx\s+vitest|vitest|"
+    r"cargo\s+test|go\s+test|"
+    r"dotnet\s+test"
+    r")\b",
+    re.I,
+)
+_PASSED_RE = re.compile(r"(\d+)\s+passed\b", re.I)
+_FAILED_RE = re.compile(r"([1-9]\d*)\s+failed\b", re.I)
+_ERROR_RE = re.compile(r"([1-9]\d*)\s+error", re.I)
+
+
+def extract_command(details: Any) -> str:
+    text = str(details or "").strip()
+    if text.startswith("{") or text.startswith("["):
+        try:
+            obj = json.loads(text)
+            if isinstance(obj, dict) and obj.get("command"):
+                return str(obj.get("command") or "")
+        except Exception:
+            pass
+    return text
+
+
+def is_test_command(command: str) -> bool:
+    return bool(_TEST_CMD_RE.search(command or ""))
+
+
+def is_green_test_output(text: str) -> bool:
+    blob = str(text or "")
+    low = blob.lower()
+    if "timed out" in low or "timeout" in low and "passed" not in low:
+        return False
+    if _FAILED_RE.search(blob) or _ERROR_RE.search(blob):
+        return False
+    if "traceback" in low and "passed" not in low:
+        return False
+    hit = _PASSED_RE.search(blob)
+    if hit:
+        return int(hit.group(1)) > 0
+    if "ran " in low and re.search(r"\bok\b", low) and "fail" not in low:
+        return True
+    return False
+
+
+def is_green_test_trace(trace: dict[str, Any]) -> bool:
+    name = str(trace.get("name") or "").lower()
+    args = extract_command(trace.get("arguments") or "")
+    result = str(trace.get("result") or "")
+    if name not in {"terminal", "run_terminal_command"}:
+        return False
+    if not is_test_command(args):
+        return False
+    return is_green_test_output(result)
+
+
+def green_test_passes(traces: list[dict[str, Any]]) -> int:
+    return sum(1 for t in traces if is_green_test_trace(t))
+
+
+def tests_already_green_loop(traces: list[dict[str, Any]]) -> bool:
+    """True when the agent re-runs or re-lists tests after they already passed."""
+    greens = green_test_passes(traces)
+    if greens >= 2:
+        return True
+    if greens < 1:
+        return False
+    last = traces[-1] if traces else {}
+    name = str(last.get("name") or "").lower()
+    args = extract_command(last.get("arguments") or last.get("details") or "")
+    if name in {"grep", "glob"} and re.search(r"\btest", args, re.I):
+        return True
+    if name in {"terminal", "run_terminal_command"} and is_test_command(args):
+        return greens >= 1 and is_green_test_output(str(last.get("result") or ""))
+    return False

--- a/core/runtime/write_signals.py
+++ b/core/runtime/write_signals.py
@@ -1,0 +1,47 @@
+"""Detect write_file loops that do not change disk bytes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_WRITE_TOOLS = frozenset({"write_file", "patch_file"})
+
+NOOP_WRITE_MARK = "no content changes"
+
+NOOP_WRITE_STOP = (
+    "STOP: The file on disk is already exactly this text. "
+    "Do NOT call write_file on it again. "
+    "If the project files exist, run pytest once (if you have not) "
+    "or give the final answer with NO tool calls so the Studio process "
+    "can continue. Rewriting the same bytes is not progress."
+)
+
+
+def is_noop_write_result(text: str) -> bool:
+    return NOOP_WRITE_MARK in str(text or "").lower()
+
+
+def is_noop_write_trace(trace: dict[str, Any]) -> bool:
+    name = str(trace.get("name") or "").strip().lower()
+    if name not in _WRITE_TOOLS:
+        return False
+    return is_noop_write_result(str(trace.get("result") or ""))
+
+
+def noop_write_loop(
+    traces: list[dict[str, Any]] | None,
+    *,
+    min_hits: int = 3,
+    lookback: int = 8,
+) -> bool:
+    """True when recent writes only restated files that already matched disk."""
+    recent = list(traces or [])[-lookback:]
+    writes = [t for t in recent if str(t.get("name") or "").strip().lower() in _WRITE_TOOLS]
+    if len(writes) < min_hits:
+        return False
+    last = writes[-min_hits:]
+    return all(is_noop_write_trace(t) for t in last)
+
+
+def noop_write_count(traces: list[dict[str, Any]] | None) -> int:
+    return sum(1 for t in (traces or []) if is_noop_write_trace(t))

--- a/core/subagents/async_runner.py
+++ b/core/subagents/async_runner.py
@@ -155,10 +155,12 @@ class AsyncSubAgentRunner:
                 for fact in context.get("semantic", []):
                     memory_parts.append(f"[Fact]: {fact.get('content', '')[:200]}")
                 if memory_parts:
-                    messages.append({
-                        "role": "system",
-                        "content": "Relevant context from memory:\n" + "\n".join(memory_parts),
-                    })
+                    messages.append(
+                        {
+                            "role": "system",
+                            "content": "Relevant context from memory:\n" + "\n".join(memory_parts),
+                        }
+                    )
             except Exception as e:
                 logger.debug(f"Memory injection failed for sub-agent: {e}")
 
@@ -220,12 +222,16 @@ class AsyncSubAgentRunner:
                     # Set up timeout
                     llm_t0 = time.monotonic()
                     try:
+                        force_final = bool(getattr(handle, "_force_final_answer", False))
+                        use_tools = tools_schemas if tools_schemas and not force_final else None
                         response = await asyncio.wait_for(
                             client.chat.completions.create(
                                 model=model,
                                 messages=messages,
-                                tools=tools_schemas if tools_schemas else None,
-                                tool_choice="auto" if tools_schemas else None,
+                                tools=use_tools,
+                                tool_choice=("none" if force_final else "auto")
+                                if use_tools
+                                else None,
                                 temperature=config.temperature,
                             ),
                             timeout=config.timeout,
@@ -269,9 +275,7 @@ class AsyncSubAgentRunner:
                         try:
                             choices = getattr(response, "choices", None) or []
                             if choices:
-                                finish_reason = getattr(
-                                    choices[0], "finish_reason", None
-                                )
+                                finish_reason = getattr(choices[0], "finish_reason", None)
                         except Exception:
                             finish_reason = None
                         # Parent bus → Studio token_usage_handler (model.calls + tokens)
@@ -311,10 +315,12 @@ class AsyncSubAgentRunner:
 
                         for tc in message.tool_calls:
                             tool_name = tc.function.name
-                            tool_calls_made.append({
-                                "name": tool_name,
-                                "arguments": tc.function.arguments,
-                            })
+                            tool_calls_made.append(
+                                {
+                                    "name": tool_name,
+                                    "arguments": tc.function.arguments,
+                                }
+                            )
                             handle.record_activity(
                                 "tool_start",
                                 f"Calling {tool_name}",
@@ -336,11 +342,112 @@ class AsyncSubAgentRunner:
                                 steps_taken=steps_taken,
                             )
                             self._notify_progress(config.name)
-                            messages.append({
-                                "role": "tool",
-                                "tool_call_id": tc.id,
-                                "content": result,
-                            })
+                            messages.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": tc.id,
+                                    "content": result,
+                                }
+                            )
+                        try:
+                            from core.runtime.test_run_signals import (
+                                extract_command,
+                                is_green_test_output,
+                                is_test_command,
+                            )
+
+                            green_n = 0
+                            for call in tool_calls_made:
+                                name = str(call.get("name") or "").lower()
+                                if name not in {"terminal", "run_terminal_command"}:
+                                    continue
+                                if is_test_command(extract_command(call.get("arguments"))):
+                                    if is_green_test_output(str(call.get("result") or "")):
+                                        green_n += 1
+                            if green_n >= 1:
+                                messages.append(
+                                    {
+                                        "role": "system",
+                                        "content": (
+                                            "### Tests already passed\n"
+                                            "Automated tests succeeded. Do not run pytest "
+                                            "or grep tests again. If the task is done, "
+                                            "reply with the final answer and NO tool calls "
+                                            "so the Studio process can continue."
+                                        ),
+                                    }
+                                )
+                            if green_n >= 2:
+                                handle._force_final_answer = True
+                                handle.record_activity(
+                                    "status",
+                                    "Tests already green — forcing final answer",
+                                    steps_taken=steps_taken,
+                                )
+                            from core.runtime.write_signals import is_noop_write_result
+
+                            noop_n = 0
+                            for call in tool_calls_made[-6:]:
+                                name = str(call.get("name") or "").lower()
+                                if name in {"write_file", "patch_file"} and is_noop_write_result(
+                                    str(call.get("result") or "")
+                                ):
+                                    noop_n += 1
+                            if noop_n >= 2:
+                                messages.append(
+                                    {
+                                        "role": "system",
+                                        "content": (
+                                            "### Files already match disk\n"
+                                            "write_file returned «no content changes». "
+                                            "Do not rewrite those files. "
+                                            "Run pytest once if needed, then the final "
+                                            "answer with NO tool calls."
+                                        ),
+                                    }
+                                )
+                            if noop_n >= 3:
+                                handle._force_final_answer = True
+                                handle.record_activity(
+                                    "status",
+                                    "No-op write_file loop — forcing final answer",
+                                    steps_taken=steps_taken,
+                                )
+                            # Same terminal command failing over and over (e.g. false
+                            # "use start_background_process" reject) — stop the spin.
+                            tails = [
+                                (
+                                    str(c.get("name") or ""),
+                                    str(c.get("arguments") or ""),
+                                    str(c.get("result") or "")[:80],
+                                )
+                                for c in tool_calls_made[-3:]
+                            ]
+                            if (
+                                len(tails) >= 3
+                                and tails[-1] == tails[-2] == tails[-3]
+                                and tails[-1][0].lower() in {"terminal", "run_terminal_command"}
+                                and tails[-1][2].lower().startswith("error")
+                            ):
+                                handle._force_final_answer = True
+                                messages.append(
+                                    {
+                                        "role": "system",
+                                        "content": (
+                                            "### Stop repeating the same terminal command\n"
+                                            "It already failed the same way. Do not call it again. "
+                                            "Write the final answer (what is done / what is blocked) "
+                                            "with NO tool calls so the process can continue."
+                                        ),
+                                    }
+                                )
+                                handle.record_activity(
+                                    "status",
+                                    "Identical terminal error — forcing final answer",
+                                    steps_taken=steps_taken,
+                                )
+                        except Exception:
+                            logger.debug("green-test finish hint failed", exc_info=True)
                     else:
                         # Final response
                         final_response = message.content or "No response"
@@ -431,6 +538,30 @@ class AsyncSubAgentRunner:
                 return handle.result
 
         except asyncio.CancelledError:
+            forced = getattr(handle, "forced_status", None)
+            if forced == SubAgentStatus.LOOP:
+                handle.status = SubAgentStatus.LOOP
+                if handle.result is None or not handle.result.error:
+                    handle.result = SubAgentResult(
+                        name=config.name,
+                        success=False,
+                        error="loop: stopped by supervisor",
+                        duration_ms=(time.monotonic() - start_time) * 1000,
+                        steps_taken=steps_taken,
+                        tool_calls=tool_calls_made,
+                        **_usage_fields(),
+                    )
+                else:
+                    handle.result.steps_taken = steps_taken
+                    handle.result.tool_calls = tool_calls_made
+                    handle.result.duration_ms = (time.monotonic() - start_time) * 1000
+                handle.record_activity(
+                    "status",
+                    "loop",
+                    steps_taken=steps_taken,
+                )
+                logger.warning("Sub-agent '%s' stopped as loop", config.name)
+                return handle.result
             handle.status = SubAgentStatus.CANCELLED
             handle.record_activity(
                 "status",
@@ -487,7 +618,8 @@ class AsyncSubAgentRunner:
             return False
 
         handle.task.cancel()
-        handle.status = SubAgentStatus.CANCELLED
+        forced = getattr(handle, "forced_status", None)
+        handle.status = forced if forced else SubAgentStatus.CANCELLED
         return True
 
     def get_handle(self, name: str) -> SubAgentHandle | None:
@@ -522,10 +654,28 @@ class AsyncSubAgentRunner:
         from core.tools.aliases import get_registered_tool, tool_schema_for_name
 
         schemas = []
+        seen: set[str] = set()
         for tool_name in config.tools:
             tool = get_registered_tool(self._parent.tools, tool_name)
             if tool:
                 schemas.append(tool_schema_for_name(tool, tool_name))
+                seen.add(str(tool_name))
+
+        # MCP tools live on the parent as mcp_<server>_<tool>.
+        inherit_mcp = bool(getattr(config, "mcp_inherit", True))
+        allowed_servers = [str(s).strip() for s in (config.mcp_servers or []) if str(s).strip()]
+        parent_tools = getattr(self._parent.tools, "tools", None) or {}
+        for name, tool in parent_tools.items():
+            key = str(name or "")
+            if not key.startswith("mcp_") or key in seen:
+                continue
+            if not inherit_mcp:
+                if not allowed_servers or not any(
+                    key.startswith(f"mcp_{srv}_") for srv in allowed_servers
+                ):
+                    continue
+            schemas.append(tool_schema_for_name(tool, key))
+            seen.add(key)
 
         return schemas
 
@@ -549,9 +699,9 @@ class AsyncSubAgentRunner:
         # Inherit parent run conversation so ActionGuard confirmations land on the
         # correct Studio tab (not ContextVar default "default", which hides the UI).
         parent_ctx = getattr(self._parent, "_event_context", None)
-        conversation_id = str(
-            getattr(parent_ctx, "conversation_id", None) or ""
-        ).strip() or "default"
+        conversation_id = (
+            str(getattr(parent_ctx, "conversation_id", None) or "").strip() or "default"
+        )
 
         tokens = subagent_scope(
             config.name,
@@ -568,4 +718,3 @@ class AsyncSubAgentRunner:
             return f"Error: {e}"
         finally:
             reset_subagent_scope(tokens)
-

--- a/core/subagents/base.py
+++ b/core/subagents/base.py
@@ -16,26 +16,30 @@ _ACTIVITY_DETAILS_MAX = 400
 
 class ProcessMode(StrEnum):
     """How a sub-agent should be executed."""
-    ASYNC = "async"          # In-process asyncio.Task (default, I/O-bound)
-    PROCESS = "process"      # Separate OS process (CPU-bound, isolation)
-    THREAD = "thread"        # In-process thread (rarely needed)
+
+    ASYNC = "async"  # In-process asyncio.Task (default, I/O-bound)
+    PROCESS = "process"  # Separate OS process (CPU-bound, isolation)
+    THREAD = "thread"  # In-process thread (rarely needed)
 
 
 class MemoryAccess(StrEnum):
     """How a sub-agent accesses the parent's memory."""
-    SHARED = "shared"        # Read/write access to parent's LTM
-    READONLY = "readonly"    # Read-only access to parent's LTM
-    ISOLATED = "isolated"    # Own separate memory stores
+
+    SHARED = "shared"  # Read/write access to parent's LTM
+    READONLY = "readonly"  # Read-only access to parent's LTM
+    ISOLATED = "isolated"  # Own separate memory stores
 
 
 class SubAgentStatus(StrEnum):
     """Status of a sub-agent."""
+
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
     TIMED_OUT = "timed_out"
+    LOOP = "loop"
 
 
 @dataclass
@@ -46,23 +50,24 @@ class SubAgentConfig:
     which tools, what system prompt, and how it runs.
     """
 
-    name: str                                    # Unique name (e.g., "researcher")
-    agent_type: str = ""                         # Registry type (researcher, coder, …)
-    system_prompt: str = ""                      # Specialized system prompt
-    model: str = ""                              # Model override (empty = inherit from parent)
+    name: str  # Unique name (e.g., "researcher")
+    agent_type: str = ""  # Registry type (researcher, coder, …)
+    system_prompt: str = ""  # Specialized system prompt
+    model: str = ""  # Model override (empty = inherit from parent)
     tools: list[str] = field(default_factory=list)  # Subset of tool names
-    max_steps: int = 150                         # Max reasoning steps
-    mode: str = "react"                          # Execution mode
+    max_steps: int = 150  # Max reasoning steps
+    mode: str = "react"  # Execution mode
     process_mode: ProcessMode = ProcessMode.ASYNC  # How to run
-    timeout: float = 900.0                       # Wait / job budget (seconds)
+    timeout: float = 900.0  # Wait / job budget (seconds)
     memory_access: MemoryAccess = MemoryAccess.SHARED  # Memory access level
-    temperature: float = 0.7                     # LLM temperature
-    description: str = ""                        # Human-readable description
+    temperature: float = 0.7  # LLM temperature
+    description: str = ""  # Human-readable description
     tags: list[str] = field(default_factory=list)  # Tags for categorization
 
     # MCP servers enabled for this sub-agent (by server name). Their tools must also
     # be listed in `tools` (or auto-included by runners) for the names to be usable.
     mcp_servers: list[str] = field(default_factory=list)
+    mcp_inherit: bool = True
 
     def __post_init__(self):
         if isinstance(self.process_mode, str):
@@ -79,27 +84,30 @@ class SubAgentResult:
     and performance metrics.
     """
 
-    name: str                                    # Sub-agent name
-    success: bool                                 # Whether the task completed successfully
-    response: str = ""                            # The sub-agent's final response
+    name: str  # Sub-agent name
+    success: bool  # Whether the task completed successfully
+    response: str = ""  # The sub-agent's final response
     tool_calls: list[dict[str, Any]] = field(default_factory=list)  # Tool calls made
-    error: str | None = None                   # Error message if failed
-    duration_ms: float = 0.0                      # Execution time in ms
-    memory_used: int = 0                          # Approximate memory used (bytes)
-    steps_taken: int = 0                          # Number of reasoning steps
-    tokens_used: int = 0                          # Sum of LLM tokens (prompt+completion) for this run
-    llm_calls: int = 0                            # Number of LLM API calls completed
+    error: str | None = None  # Error message if failed
+    duration_ms: float = 0.0  # Execution time in ms
+    memory_used: int = 0  # Approximate memory used (bytes)
+    steps_taken: int = 0  # Number of reasoning steps
+    tokens_used: int = 0  # Sum of LLM tokens (prompt+completion) for this run
+    llm_calls: int = 0  # Number of LLM API calls completed
     # True when each LLM call already emitted LLMCallCompletedEvent (Studio meters per-call).
     usage_accounted: bool = False
-    model: str = ""                               # Model id used for this run (if known)
+    model: str = ""  # Model id used for this run (if known)
 
     @property
     def status(self) -> SubAgentStatus:
         """Derive status from result data."""
         if self.error:
-            if "timeout" in (self.error or "").lower():
+            err = (self.error or "").lower()
+            if "timeout" in err:
                 return SubAgentStatus.TIMED_OUT
-            elif "cancel" in (self.error or "").lower():
+            if err.startswith("loop:") or "tool calls (loop)" in err:
+                return SubAgentStatus.LOOP
+            if "cancel" in err:
                 return SubAgentStatus.CANCELLED
             return SubAgentStatus.FAILED
         return SubAgentStatus.COMPLETED if self.success else SubAgentStatus.FAILED
@@ -112,16 +120,16 @@ class SubAgentHandle:
     Provides methods to check status, get results, and cancel.
     """
 
-    name: str                                    # Sub-agent name
+    name: str  # Sub-agent name
     config: SubAgentConfig = field(default_factory=SubAgentConfig)
     status: SubAgentStatus = SubAgentStatus.PENDING
-    task: Any | None = None                   # asyncio.Task or multiprocessing.Process
+    task: Any | None = None  # asyncio.Task or multiprocessing.Process
     result: SubAgentResult | None = None
-    started_at: float | None = None           # time.monotonic timestamp
-    process_id: int | None = None             # OS PID for process-mode agents
-    task_preview: str = ""                       # Short task description for UI
-    agent_type: str = ""                         # Registry type (researcher, coder, …)
-    spawn_fallback_reason: str = ""              # Set when OS-process spawn fell back to async
+    started_at: float | None = None  # time.monotonic timestamp
+    process_id: int | None = None  # OS PID for process-mode agents
+    task_preview: str = ""  # Short task description for UI
+    agent_type: str = ""  # Registry type (researcher, coder, …)
+    spawn_fallback_reason: str = ""  # Set when OS-process spawn fell back to async
     done_event: Any = field(default=None, repr=False)  # asyncio.Event set on completion
     # Live progress for Studio / status UIs
     steps_taken: int = 0
@@ -142,6 +150,7 @@ class SubAgentHandle:
             SubAgentStatus.FAILED,
             SubAgentStatus.CANCELLED,
             SubAgentStatus.TIMED_OUT,
+            SubAgentStatus.LOOP,
         )
 
     @property

--- a/core/subagents/manager.py
+++ b/core/subagents/manager.py
@@ -332,7 +332,9 @@ class SubAgentManager:
             SubAgentProgressEvent(
                 name=handle.name,
                 agent_type=handle.agent_type or handle.config.agent_type or "",
-                status=handle.status.value if hasattr(handle.status, "value") else str(handle.status),
+                status=handle.status.value
+                if hasattr(handle.status, "value")
+                else str(handle.status),
                 steps_taken=int(handle.steps_taken or 0),
                 max_steps=int(handle.max_steps or handle.config.max_steps or 0),
                 current_activity=handle.current_activity or "",
@@ -366,14 +368,14 @@ class SubAgentManager:
             SubAgentFinishedEvent(
                 name=handle.name,
                 agent_type=handle.agent_type or handle.config.agent_type or "",
-                status=handle.status.value if hasattr(handle.status, "value") else str(handle.status),
+                status=handle.status.value
+                if hasattr(handle.status, "value")
+                else str(handle.status),
                 task_preview=handle.task_preview or "",
                 success=success,
                 error=error,
                 response_preview=response,
-                steps_taken=int(
-                    (result.steps_taken if result else 0) or handle.steps_taken or 0
-                ),
+                steps_taken=int((result.steps_taken if result else 0) or handle.steps_taken or 0),
                 elapsed_ms=float(handle.elapsed_ms or 0),
                 tokens_used=tokens_used,
                 llm_calls=llm_calls,
@@ -385,9 +387,7 @@ class SubAgentManager:
         self._maybe_complete_sdd_task(handle, success=success)
         self._publish_runtime(handle)
 
-    def _maybe_complete_sdd_task(
-        self, handle: SubAgentHandle, *, success: bool
-    ) -> None:
+    def _maybe_complete_sdd_task(self, handle: SubAgentHandle, *, success: bool) -> None:
         try:
             from core.sdd.task_completion import try_complete_sdd_task_for_subagent
 
@@ -421,9 +421,7 @@ class SubAgentManager:
                     from core.sdd.store import SpecStore
 
                     store = SpecStore(project_root)
-                    await dispatch_change_tasks(
-                        store, str(change_id), parent_agent=self._parent
-                    )
+                    await dispatch_change_tasks(store, str(change_id), parent_agent=self._parent)
                 except Exception:
                     logger.debug("SDD next-wave dispatch skipped", exc_info=True)
 
@@ -477,9 +475,7 @@ class SubAgentManager:
         if wanted:
             existing = self._handles.get(wanted)
             instance = (
-                wanted
-                if existing is None or existing.is_done
-                else self.allocate_name(agent_type)
+                wanted if existing is None or existing.is_done else self.allocate_name(agent_type)
             )
         else:
             instance = self.allocate_name(agent_type)
@@ -543,9 +539,7 @@ class SubAgentManager:
         if cfg_timeout > 0:
             return cfg_timeout
         parent_cfg = getattr(self._parent, "config", None)
-        parent_timeout = float(
-            getattr(parent_cfg, "subagent_process_timeout", 0) or 0
-        )
+        parent_timeout = float(getattr(parent_cfg, "subagent_process_timeout", 0) or 0)
         if parent_timeout > 0:
             return parent_timeout
         return _DEFAULT_WAIT_TIMEOUT_S
@@ -631,9 +625,7 @@ class SubAgentManager:
 
         if handle.is_done:
             if handle.result is None:
-                raise TimeoutError(
-                    f"sub-agent '{name}' finished without a result"
-                )
+                raise TimeoutError(f"sub-agent '{name}' finished without a result")
             return handle.result
 
         chunk = float(timeout) if timeout is not None else self._default_wait_timeout(handle)
@@ -649,9 +641,7 @@ class SubAgentManager:
 
         def _result_or_raise() -> SubAgentResult:
             if handle.result is None:
-                raise TimeoutError(
-                    f"sub-agent '{name}' finished without a result"
-                )
+                raise TimeoutError(f"sub-agent '{name}' finished without a result")
             return handle.result
 
         while True:
@@ -662,9 +652,7 @@ class SubAgentManager:
             primary = chunk - grace if chunk > grace else 0.0
             if primary > 0:
                 try:
-                    await asyncio.wait_for(
-                        self._wait_for_handle(handle), timeout=primary
-                    )
+                    await asyncio.wait_for(self._wait_for_handle(handle), timeout=primary)
                 except TimeoutError:
                     pass
                 waited += primary
@@ -692,9 +680,7 @@ class SubAgentManager:
             tail = min(grace, chunk) if primary > 0 else chunk
             if tail > 0:
                 try:
-                    await asyncio.wait_for(
-                        self._wait_for_handle(handle), timeout=tail
-                    )
+                    await asyncio.wait_for(self._wait_for_handle(handle), timeout=tail)
                 except TimeoutError:
                     pass
                 waited += tail
@@ -751,11 +737,7 @@ class SubAgentManager:
         except TimeoutError:
             logger.warning("wait_all timed out — some sub-agents may still be running")
 
-        return {
-            name: h.result
-            for name, h in self._handles.items()
-            if h.result is not None
-        }
+        return {name: h.result for name, h in self._handles.items() if h.result is not None}
 
     def list_active(self) -> list[SubAgentHandle]:
         """List all currently running sub-agents.
@@ -811,9 +793,7 @@ class SubAgentManager:
         if probe is None:
             owner, bare = parse_job_id(text)
             if bare and bare != text:
-                probe = get_job(
-                    profile, bare, include_activity=False, include_result=True
-                )
+                probe = get_job(profile, bare, include_activity=False, include_result=True)
             if probe is None:
                 return None
 
@@ -829,15 +809,19 @@ class SubAgentManager:
                     SubAgentStatus.FAILED.value,
                     SubAgentStatus.CANCELLED.value,
                     SubAgentStatus.TIMED_OUT.value,
+                    SubAgentStatus.LOOP.value,
                 }:
                     res = last.get("result") if isinstance(last.get("result"), dict) else {}
-                    success = bool(res.get("success")) if res else status == (
-                        SubAgentStatus.COMPLETED.value
+                    success = (
+                        bool(res.get("success"))
+                        if res
+                        else status == (SubAgentStatus.COMPLETED.value)
                     )
                     if status in {
                         SubAgentStatus.FAILED.value,
                         SubAgentStatus.CANCELLED.value,
                         SubAgentStatus.TIMED_OUT.value,
+                        SubAgentStatus.LOOP.value,
                     }:
                         success = False
                     return SubAgentResult(
@@ -845,27 +829,20 @@ class SubAgentManager:
                         success=success,
                         response=str(res.get("response") or last.get("response") or ""),
                         error=str(res.get("error") or last.get("error") or ""),
-                        duration_ms=float(
-                            res.get("duration_ms") or last.get("elapsed_ms") or 0
-                        ),
-                        steps_taken=int(
-                            res.get("steps_taken") or last.get("steps_taken") or 0
-                        ),
+                        duration_ms=float(res.get("duration_ms") or last.get("elapsed_ms") or 0),
+                        steps_taken=int(res.get("steps_taken") or last.get("steps_taken") or 0),
                     )
             now = asyncio.get_running_loop().time()
             if now >= deadline:
                 raise TimeoutError(
-                    f"timed out waiting for sub-agent '{text}' "
-                    f"(registry job still running)"
+                    f"timed out waiting for sub-agent '{text}' (registry job still running)"
                 )
             await asyncio.sleep(0.5)
             last = get_job(profile, text, include_activity=False, include_result=True)
             if last is None:
                 owner, bare = parse_job_id(text)
                 if bare:
-                    last = get_job(
-                        profile, bare, include_activity=False, include_result=True
-                    )
+                    last = get_job(profile, bare, include_activity=False, include_result=True)
 
     async def terminate(self, name: str) -> bool:
         """Terminate a specific sub-agent.
@@ -984,15 +961,11 @@ class SubAgentManager:
             mode = h.config.process_mode.value
             elapsed = int(h.elapsed_ms)
             if html:
-                lines.append(
-                    f"• <code>{h.name}</code> [{h.status.value}] {mode}{pid} {elapsed}ms"
-                )
+                lines.append(f"• <code>{h.name}</code> [{h.status.value}] {mode}{pid} {elapsed}ms")
                 if preview:
                     lines.append(f"  <i>{preview}</i>")
             else:
-                lines.append(
-                    f"  {h.name} [{h.status.value}] {mode}{pid} {elapsed}ms — {preview}"
-                )
+                lines.append(f"  {h.name} [{h.status.value}] {mode}{pid} {elapsed}ms — {preview}")
 
         pending = self.interactions.list_pending_questions()
         if pending:
@@ -1050,9 +1023,7 @@ class SubAgentManager:
         except Exception:
             profile_agents = []
 
-        agents = merge_local_and_profile(
-            local_agents, profile_agents, local_owner=owner
-        )
+        agents = merge_local_and_profile(local_agents, profile_agents, local_owner=owner)
         # Ensure source label is present for local-only fallback.
         for row in agents:
             if row.get("local") and not row.get("source"):
@@ -1079,7 +1050,9 @@ class SubAgentManager:
         handle = self._handles.get(name)
         if handle:
             if handle.is_done and not handle.current_activity:
-                status = handle.status.value if hasattr(handle.status, "value") else str(handle.status)
+                status = (
+                    handle.status.value if hasattr(handle.status, "value") else str(handle.status)
+                )
                 handle.record_activity("status", f"Finished ({status})")
             self._mark_done(handle)
             self._emit_finished_once(handle)

--- a/core/subagents/process.py
+++ b/core/subagents/process.py
@@ -192,22 +192,20 @@ def run_sub_agent_in_process(
     )
     registry.register_all()
 
-    # MCP for this sub (if any servers listed in its config and defs passed)
-    if mcp_servers and getattr(config, "mcp_servers", None):
+    # MCP for this sub: assigned names + parent defs, filling popular catalogs
+    # (Context7 may be assigned on python-coder but missing from parent mcp_servers).
+    assigned_mcp = [
+        str(s).strip() for s in (getattr(config, "mcp_servers", None) or []) if str(s).strip()
+    ]
+    if assigned_mcp:
         try:
-            from core.mcp.manager import MCPManager
+            from core.mcp.assign import mcp_defs_for_names
 
-            mcp_mgr = MCPManager({k: v for k, v in mcp_servers.items() if k in config.mcp_servers})
-            loop.run_until_complete(mcp_mgr.connect_all())
-            loop.run_until_complete(
-                registry.register_mcp(
-                    {k: v for k, v in mcp_servers.items() if k in config.mcp_servers},
-                    {"main": list(config.mcp_servers)},
-                    slot="main",
+            subset = mcp_defs_for_names(mcp_servers, assigned_mcp)
+            if subset:
+                loop.run_until_complete(
+                    registry.register_mcp(subset, {"main": assigned_mcp}, slot="main")
                 )
-            )
-            # stash for cleanup if needed
-            registry._mcp_manager = mcp_mgr  # type: ignore
         except Exception as e:
             print(f"[sub-process] MCP init skipped: {e}")
 
@@ -375,6 +373,7 @@ def run_sub_agent_in_process(
         hb_thread = threading.Thread(target=heartbeat_worker, daemon=True)
         hb_thread.start()
 
+        force_final = False
         while True:
             while steps_taken < max_steps:
                 # Check for cancel signal
@@ -458,8 +457,10 @@ def run_sub_agent_in_process(
                             client.chat.completions.create(
                                 model=model,
                                 messages=messages,
-                                tools=tools_schemas if tools_schemas else None,
-                                tool_choice="auto" if tools_schemas else None,
+                                tools=tools_schemas if tools_schemas and not force_final else None,
+                                tool_choice=(
+                                    "none" if force_final else ("auto" if tools_schemas else None)
+                                ),
                                 temperature=config.temperature,
                             ),
                             timeout=config.timeout,
@@ -583,6 +584,65 @@ def run_sub_agent_in_process(
                                 "content": tool_result,
                             }
                         )
+
+                    try:
+                        from core.runtime.test_run_signals import (
+                            extract_command,
+                            is_green_test_output,
+                            is_test_command,
+                        )
+
+                        green_n = 0
+                        for call in tool_calls_made:
+                            name = str(call.get("name") or "").lower()
+                            if name not in {"terminal", "run_terminal_command"}:
+                                continue
+                            if is_test_command(extract_command(call.get("arguments"))):
+                                if is_green_test_output(str(call.get("result") or "")):
+                                    green_n += 1
+                        if green_n >= 1:
+                            messages.append(
+                                {
+                                    "role": "system",
+                                    "content": (
+                                        "### Tests already passed\n"
+                                        "Automated tests succeeded. Do not run pytest "
+                                        "or grep tests again. If the task is done, "
+                                        "reply with the final answer and NO tool calls "
+                                        "so the Studio process can continue."
+                                    ),
+                                }
+                            )
+                        if green_n >= 2:
+                            force_final = True
+                        tails = [
+                            (
+                                str(c.get("name") or ""),
+                                str(c.get("arguments") or ""),
+                                str(c.get("result") or "")[:80],
+                            )
+                            for c in tool_calls_made[-3:]
+                        ]
+                        if (
+                            len(tails) >= 3
+                            and tails[-1] == tails[-2] == tails[-3]
+                            and tails[-1][0].lower() in {"terminal", "run_terminal_command"}
+                            and tails[-1][2].lower().startswith("error")
+                        ):
+                            force_final = True
+                            messages.append(
+                                {
+                                    "role": "system",
+                                    "content": (
+                                        "### Stop repeating the same terminal command\n"
+                                        "It already failed the same way. Do not call it again. "
+                                        "Write the final answer with NO tool calls."
+                                    ),
+                                }
+                            )
+                    except Exception:
+                        pass
+
                 else:
                     # Final answer
                     final_response = message.content or "No response"
@@ -1145,6 +1205,23 @@ class SubAgentProcessManager:
                 continue
 
             if msg.msg_type == "result":
+                forced = getattr(handle, "forced_status", None)
+                if forced:
+                    handle.status = forced
+                    if handle.result is None or not getattr(handle.result, "error", None):
+                        meta = msg.metadata or {}
+                        handle.result = SubAgentResult(
+                            name=agent_name,
+                            success=False,
+                            error=str(getattr(forced, "value", forced)),
+                            response=msg.content,
+                            duration_ms=meta.get("duration_ms", 0),
+                            steps_taken=meta.get("steps_taken", 0),
+                            tool_calls=meta.get("tool_calls", []),
+                        )
+                    self._notify_parent_done(agent_name)
+                    self._cleanup_ipc(agent_name)
+                    return
                 # Final result received
                 meta = msg.metadata or {}
                 handle.result = SubAgentResult(
@@ -1323,13 +1400,24 @@ class SubAgentProcessManager:
                 terminate_process(process.pid, grace=1.0)
             process.join(timeout=1)
 
-        handle.status = SubAgentStatus.CANCELLED
-        handle.result = SubAgentResult(
-            name=name,
-            success=False,
-            error="Cancelled by parent",
-            duration_ms=(time.monotonic() - (handle.started_at or time.monotonic())) * 1000,
-        )
+        forced = getattr(handle, "forced_status", None)
+        if forced:
+            handle.status = forced
+            if handle.result is None:
+                handle.result = SubAgentResult(
+                    name=name,
+                    success=False,
+                    error="loop: stopped by supervisor",
+                    duration_ms=(time.monotonic() - (handle.started_at or time.monotonic())) * 1000,
+                )
+        else:
+            handle.status = SubAgentStatus.CANCELLED
+            handle.result = SubAgentResult(
+                name=name,
+                success=False,
+                error="Cancelled by parent",
+                duration_ms=(time.monotonic() - (handle.started_at or time.monotonic())) * 1000,
+            )
         self._notify_parent_done(name)
         return True
 

--- a/core/subagents/prompt.py
+++ b/core/subagents/prompt.py
@@ -34,7 +34,7 @@ def build_subagent_system_prompt(
 {task}
 
 ## Available Tools
-{', '.join(config.tools) if config.tools else 'No tools available'}
+{", ".join(config.tools) if config.tools else "No tools available"}
 
 ## Instructions
 1. Focus on your specific task
@@ -42,6 +42,7 @@ def build_subagent_system_prompt(
 3. Provide a clear, concise final answer
 4. If you cannot complete the task, explain why
 5. File paths and shell commands run in the shared working directory below — same as the main agent
+6. When automated tests already pass, stop calling tools and write the final answer so the parent process can continue. Do not re-run the same passing pytest.
 
 Remember: You are {config.name}. Stay focused on your specialized role.
 """

--- a/core/subagents/registry.py
+++ b/core/subagents/registry.py
@@ -74,6 +74,11 @@ PREDEFINED_SUBAGENTS = {
             "delete_file",
             "terminal",
             "code_executor",
+            "start_background_process",
+            "check_background_process",
+            "stop_background_process",
+            "list_background_processes",
+            "restart_background_process",
         ],
         max_steps=150,
         mode="react",
@@ -157,6 +162,7 @@ def _copy_config(original: SubAgentConfig) -> SubAgentConfig:
         description=original.description,
         tags=list(original.tags),
         mcp_servers=list(original.mcp_servers),
+        mcp_inherit=bool(getattr(original, "mcp_inherit", True)),
     )
 
 

--- a/core/subagents/runtime_registry.py
+++ b/core/subagents/runtime_registry.py
@@ -525,6 +525,7 @@ def _normalize_job(
         "failed",
         "cancelled",
         "timed_out",
+        "loop",
     }
     if running and done:
         done = False
@@ -551,8 +552,7 @@ def _normalize_job(
                 "status": status,
                 "running": False,
                 "done": True,
-                "current_activity": raw.get("current_activity")
-                or "Host process exited",
+                "current_activity": raw.get("current_activity") or "Host process exited",
             }
             try:
                 # Persist cancelled state for retention window instead of unlink.

--- a/core/subagents/spawn.py
+++ b/core/subagents/spawn.py
@@ -32,14 +32,8 @@ def _inject_external_cli_tools(
 
 def resolve_process_mode(parent_config: Any) -> ProcessMode:
     """Pick async vs OS-process mode from parent runtime config."""
-    raw = str(
-        getattr(parent_config, "subagent_default_process_mode", "async") or "async"
-    ).lower()
-    if (
-        raw == "process"
-        and process_subagents_supported()
-        and not prefer_async_subagents()
-    ):
+    raw = str(getattr(parent_config, "subagent_default_process_mode", "async") or "async").lower()
+    if raw == "process" and process_subagents_supported() and not prefer_async_subagents():
         return ProcessMode.PROCESS
     return ProcessMode.ASYNC
 
@@ -74,9 +68,7 @@ def resolve_subagent_model_id(
             if mc and (mc.model or "").strip():
                 return str(mc.model).strip()
         except Exception:
-            logger.debug(
-                "agent_models lookup failed for slot %r", slot, exc_info=True
-            )
+            logger.debug("agent_models lookup failed for slot %r", slot, exc_info=True)
 
     # 2) Studio provider slots and named presets (reads profile menu from disk).
     binding = resolve_model_slot_binding(profile, slot)
@@ -113,8 +105,7 @@ def resolve_subagent_model_id(
             return slot
 
     logger.warning(
-        "Could not resolve sub-agent model_slot %r for profile %r — "
-        "inheriting parent model",
+        "Could not resolve sub-agent model_slot %r for profile %r — inheriting parent model",
         slot,
         profile,
     )
@@ -138,8 +129,11 @@ def prepare_subagent_config(
         cfg.timeout = float(timeout)
 
     mcp_assigns = getattr(parent_config, "mcp_assignments", None) or {}
-    if not cfg.mcp_servers and agent_type in mcp_assigns:
-        cfg.mcp_servers = list(mcp_assigns[agent_type])
+    if agent_type in mcp_assigns:
+        cfg.mcp_servers = list(mcp_assigns[agent_type] or [])
+        cfg.mcp_inherit = False
+    elif not cfg.mcp_servers:
+        cfg.mcp_inherit = True
 
     from core.subagents.store import SubAgentTypeStore
 
@@ -167,5 +161,15 @@ def prepare_subagent_config(
     tools = list(cfg.tools or [])
     if "ask_user" not in tools:
         tools.append("ask_user")
+    if "terminal" in tools or "run_terminal_command" in tools:
+        for bg in (
+            "start_background_process",
+            "check_background_process",
+            "stop_background_process",
+            "list_background_processes",
+            "restart_background_process",
+        ):
+            if bg not in tools:
+                tools.append(bg)
     cfg.tools = _inject_external_cli_tools(agent_type, profile, tools)
     return cfg

--- a/core/subagents/store.py
+++ b/core/subagents/store.py
@@ -51,6 +51,8 @@ class CustomSubAgentType:
     temperature: float = 0.3
     skills: list[str] = field(default_factory=list)
     mcp_servers: list[str] = field(default_factory=list)
+    skills_inherit: bool = True
+    mcp_inherit: bool = True
     model_slot: str = ""
     external_cli_id: str = ""
 
@@ -68,6 +70,8 @@ class CustomSubAgentType:
             ),
             skills=[str(s) for s in (data.get("skills") or []) if str(s).strip()],
             mcp_servers=[str(m) for m in (data.get("mcp_servers") or []) if str(m).strip()],
+            skills_inherit=bool(data.get("skills_inherit", True)),
+            mcp_inherit=bool(data.get("mcp_inherit", True)),
             model_slot=str(data.get("model_slot") or ""),
             external_cli_id=str(data.get("external_cli_id") or ""),
         )
@@ -214,17 +218,17 @@ def sync_custom_type_profile_bindings(
             config.mcp_assignments = old_mcp
 
     assigns = dict(getattr(config, "skill_assignments", None) or {})
-    if custom.skills:
+    if getattr(custom, "skills_inherit", True):
+        assigns.pop(agent_slot, None)
+    else:
         assigns[agent_slot] = list(dict.fromkeys(custom.skills))
-    elif agent_slot in assigns:
-        del assigns[agent_slot]
     config.skill_assignments = assigns
 
     mcp_assigns = dict(getattr(config, "mcp_assignments", None) or {})
-    if custom.mcp_servers:
+    if getattr(custom, "mcp_inherit", True):
+        mcp_assigns.pop(agent_slot, None)
+    else:
         mcp_assigns[agent_slot] = list(dict.fromkeys(custom.mcp_servers))
-    elif agent_slot in mcp_assigns:
-        del mcp_assigns[agent_slot]
     config.mcp_assignments = mcp_assigns
 
     model_slot = (custom.model_slot or "").strip()

--- a/core/subagents/store.py
+++ b/core/subagents/store.py
@@ -218,17 +218,19 @@ def sync_custom_type_profile_bindings(
             config.mcp_assignments = old_mcp
 
     assigns = dict(getattr(config, "skill_assignments", None) or {})
-    if getattr(custom, "skills_inherit", True):
+    explicit_skills = list(dict.fromkeys(custom.skills))
+    if getattr(custom, "skills_inherit", True) and not explicit_skills:
         assigns.pop(agent_slot, None)
     else:
-        assigns[agent_slot] = list(dict.fromkeys(custom.skills))
+        assigns[agent_slot] = explicit_skills
     config.skill_assignments = assigns
 
     mcp_assigns = dict(getattr(config, "mcp_assignments", None) or {})
-    if getattr(custom, "mcp_inherit", True):
+    explicit_mcp = list(dict.fromkeys(custom.mcp_servers))
+    if getattr(custom, "mcp_inherit", True) and not explicit_mcp:
         mcp_assigns.pop(agent_slot, None)
     else:
-        mcp_assigns[agent_slot] = list(dict.fromkeys(custom.mcp_servers))
+        mcp_assigns[agent_slot] = explicit_mcp
     config.mcp_assignments = mcp_assigns
 
     model_slot = (custom.model_slot or "").strip()

--- a/core/subagents/supervisor.py
+++ b/core/subagents/supervisor.py
@@ -16,11 +16,15 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from core.runtime.introspect_signals import introspect_loop
 from core.runtime.step_budget import (
     _looks_like_error,
     _looks_like_progress,
+    _signatures_loop,
     _tool_signature,
 )
+from core.runtime.test_run_signals import tests_already_green_loop
+from core.runtime.write_signals import noop_write_loop
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +32,7 @@ DEFAULT_POLL_S = 4.0
 DEFAULT_IDLE_S = 90.0
 DEFAULT_MAX_INTERVENTIONS = 3
 DEFAULT_COOLDOWN_S = 45.0
+DEFAULT_LOOP_COOLDOWN_S = 8.0
 DEFAULT_MIN_STEPS_BEFORE_STALL = 4
 
 
@@ -38,6 +43,7 @@ class SupervisorPolicy:
     idle_s: float = DEFAULT_IDLE_S
     max_interventions: int = DEFAULT_MAX_INTERVENTIONS
     cooldown_s: float = DEFAULT_COOLDOWN_S
+    loop_cooldown_s: float = DEFAULT_LOOP_COOLDOWN_S
     min_steps_before_stall: int = DEFAULT_MIN_STEPS_BEFORE_STALL
 
     @classmethod
@@ -51,17 +57,11 @@ class SupervisorPolicy:
             enabled=bool(enabled),
             poll_s=max(
                 1.0,
-                float(
-                    getattr(cfg, "subagent_supervisor_poll_s", DEFAULT_POLL_S)
-                    or DEFAULT_POLL_S
-                ),
+                float(getattr(cfg, "subagent_supervisor_poll_s", DEFAULT_POLL_S) or DEFAULT_POLL_S),
             ),
             idle_s=max(
                 5.0,
-                float(
-                    getattr(cfg, "subagent_supervisor_idle_s", DEFAULT_IDLE_S)
-                    or DEFAULT_IDLE_S
-                ),
+                float(getattr(cfg, "subagent_supervisor_idle_s", DEFAULT_IDLE_S) or DEFAULT_IDLE_S),
             ),
             max_interventions=max(
                 0,
@@ -79,6 +79,17 @@ class SupervisorPolicy:
                 float(
                     getattr(cfg, "subagent_supervisor_cooldown_s", DEFAULT_COOLDOWN_S)
                     or DEFAULT_COOLDOWN_S
+                ),
+            ),
+            loop_cooldown_s=max(
+                0.0,
+                float(
+                    getattr(
+                        cfg,
+                        "subagent_supervisor_loop_cooldown_s",
+                        DEFAULT_LOOP_COOLDOWN_S,
+                    )
+                    or DEFAULT_LOOP_COOLDOWN_S
                 ),
             ),
             min_steps_before_stall=max(
@@ -105,14 +116,15 @@ class Diagnosis:
 
     @property
     def needs_intervention(self) -> bool:
-        return self.kind in {"loop", "thrash", "hung", "stall"}
+        return self.kind in {"loop", "thrash", "hung", "stall", "launch", "tests_green"}
 
 
-def _activity_tool_traces(handle: Any, *, lookback: int = 8) -> list[dict[str, Any]]:
+def _activity_tool_traces(handle: Any, *, lookback: int = 12) -> list[dict[str, Any]]:
     """Build tool-like traces from handle.activity_log."""
     log = list(getattr(handle, "activity_log", None) or [])
     traces: list[dict[str, Any]] = []
-    for entry in log[-lookback * 2 :]:
+    # step + tool_start + tool_result ≈ 3 rows per call
+    for entry in log[-lookback * 3 :]:
         kind = str(entry.get("kind") or "")
         tool = str(entry.get("tool_name") or "")
         details = str(entry.get("details") or "")
@@ -148,6 +160,223 @@ def _activity_tool_traces(handle: Any, *, lookback: int = 8) -> list[dict[str, A
     return traces[-lookback:]
 
 
+_SEARCH_TOOLS = frozenset({"grep", "glob", "list_directory"})
+
+
+def _is_search_tool(name: str) -> bool:
+    return str(name or "").strip().lower() in _SEARCH_TOOLS
+
+
+def _extract_command(details: Any) -> str:
+    text = str(details or "").strip()
+    if text.startswith("{") or text.startswith("["):
+        try:
+            import json
+
+            obj = json.loads(text)
+            if isinstance(obj, dict) and obj.get("command"):
+                return str(obj.get("command") or "")
+        except Exception:
+            pass
+    return text
+
+
+def _looks_like_project_launch(details: Any) -> bool:
+    try:
+        from core.tools.terminal import _is_untracked_long_running_command
+    except Exception:
+        return False
+    return bool(_is_untracked_long_running_command(_extract_command(details)))
+
+
+def _looks_like_port_kill(details: Any) -> bool:
+    blob = _extract_command(details).lower()
+    if "kill" not in blob and "pkill" not in blob:
+        return False
+    return any(x in blob for x in ("lsof", "fuser", ":8000", ":3000", ":5173", "ti:"))
+
+
+def _alternating_launch_kill(traces: list[dict[str, Any]]) -> bool:
+    terms = [
+        t
+        for t in traces
+        if str(t.get("name") or "").lower() in {"terminal", "run_terminal_command"}
+    ]
+    if len(terms) < 4:
+        return False
+    flags = []
+    for t in terms[-4:]:
+        args = t.get("arguments")
+        flags.append(
+            "launch"
+            if _looks_like_project_launch(args)
+            else ("kill" if _looks_like_port_kill(args) else "other")
+        )
+    return flags in (["launch", "kill", "launch", "kill"], ["kill", "launch", "kill", "launch"])
+
+
+def _tool_path(details: Any) -> str:
+    text = str(details or "").strip()
+    if not text:
+        return ""
+    if text.startswith("{") or text.startswith("["):
+        try:
+            import json
+
+            obj = json.loads(text)
+            if isinstance(obj, dict):
+                for key in ("path", "file", "target", "root"):
+                    val = str(obj.get(key) or "").strip()
+                    if val:
+                        return val
+        except Exception:
+            pass
+    import re
+
+    hit = re.search(r'"path"\s*:\s*"([^"]+)"', text)
+    return hit.group(1) if hit else ""
+
+
+def _same_path_search_loop(traces: list[dict[str, Any]]) -> bool:
+    """True when grep/glob keeps hitting the same file with tweaked patterns."""
+    search = [t for t in traces if _is_search_tool(str(t.get("name") or ""))]
+    if len(search) < 4:
+        return False
+    paths = [_tool_path(t.get("arguments")) for t in search[-6:]]
+    paths = [p for p in paths if p]
+    if len(paths) < 4:
+        return False
+    last = paths[-1]
+    return paths.count(last) >= 4
+
+
+def _prefer_tool(available: list[str], *candidates: str) -> str | None:
+    have = {str(t).strip() for t in available if str(t).strip()}
+    if not have:
+        return candidates[0] if candidates else None
+    for name in candidates:
+        if name in have:
+            return name
+    return None
+
+
+def build_loop_guidance(
+    *,
+    tool: str,
+    details: str = "",
+    available_tools: list[str] | None = None,
+    attempt: int = 1,
+    max_attempts: int = DEFAULT_MAX_INTERVENTIONS,
+) -> str:
+    """Concrete next-step guidance so the model can leave a tool loop."""
+    tool_l = (tool or "tool").strip() or "tool"
+    blob = (details or "").lower()
+    available = [str(t).strip() for t in (available_tools or []) if str(t).strip()]
+    read = _prefer_tool(available, "read_file", "grep", "glob", "list_directory")
+    write = _prefer_tool(available, "write_file", "delete_file")
+    search = _prefer_tool(available, "grep", "glob", "read_file")
+
+    if tool_l in {"terminal", "run_terminal_command"}:
+        if (
+            "inspect." in blob
+            or "import inspect" in blob
+            or "python -c" in blob
+            or "__init__" in blob
+            or "protocol" in blob
+        ):
+            next_move = (
+                f"stop inspect.getsource / python -c on libraries. "
+                f"You already have enough API surface. Next call must be "
+                f"{write or 'write_file'} for the project files "
+                f"(or {read or 'read_file'} a local .py you will edit) — "
+                f"do not introspect another method"
+            )
+        elif _looks_like_project_launch(details) or any(
+            x in blob for x in ("uvicorn", "gunicorn", "npm run dev", "fastapi run", ".main")
+        ):
+            bg = _prefer_tool(
+                available,
+                "start_background_process",
+                "run_project",
+                "check_background_process",
+            )
+            next_move = (
+                f"stop launching the server via terminal. Use "
+                f"{bg or 'start_background_process'} with the same command "
+                f"(then check_background_process). Do not use `&`, nohup, or "
+                f"python -m *.main in terminal"
+            )
+        elif any(x in blob for x in ("pip install",)):
+            next_move = (
+                f"stop re-running that command; {read or 'read_file'} the project "
+                "files you already have and continue implementation"
+            )
+        else:
+            next_move = (
+                f"do not re-run this terminal command; {read or 'read_file'} / "
+                f"{search or 'grep'} the relevant source, then "
+                f"{write or 'write_file'} or finish with what you know"
+            )
+    elif tool_l == "read_file":
+        next_move = (
+            f"you already have this file; next {write or 'write_file'} a change "
+            f"or {search or 'grep'} a different path — do not re-read the same file"
+        )
+    elif tool_l in {"grep", "glob"}:
+        next_move = (
+            f"open one hit with {read or 'read_file'}, then {write or 'write_file'} "
+            "or answer; do not repeat the same search"
+        )
+    elif tool_l == "write_file":
+        if "no content changes" in blob:
+            next_move = (
+                "STOP rewriting files that already match disk. "
+                "Do not call write_file again on those paths. "
+                "Run pytest once if you have not, then the next message must be "
+                "the final answer with NO tool calls so the process can continue"
+            )
+        else:
+            next_move = (
+                f"stop rewriting the same file; {read or 'read_file'} to verify or "
+                "move to the next deliverable / final answer"
+            )
+    elif tool_l in {"web_search", "web_fetch"}:
+        next_move = (
+            "use a different query/URL once, then write the answer from evidence "
+            "you already have — do not repeat the same fetch/search"
+        )
+    else:
+        next_move = (
+            f"call a different tool or different arguments "
+            f"({read or 'read_file'} / {write or 'write_file'}), "
+            "or produce a partial final result"
+        )
+
+    tools_line = ""
+    if available:
+        tools_line = " Allowed tools: " + ", ".join(available) + "."
+
+    last = attempt >= max(1, int(max_attempts or 1))
+    if last and _is_search_tool(tool_l):
+        warning = (
+            " Stop refining the same search — open the file with "
+            f"{read or 'read_file'} now. Search tweaks are not a failure, "
+            "but they will not find new facts."
+        )
+    elif last:
+        warning = (
+            " LAST CHANCE: if you repeat the same call, the job will be stopped with status loop."
+        )
+    else:
+        warning = f" Attempt {attempt}/{max_attempts}."
+    return (
+        f"SUPERVISOR GUIDANCE: You are looping on `{tool_l}`. "
+        f"Do NOT call `{tool_l}` with the same arguments again. "
+        f"Required next move: {next_move}.{tools_line}"
+        f"{warning}"
+    )
+
+
 def assess_handle(
     handle: Any,
     *,
@@ -157,9 +386,7 @@ def assess_handle(
     """Classify sub-agent health from live handle state."""
     pol = policy or SupervisorPolicy()
     status = getattr(handle, "status", None)
-    status_val = (
-        status.value if hasattr(status, "value") else str(status or "")
-    ).lower()
+    status_val = (status.value if hasattr(status, "value") else str(status or "")).lower()
     is_running = bool(getattr(handle, "is_running", False)) or status_val == "running"
     if not is_running:
         return Diagnosis(
@@ -173,18 +400,19 @@ def assess_handle(
     traces = _activity_tool_traces(handle)
     sigs = [str(t.get("signature") or "") for t in traces if t.get("signature")]
     error_count = sum(1 for t in traces if t.get("is_error"))
-    progress_count = sum(
-        1 for t in traces if _looks_like_progress(str(t.get("result") or ""))
-    )
+    progress_count = sum(1 for t in traces if _looks_like_progress(str(t.get("result") or "")))
     steps = int(getattr(handle, "steps_taken", 0) or 0)
     last_tool = str(getattr(handle, "last_tool", "") or "")
     activity = str(getattr(handle, "current_activity", "") or "")
 
-    loop_hit = False
-    if len(sigs) >= 3 and sigs[-1] and sigs[-1] == sigs[-2] == sigs[-3]:
-        loop_hit = True
-    elif len(sigs) >= 4 and sigs[-1] and sigs[-4:].count(sigs[-1]) >= 3:
-        loop_hit = True
+    path_loop = _same_path_search_loop(traces)
+    inspect_hit = introspect_loop(traces)
+    noop_write_hit = noop_write_loop(traces)
+    loop_hit = _signatures_loop(sigs) or path_loop or inspect_hit or noop_write_hit
+    last_args = str((traces[-1] or {}).get("arguments") or "") if traces else ""
+    launch_hit = str(last_tool).lower() in {"terminal", "run_terminal_command"} and (
+        _looks_like_project_launch(last_args) or _alternating_launch_kill(traces)
+    )
 
     actively = True
     if hasattr(handle, "is_actively_working"):
@@ -204,20 +432,92 @@ def assess_handle(
         "activity": activity[:120],
     }
 
+    if tests_already_green_loop(traces):
+        available = list(getattr(getattr(handle, "config", None), "tools", None) or [])
+        return Diagnosis(
+            kind="tests_green",
+            severity="warning",
+            summary="tests already passed — finish so the process can continue",
+            guidance=(
+                "SUPERVISOR GUIDANCE: Automated tests already passed. "
+                "Do NOT run pytest/grep on tests again. "
+                "Your next message must be the final answer with NO tool calls "
+                "so the Studio process can continue to the next node. "
+                "Summarize what you fixed and stop."
+            ),
+            signals={
+                **signals,
+                "loop_tool": last_tool or "terminal",
+                "loop_details": last_args[:240],
+                "search_loop": True,
+                "tests_green": True,
+            },
+        )
+
+    if launch_hit:
+        available = list(getattr(getattr(handle, "config", None), "tools", None) or [])
+        bg = _prefer_tool(
+            available,
+            "start_background_process",
+            "run_project",
+            "check_background_process",
+        )
+        return Diagnosis(
+            kind="launch",
+            severity="warning",
+            summary="project launch via terminal — use start_background_process",
+            guidance=(
+                "SUPERVISOR GUIDANCE: You are starting a long-running project/server "
+                "via terminal. Stop that. Call "
+                f"{bg or 'start_background_process'} with the same command "
+                "(label the app), then check_background_process. "
+                "Do not use `&`, nohup, python -m *.main, or uvicorn in terminal — "
+                "those hang the tool and are not tracked."
+            ),
+            signals={
+                **signals,
+                "loop_tool": last_tool or "terminal",
+                "loop_details": last_args[:240],
+                "search_loop": False,
+                "launch_via_terminal": True,
+            },
+        )
+
     if loop_hit:
         tool = last_tool or (traces[-1].get("name") if traces else "tool")
+        details = str((traces[-1] or {}).get("arguments") or "") if traces else ""
+        if noop_write_hit:
+            details = str((traces[-1] or {}).get("result") or details)
+        available = list(getattr(getattr(handle, "config", None), "tools", None) or [])
+        search_only = _is_search_tool(str(tool)) or path_loop
+        if noop_write_hit:
+            summary = f"write_file no-op loop ({tool})"
+        elif inspect_hit:
+            summary = f"library introspection loop via terminal ({tool})"
+        elif path_loop and not _signatures_loop(sigs):
+            summary = f"repeated search on the same path ({tool})"
+        else:
+            summary = f"repeated identical tool calls ({tool})"
         return Diagnosis(
             kind="loop",
-            severity="critical",
-            summary=f"repeated identical tool calls ({tool})",
-            guidance=(
-                f"SUPERVISOR GUIDANCE: You are looping on the same tool call "
-                f"({tool}). Stop repeating it. Change approach: try a different "
-                f"tool, different arguments, read a related file, or summarize "
-                f"what you already know and produce a partial result. Do not "
-                f"call the same tool with the same arguments again."
+            severity="warn" if search_only else "critical",
+            summary=summary,
+            guidance=build_loop_guidance(
+                tool=str(tool),
+                details=details,
+                available_tools=available,
+                attempt=1,
+                max_attempts=pol.max_interventions,
             ),
-            signals=signals,
+            signals={
+                **signals,
+                "loop_tool": str(tool),
+                "loop_details": details[:240],
+                "search_loop": search_only,
+                "path_loop": path_loop,
+                "inspect_loop": inspect_hit,
+                "noop_write_loop": noop_write_hit,
+            },
         )
 
     if len(traces) >= 3 and error_count == len(traces) and progress_count == 0:
@@ -382,32 +682,74 @@ class SubagentSupervisor:
 
         count = int(self._interventions.get(name, 0))
         if count >= self._policy.max_interventions:
-            # Emit once per "exhausted" transition
+            search_loop = (
+                bool(diagnosis.signals.get("search_loop"))
+                or _is_search_tool(
+                    str(diagnosis.signals.get("loop_tool") or handle.last_tool or "")
+                )
+                or diagnosis.kind == "launch"
+                or diagnosis.kind == "tests_green"
+                or bool(diagnosis.signals.get("launch_via_terminal"))
+                or bool(diagnosis.signals.get("tests_green"))
+            )
             if self._last_kind.get(name) != "exhausted":
                 self._last_kind[name] = "exhausted"
+                fatal = diagnosis.kind == "loop" and not search_loop
                 self._emit(
                     handle,
                     diagnosis,
                     attempt=count,
                     message=(
                         f"Supervisor: max interventions ({count}) reached for "
-                        f"`{name}` ({diagnosis.kind}); waiting for natural stop"
+                        f"`{name}` ({diagnosis.kind}); stopping with status loop"
+                        if fatal
+                        else f"Supervisor: max interventions ({count}) reached for "
+                        f"`{name}` ({diagnosis.kind}); "
+                        + (
+                            "search tweaks are not a failure — waiting for a read/write"
+                            if search_loop
+                            else "waiting for natural stop"
+                        )
                     ),
                     exhausted=True,
                 )
+                if fatal:
+                    await self._stop_loop(handle, diagnosis)
             return
 
         now = time.monotonic()
         last = float(self._last_intervene_at.get(name, 0.0))
-        if last and (now - last) < self._policy.cooldown_s:
+        cooldown = (
+            self._policy.loop_cooldown_s
+            if diagnosis.kind in {"loop", "launch", "tests_green"}
+            else self._policy.cooldown_s
+        )
+        if last and (now - last) < cooldown:
             return
 
-        # Don't spam same kind every poll without cooldown already covered
-        ok = await self._send_guidance(handle, diagnosis, attempt=count + 1)
+        attempt = count + 1
+        if diagnosis.kind == "loop":
+            diagnosis = Diagnosis(
+                kind=diagnosis.kind,
+                severity=diagnosis.severity,
+                summary=diagnosis.summary,
+                guidance=build_loop_guidance(
+                    tool=str(diagnosis.signals.get("loop_tool") or handle.last_tool or "tool"),
+                    details=str(diagnosis.signals.get("loop_details") or ""),
+                    available_tools=list(
+                        getattr(getattr(handle, "config", None), "tools", None) or []
+                    ),
+                    attempt=attempt,
+                    max_attempts=self._policy.max_interventions,
+                ),
+                signals=diagnosis.signals,
+            )
+
+        ok = await self._send_guidance(handle, diagnosis, attempt=attempt)
         if not ok:
             return
 
-        self._interventions[name] = count + 1
+        self._interventions[name] = attempt
         self._last_intervene_at[name] = now
         self._last_kind[name] = diagnosis.kind
         self._emit(
@@ -481,6 +823,40 @@ class SubagentSupervisor:
             diagnosis.summary,
         )
         return True
+
+    async def _stop_loop(self, handle: Any, diagnosis: Diagnosis) -> None:
+        """Stop a looping job with status=loop (not cancelled)."""
+        from core.subagents.base import SubAgentResult, SubAgentStatus
+
+        name = str(getattr(handle, "name", "") or "")
+        error = (
+            "loop: repeated identical tool calls after "
+            f"{self._policy.max_interventions} supervisor interventions"
+        )
+        handle.forced_status = SubAgentStatus.LOOP
+        handle.result = SubAgentResult(
+            name=name,
+            success=False,
+            error=error,
+            steps_taken=int(getattr(handle, "steps_taken", 0) or 0),
+            duration_ms=float(getattr(handle, "elapsed_ms", 0) or 0),
+        )
+        try:
+            handle.record_activity(
+                "status",
+                "loop",
+                details=error,
+                steps_taken=int(getattr(handle, "steps_taken", 0) or 0),
+            )
+        except Exception:
+            pass
+        terminate = getattr(self._manager, "terminate", None)
+        if callable(terminate):
+            try:
+                await terminate(name)
+            except Exception:
+                logger.exception("supervisor: failed to stop looping job %s", name)
+        logger.warning("Supervisor stopped %s with status=loop (%s)", name, diagnosis.summary)
 
     def _emit(
         self,

--- a/core/subagents/supervisor.py
+++ b/core/subagents/supervisor.py
@@ -237,6 +237,83 @@ def _tool_path(details: Any) -> str:
     return hit.group(1) if hit else ""
 
 
+def _loop_target(details: Any) -> str:
+    """Human-facing path / command / query from the looping tool call."""
+    path = _tool_path(details)
+    if path:
+        return path
+    text = str(details or "").strip()
+    if text.startswith("{") or text.startswith("["):
+        try:
+            import json
+
+            obj = json.loads(text)
+            if isinstance(obj, dict):
+                for key in ("command", "query", "pattern", "url"):
+                    val = str(obj.get(key) or "").strip()
+                    if val:
+                        return val
+        except Exception:
+            pass
+    cmd = _extract_command(details).strip()
+    if cmd:
+        return " ".join(cmd.split())[:240]
+    return ""
+
+
+def _result_excerpt(result: str, limit: int = 360) -> str:
+    text = " ".join(str(result or "").split())
+    if not text:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)] + "…"
+
+
+def format_human_loop_question(
+    base: str,
+    *,
+    details: str = "",
+    last_result: str = "",
+) -> str:
+    """Question the human sees: what is stuck, which call, last result."""
+    parts = [str(base or "").strip()]
+    target = _loop_target(details)
+    if target:
+        parts.append(f"Repeating: {target}")
+    excerpt = _result_excerpt(last_result)
+    if excerpt:
+        parts.append(f"Last result: {excerpt}")
+    return "\n".join(p for p in parts if p)
+
+
+def format_human_loop_context(
+    *,
+    problem: str,
+    tool: str,
+    details: str = "",
+    last_result: str = "",
+    next_move: str = "",
+    known: str = "",
+) -> str:
+    """Structured evidence for the ask_user dialog (not raw supervisor guidance)."""
+    lines = [
+        f"What is stuck: {problem}",
+        f"Tool: {tool}",
+    ]
+    target = _loop_target(details)
+    if target:
+        lines.append(f"Repeating: {target}")
+    if known:
+        lines.append(f"Already known: {known}")
+    excerpt = _result_excerpt(last_result, 480)
+    if excerpt:
+        lines.append(f"Last tool result: {excerpt}")
+    if next_move:
+        lines.append(f"What the supervisor already asked the agent to do: {next_move}")
+    return "\n".join(lines)
+
+
 def _same_path_search_loop(traces: list[dict[str, Any]]) -> bool:
     """True when grep/glob keeps hitting the same file with tweaked patterns."""
     search = [t for t in traces if _is_search_tool(str(t.get("name") or ""))]
@@ -300,6 +377,8 @@ def diagnose_loop_fix(
     """What is stuck, what is already known, and what to fix next."""
     tool_l = (tool or "tool").strip() or "tool"
     blob = (details or "").lower()
+    target = _loop_target(details)
+    target_s = f" (`{target}`)" if target else ""
     available = [str(t).strip() for t in (available_tools or []) if str(t).strip()]
     read = _prefer_tool(available, "read_file", "grep", "glob", "list_directory")
     write = _prefer_tool(available, "write_file", "delete_file")
@@ -319,7 +398,8 @@ def diagnose_loop_fix(
                 "Do not introspect another library method"
             ),
             "user_question": (
-                "The coder is stuck inspecting libraries instead of writing files. "
+                "The coder is stuck inspecting libraries instead of writing files"
+                f"{target_s}. "
                 "Should it implement from known FastAPI/Dishka APIs, skip this step, "
                 "or do you want a different approach?"
             ),
@@ -334,7 +414,8 @@ def diagnose_loop_fix(
                 "then the next message must be the final answer with NO tool calls"
             ),
             "user_question": (
-                "The coder keeps rewriting files that already match disk. "
+                "The coder keeps rewriting files that already match disk"
+                f"{target_s}. "
                 "Should it stop and finalize, run tests once, or change a specific file?"
             ),
         }
@@ -358,8 +439,8 @@ def diagnose_loop_fix(
                 ),
                 "user_question": (
                     "The coder keeps launching the server in terminal instead of "
-                    "start_background_process. Should it switch to the background tool, "
-                    "skip the server, or stop?"
+                    f"start_background_process{target_s}. "
+                    "Should it switch to the background tool, skip the server, or stop?"
                 ),
             }
         if _looks_like_venv_package_hunt(details):
@@ -378,8 +459,8 @@ def diagnose_loop_fix(
                     f"and run pytest. Searching .venv is not a fix"
                 ),
                 "user_question": (
-                    "The coder is looping on `ls/grep` inside .venv (mako/alembic/etc. "
-                    "are not installed). Should it implement without those packages, "
+                    f"The coder is looping on `ls/grep` inside .venv{target_s}. "
+                    "Those packages are not installed. Should it implement without them, "
                     "`uv add` a specific package, or stop and wait for you?"
                 ),
             }
@@ -392,7 +473,7 @@ def diagnose_loop_fix(
                     "and continue implementation or run tests once"
                 ),
                 "user_question": (
-                    "The coder is retrying the same install command. "
+                    f"The coder is retrying the same install command{target_s}. "
                     "Should it continue with current deps, install a named package, or stop?"
                 ),
             }
@@ -409,7 +490,7 @@ def diagnose_loop_fix(
                 "the fix or write the final answer"
             ),
             "user_question": (
-                "The coder is repeating the same terminal command. "
+                f"The coder is repeating the same terminal command{target_s}. "
                 "What should it do instead (which file to edit, which command, or stop)?"
             ),
         }
@@ -423,7 +504,7 @@ def diagnose_loop_fix(
                 "different path — do not re-read the same file"
             ),
             "user_question": (
-                "The coder keeps re-reading the same file. "
+                f"The coder keeps re-reading the same file{target_s}. "
                 "Which change should it make, or should it stop?"
             ),
         }
@@ -436,7 +517,7 @@ def diagnose_loop_fix(
                 "or answer; do not repeat the same search"
             ),
             "user_question": (
-                "The coder is stuck repeating grep/glob. "
+                f"The coder is stuck repeating grep/glob{target_s}. "
                 "Which path should it open, or should it stop searching?"
             ),
         }
@@ -449,7 +530,7 @@ def diagnose_loop_fix(
                 "move to the next deliverable / final answer"
             ),
             "user_question": (
-                "The coder keeps rewriting the same file. "
+                f"The coder keeps rewriting the same file{target_s}. "
                 "Should it finalize, edit a different file, or stop?"
             ),
         }
@@ -462,7 +543,7 @@ def diagnose_loop_fix(
                 "you already have — do not repeat the same fetch/search"
             ),
             "user_question": (
-                "The coder is looping on web_search/web_fetch. "
+                f"The coder is looping on web_search/web_fetch{target_s}. "
                 "Should it write from current evidence, try a specific URL, or stop?"
             ),
         }
@@ -475,7 +556,7 @@ def diagnose_loop_fix(
             "or produce a partial final result"
         ),
         "user_question": (
-            f"The coder is looping on `{tool_l}`. "
+            f"The coder is looping on `{tool_l}`{target_s}. "
             f"What should it do next, or should it stop? (You can reply via {ask}.)"
         ),
     }
@@ -661,6 +742,14 @@ def assess_handle(
             summary = f"repeated search on the same path ({tool})"
         else:
             summary = f"repeated identical tool calls ({tool})"
+        fix = diagnose_loop_fix(
+            tool=str(tool),
+            details=details,
+            last_result=last_result,
+            available_tools=available,
+            inspect_loop=inspect_hit,
+            noop_write_loop=noop_write_hit,
+        )
         return Diagnosis(
             kind="loop",
             severity="warn" if search_only else "critical",
@@ -684,14 +773,19 @@ def assess_handle(
                 "path_loop": path_loop,
                 "inspect_loop": inspect_hit,
                 "noop_write_loop": noop_write_hit,
-                "user_question": diagnose_loop_fix(
+                "user_question": format_human_loop_question(
+                    fix["user_question"],
+                    details=details,
+                    last_result=last_result,
+                ),
+                "user_context": format_human_loop_context(
+                    problem=fix["problem"],
                     tool=str(tool),
                     details=details,
                     last_result=last_result,
-                    available_tools=available,
-                    inspect_loop=inspect_hit,
-                    noop_write_loop=noop_write_hit,
-                )["user_question"],
+                    next_move=fix["next_move"],
+                    known=fix["known"],
+                ),
             },
         )
 
@@ -1046,10 +1140,19 @@ class SubagentSupervisor:
                     notify(name, force=True)
                 except Exception:
                     pass
+            context = str(diagnosis.signals.get("user_context") or "").strip()
+            if not context:
+                context = format_human_loop_context(
+                    problem=diagnosis.summary,
+                    tool=str(diagnosis.signals.get("loop_tool") or ""),
+                    details=str(diagnosis.signals.get("loop_details") or ""),
+                    last_result=str(diagnosis.signals.get("last_result") or ""),
+                    next_move=diagnosis.guidance,
+                )
             answer = await ask(
                 name,
                 question,
-                context=f"{diagnosis.summary}\n{diagnosis.guidance}",
+                context=context,
             )
         except Exception:
             logger.exception("supervisor: ask_user failed for %s", name)

--- a/core/subagents/supervisor.py
+++ b/core/subagents/supervisor.py
@@ -260,38 +260,87 @@ def _prefer_tool(available: list[str], *candidates: str) -> str | None:
     return None
 
 
-def build_loop_guidance(
+def _looks_like_venv_package_hunt(details: str) -> bool:
+    blob = (details or "").lower()
+    in_venv = any(token in blob for token in ("site-packages", ".venv/", "venv/lib", "/lib/python"))
+    hunts = any(token in blob for token in ("grep", "find ", "ls ", "rg ", "pip show", "pip list"))
+    return in_venv and hunts
+
+
+def _looks_like_absence_result(result: str) -> bool:
+    blob = (result or "").lower()
+    if not blob.strip():
+        return False
+    return any(
+        token in blob
+        for token in (
+            "not found",
+            "no such",
+            "none\n",
+            "none of",
+            "no mako",
+            "no alemb",
+            "really none",
+            "exit code 1",
+            "0 match",
+            "no matches",
+        )
+    )
+
+
+def diagnose_loop_fix(
     *,
     tool: str,
     details: str = "",
+    last_result: str = "",
     available_tools: list[str] | None = None,
-    attempt: int = 1,
-    max_attempts: int = DEFAULT_MAX_INTERVENTIONS,
-) -> str:
-    """Concrete next-step guidance so the model can leave a tool loop."""
+    inspect_loop: bool = False,
+    noop_write_loop: bool = False,
+) -> dict[str, str]:
+    """What is stuck, what is already known, and what to fix next."""
     tool_l = (tool or "tool").strip() or "tool"
     blob = (details or "").lower()
     available = [str(t).strip() for t in (available_tools or []) if str(t).strip()]
     read = _prefer_tool(available, "read_file", "grep", "glob", "list_directory")
     write = _prefer_tool(available, "write_file", "delete_file")
     search = _prefer_tool(available, "grep", "glob", "read_file")
+    ask = _prefer_tool(available, "ask_user") or "ask_user"
+
+    if inspect_loop or (
+        tool_l in {"terminal", "run_terminal_command"}
+        and any(x in blob for x in ("inspect.", "python -c", "__init__", "protocol"))
+    ):
+        return {
+            "problem": "library introspection via terminal",
+            "known": "inspect/python -c on third-party packages will not write the project.",
+            "next_move": (
+                f"stop inspect.getsource / python -c. Write the app with "
+                f"{write or 'write_file'} (or {read or 'read_file'} a local file you will edit). "
+                "Do not introspect another library method"
+            ),
+            "user_question": (
+                "The coder is stuck inspecting libraries instead of writing files. "
+                "Should it implement from known FastAPI/Dishka APIs, skip this step, "
+                "or do you want a different approach?"
+            ),
+        }
+
+    if noop_write_loop or (tool_l == "write_file" and "no content changes" in blob):
+        return {
+            "problem": "rewriting files that already match disk",
+            "known": "write_file already reported no content changes.",
+            "next_move": (
+                "STOP rewriting those paths. Run pytest once if you have not, "
+                "then the next message must be the final answer with NO tool calls"
+            ),
+            "user_question": (
+                "The coder keeps rewriting files that already match disk. "
+                "Should it stop and finalize, run tests once, or change a specific file?"
+            ),
+        }
 
     if tool_l in {"terminal", "run_terminal_command"}:
-        if (
-            "inspect." in blob
-            or "import inspect" in blob
-            or "python -c" in blob
-            or "__init__" in blob
-            or "protocol" in blob
-        ):
-            next_move = (
-                f"stop inspect.getsource / python -c on libraries. "
-                f"You already have enough API surface. Next call must be "
-                f"{write or 'write_file'} for the project files "
-                f"(or {read or 'read_file'} a local .py you will edit) — "
-                f"do not introspect another method"
-            )
-        elif _looks_like_project_launch(details) or any(
+        if _looks_like_project_launch(details) or any(
             x in blob for x in ("uvicorn", "gunicorn", "npm run dev", "fastapi run", ".main")
         ):
             bg = _prefer_tool(
@@ -300,57 +349,162 @@ def build_loop_guidance(
                 "run_project",
                 "check_background_process",
             )
-            next_move = (
-                f"stop launching the server via terminal. Use "
-                f"{bg or 'start_background_process'} with the same command "
-                f"(then check_background_process). Do not use `&`, nohup, or "
-                f"python -m *.main in terminal"
+            return {
+                "problem": "starting a long-running server in the foreground terminal",
+                "known": "foreground uvicorn/npm/etc. blocks the agent and is not how Studio tracks processes.",
+                "next_move": (
+                    f"use {bg or 'start_background_process'} with the same command, "
+                    "then check_background_process. Do not use &, nohup, or python -m *.main in terminal"
+                ),
+                "user_question": (
+                    "The coder keeps launching the server in terminal instead of "
+                    "start_background_process. Should it switch to the background tool, "
+                    "skip the server, or stop?"
+                ),
+            }
+        if _looks_like_venv_package_hunt(details):
+            absence = (
+                "The venv listing already shows those packages are not installed. "
+                "Repeating ls/grep will not install them."
+                if _looks_like_absence_result(last_result) or "grep" in blob
+                else "Hunting site-packages does not implement the task."
             )
-        elif any(x in blob for x in ("pip install",)):
-            next_move = (
-                f"stop re-running that command; {read or 'read_file'} the project "
-                "files you already have and continue implementation"
-            )
-        else:
-            next_move = (
-                f"do not re-run this terminal command; {read or 'read_file'} / "
-                f"{search or 'grep'} the relevant source, then "
-                f"{write or 'write_file'} or finish with what you know"
-            )
-    elif tool_l == "read_file":
-        next_move = (
-            f"you already have this file; next {write or 'write_file'} a change "
-            f"or {search or 'grep'} a different path — do not re-read the same file"
-        )
-    elif tool_l in {"grep", "glob"}:
-        next_move = (
-            f"open one hit with {read or 'read_file'}, then {write or 'write_file'} "
-            "or answer; do not repeat the same search"
-        )
-    elif tool_l == "write_file":
-        if "no content changes" in blob:
-            next_move = (
-                "STOP rewriting files that already match disk. "
-                "Do not call write_file again on those paths. "
-                "Run pytest once if you have not, then the next message must be "
-                "the final answer with NO tool calls so the process can continue"
-            )
-        else:
-            next_move = (
+            return {
+                "problem": "searching the virtualenv for missing packages",
+                "known": absence,
+                "next_move": (
+                    f"do not ls/grep site-packages again. If you need a package, "
+                    f"`uv add <name>` once; otherwise {write or 'write_file'} the app "
+                    f"and run pytest. Searching .venv is not a fix"
+                ),
+                "user_question": (
+                    "The coder is looping on `ls/grep` inside .venv (mako/alembic/etc. "
+                    "are not installed). Should it implement without those packages, "
+                    "`uv add` a specific package, or stop and wait for you?"
+                ),
+            }
+        if any(x in blob for x in ("pip install", "uv add", "uv sync")):
+            return {
+                "problem": "repeating a package-install command",
+                "known": "the install command already ran; retrying it is not progress.",
+                "next_move": (
+                    f"stop re-running the installer; {read or 'read_file'} the project "
+                    "and continue implementation or run tests once"
+                ),
+                "user_question": (
+                    "The coder is retrying the same install command. "
+                    "Should it continue with current deps, install a named package, or stop?"
+                ),
+            }
+        return {
+            "problem": f"repeating the same `{tool_l}` command",
+            "known": (
+                "The last command already returned an answer (including empty / not found)."
+                if last_result
+                else "Repeating the same shell command will not change the result."
+            ),
+            "next_move": (
+                f"do not re-run this terminal command. {read or 'read_file'} / "
+                f"{search or 'grep'} project source, then {write or 'write_file'} "
+                "the fix or write the final answer"
+            ),
+            "user_question": (
+                "The coder is repeating the same terminal command. "
+                "What should it do instead (which file to edit, which command, or stop)?"
+            ),
+        }
+
+    if tool_l == "read_file":
+        return {
+            "problem": "re-reading the same file",
+            "known": "you already have this file contents.",
+            "next_move": (
+                f"next {write or 'write_file'} a change or {search or 'grep'} a "
+                "different path — do not re-read the same file"
+            ),
+            "user_question": (
+                "The coder keeps re-reading the same file. "
+                "Which change should it make, or should it stop?"
+            ),
+        }
+    if tool_l in {"grep", "glob"}:
+        return {
+            "problem": "repeating the same search",
+            "known": "the search already returned its hits (or none).",
+            "next_move": (
+                f"open one hit with {read or 'read_file'}, then {write or 'write_file'} "
+                "or answer; do not repeat the same search"
+            ),
+            "user_question": (
+                "The coder is stuck repeating grep/glob. "
+                "Which path should it open, or should it stop searching?"
+            ),
+        }
+    if tool_l == "write_file":
+        return {
+            "problem": "rewriting the same file",
+            "known": "another rewrite of the same path is not new work.",
+            "next_move": (
                 f"stop rewriting the same file; {read or 'read_file'} to verify or "
                 "move to the next deliverable / final answer"
-            )
-    elif tool_l in {"web_search", "web_fetch"}:
-        next_move = (
-            "use a different query/URL once, then write the answer from evidence "
-            "you already have — do not repeat the same fetch/search"
-        )
-    else:
-        next_move = (
+            ),
+            "user_question": (
+                "The coder keeps rewriting the same file. "
+                "Should it finalize, edit a different file, or stop?"
+            ),
+        }
+    if tool_l in {"web_search", "web_fetch"}:
+        return {
+            "problem": "repeating the same web search/fetch",
+            "known": "you already have that page/query result.",
+            "next_move": (
+                "use a different query/URL once, then write the answer from evidence "
+                "you already have — do not repeat the same fetch/search"
+            ),
+            "user_question": (
+                "The coder is looping on web_search/web_fetch. "
+                "Should it write from current evidence, try a specific URL, or stop?"
+            ),
+        }
+    return {
+        "problem": f"repeating `{tool_l}`",
+        "known": "the same tool call will not produce new information.",
+        "next_move": (
             f"call a different tool or different arguments "
             f"({read or 'read_file'} / {write or 'write_file'}), "
             "or produce a partial final result"
-        )
+        ),
+        "user_question": (
+            f"The coder is looping on `{tool_l}`. "
+            f"What should it do next, or should it stop? (You can reply via {ask}.)"
+        ),
+    }
+
+
+def build_loop_guidance(
+    *,
+    tool: str,
+    details: str = "",
+    available_tools: list[str] | None = None,
+    attempt: int = 1,
+    max_attempts: int = DEFAULT_MAX_INTERVENTIONS,
+    last_result: str = "",
+    inspect_loop: bool = False,
+    noop_write_loop: bool = False,
+) -> str:
+    """Concrete next-step guidance so the model can leave a tool loop."""
+    tool_l = (tool or "tool").strip() or "tool"
+    available = [str(t).strip() for t in (available_tools or []) if str(t).strip()]
+    read = _prefer_tool(available, "read_file", "grep", "glob", "list_directory")
+    ask = _prefer_tool(available, "ask_user") or "ask_user"
+    fix = diagnose_loop_fix(
+        tool=tool_l,
+        details=details,
+        last_result=last_result,
+        available_tools=available,
+        inspect_loop=inspect_loop,
+        noop_write_loop=noop_write_loop,
+    )
 
     tools_line = ""
     if available:
@@ -365,14 +519,22 @@ def build_loop_guidance(
         )
     elif last:
         warning = (
-            " LAST CHANCE: if you repeat the same call, the job will be stopped with status loop."
+            f" LAST CHANCE: apply the fix above. If you cannot, call `{ask}` "
+            f"now with this question (do not run another `{tool_l}`): "
+            f"{fix['user_question']} "
+            "If you repeat the same call instead, the supervisor will ask the "
+            "human and then stop the job."
         )
     else:
-        warning = f" Attempt {attempt}/{max_attempts}."
+        warning = (
+            f" Attempt {attempt}/{max_attempts}. If you cannot apply the fix, "
+            f"call `{ask}` instead of repeating `{tool_l}`."
+        )
     return (
-        f"SUPERVISOR GUIDANCE: You are looping on `{tool_l}`. "
+        f"SUPERVISOR GUIDANCE: You are looping on `{tool_l}` "
+        f"({fix['problem']}). {fix['known']} "
         f"Do NOT call `{tool_l}` with the same arguments again. "
-        f"Required next move: {next_move}.{tools_line}"
+        f"What to fix: {fix['next_move']}.{tools_line}"
         f"{warning}"
     )
 
@@ -410,6 +572,7 @@ def assess_handle(
     noop_write_hit = noop_write_loop(traces)
     loop_hit = _signatures_loop(sigs) or path_loop or inspect_hit or noop_write_hit
     last_args = str((traces[-1] or {}).get("arguments") or "") if traces else ""
+    last_result = str((traces[-1] or {}).get("result") or "") if traces else ""
     launch_hit = str(last_tool).lower() in {"terminal", "run_terminal_command"} and (
         _looks_like_project_launch(last_args) or _alternating_launch_kill(traces)
     )
@@ -508,15 +671,27 @@ def assess_handle(
                 available_tools=available,
                 attempt=1,
                 max_attempts=pol.max_interventions,
+                last_result=last_result,
+                inspect_loop=inspect_hit,
+                noop_write_loop=noop_write_hit,
             ),
             signals={
                 **signals,
                 "loop_tool": str(tool),
                 "loop_details": details[:240],
+                "last_result": last_result[:400],
                 "search_loop": search_only,
                 "path_loop": path_loop,
                 "inspect_loop": inspect_hit,
                 "noop_write_loop": noop_write_hit,
+                "user_question": diagnose_loop_fix(
+                    tool=str(tool),
+                    details=details,
+                    last_result=last_result,
+                    available_tools=available,
+                    inspect_loop=inspect_hit,
+                    noop_write_loop=noop_write_hit,
+                )["user_question"],
             },
         )
 
@@ -594,6 +769,8 @@ class SubagentSupervisor:
         self._interventions: dict[str, int] = {}
         self._last_intervene_at: dict[str, float] = {}
         self._last_kind: dict[str, str] = {}
+        self._escalating: set[str] = set()
+        self._escalated: set[str] = set()
 
     @property
     def policy(self) -> SupervisorPolicy:
@@ -639,6 +816,8 @@ class SubagentSupervisor:
         self._interventions.pop(name, None)
         self._last_intervene_at.pop(name, None)
         self._last_kind.pop(name, None)
+        self._escalating.discard(name)
+        self._escalated.discard(name)
 
     async def _watch_loop(self) -> None:
         try:
@@ -676,6 +855,8 @@ class SubagentSupervisor:
         name = str(getattr(handle, "name", "") or "")
         if not name:
             return
+        if name in self._escalating:
+            return
         diagnosis = assess_handle(handle, policy=self._policy)
         if not diagnosis.needs_intervention:
             return
@@ -701,7 +882,7 @@ class SubagentSupervisor:
                     attempt=count,
                     message=(
                         f"Supervisor: max interventions ({count}) reached for "
-                        f"`{name}` ({diagnosis.kind}); stopping with status loop"
+                        f"`{name}` ({diagnosis.kind}); asking the human"
                         if fatal
                         else f"Supervisor: max interventions ({count}) reached for "
                         f"`{name}` ({diagnosis.kind}); "
@@ -714,7 +895,13 @@ class SubagentSupervisor:
                     exhausted=True,
                 )
                 if fatal:
-                    await self._stop_loop(handle, diagnosis)
+                    if name in self._escalated:
+                        await self._stop_loop(handle, diagnosis)
+                    else:
+                        asyncio.create_task(
+                            self._ask_human_then_retry_or_stop(handle, diagnosis),
+                            name=f"supervisor-ask-{name[:24]}",
+                        )
             return
 
         now = time.monotonic()
@@ -741,6 +928,9 @@ class SubagentSupervisor:
                     ),
                     attempt=attempt,
                     max_attempts=self._policy.max_interventions,
+                    last_result=str(diagnosis.signals.get("last_result") or ""),
+                    inspect_loop=bool(diagnosis.signals.get("inspect_loop")),
+                    noop_write_loop=bool(diagnosis.signals.get("noop_write_loop")),
                 ),
                 signals=diagnosis.signals,
             )
@@ -823,6 +1013,81 @@ class SubagentSupervisor:
             diagnosis.summary,
         )
         return True
+
+    async def _ask_human_then_retry_or_stop(self, handle: Any, diagnosis: Diagnosis) -> None:
+        """When the model cannot leave a loop, ask the human what to do."""
+        name = str(getattr(handle, "name", "") or "")
+        if not name or name in self._escalating:
+            return
+        self._escalating.add(name)
+        question = str(diagnosis.signals.get("user_question") or "").strip() or (
+            f"Sub-agent `{name}` is stuck in a tool loop ({diagnosis.summary}). "
+            "What should it do next, or should it stop?"
+        )
+        interactions = getattr(self._manager, "interactions", None)
+        ask = getattr(interactions, "ask_user", None)
+        if not callable(ask):
+            self._escalating.discard(name)
+            await self._stop_loop(handle, diagnosis)
+            return
+        try:
+            try:
+                handle.record_activity(
+                    "status",
+                    "awaiting user (supervisor)",
+                    details=question,
+                    steps_taken=int(getattr(handle, "steps_taken", 0) or 0),
+                )
+            except Exception:
+                pass
+            notify = getattr(self._manager, "notify_progress", None)
+            if callable(notify):
+                try:
+                    notify(name, force=True)
+                except Exception:
+                    pass
+            answer = await ask(
+                name,
+                question,
+                context=f"{diagnosis.summary}\n{diagnosis.guidance}",
+            )
+        except Exception:
+            logger.exception("supervisor: ask_user failed for %s", name)
+            self._escalating.discard(name)
+            await self._stop_loop(handle, diagnosis)
+            return
+
+        self._escalating.discard(name)
+        self._escalated.add(name)
+        text = str(answer or "").strip()
+        low = text.lower()
+        if not text or low.startswith("error:") or low in {"stop", "cancel", "abort", "kill"}:
+            await self._stop_loop(handle, diagnosis)
+            return
+
+        self._interventions[name] = max(0, int(self._policy.max_interventions) - 1)
+        self._last_kind[name] = "user_reply"
+        reply = Diagnosis(
+            kind="loop",
+            severity="warning",
+            summary="human answered supervisor question",
+            guidance=(
+                "SUPERVISOR GUIDANCE: The human answered because you could not "
+                "leave the tool loop yourself. Follow this and do not repeat "
+                f"the previous command:\n{text}"
+            ),
+            signals=diagnosis.signals,
+        )
+        await self._send_guidance(handle, reply, attempt=self._interventions[name])
+        try:
+            handle.record_activity(
+                "supervisor_guidance",
+                "Supervisor: human reply",
+                details=text[:300],
+                steps_taken=int(getattr(handle, "steps_taken", 0) or 0),
+            )
+        except Exception:
+            pass
 
     async def _stop_loop(self, handle: Any, diagnosis: Diagnosis) -> None:
         """Stop a looping job with status=loop (not cancelled)."""

--- a/core/tools/code_executor.py
+++ b/core/tools/code_executor.py
@@ -262,9 +262,7 @@ def _build_safe_builtins(allowed_modules: frozenset[str]) -> dict:
         root = (name or "").split(".", 1)[0]
         if root not in allowed_modules:
             allowed = ", ".join(sorted(allowed_modules))
-            raise ImportError(
-                f"Import of '{name}' is not allowed. Allowed modules: {allowed}"
-            )
+            raise ImportError(f"Import of '{name}' is not allowed. Allowed modules: {allowed}")
         return _builtins.__import__(name, globals, locals, fromlist, level)
 
     mapping: dict = {
@@ -314,6 +312,10 @@ class PythonExecutorTool(BaseTool):
     async def execute(self, code: str, timeout: int = 10) -> str:
         if not settings.enable_code_executor:
             return "Error: Code executor is disabled (HOLIX_ENABLE_CODE_EXECUTOR=false)"
+        from core.runtime.introspect_signals import INTROSPECT_REFUSAL, is_introspect_code
+
+        if is_introspect_code(code):
+            return INTROSPECT_REFUSAL
         try:
             timeout_s = max(1, int(timeout or 10))
         except (TypeError, ValueError):
@@ -333,10 +335,7 @@ class PythonExecutorTool(BaseTool):
                 "HOLIX_PROFILE",
             }:
                 # Keep home/profile for path resolution if needed; drop API keys etc.
-                if any(
-                    s in key.upper()
-                    for s in ("KEY", "TOKEN", "SECRET", "PASSWORD", "PEPPER")
-                ):
+                if any(s in key.upper() for s in ("KEY", "TOKEN", "SECRET", "PASSWORD", "PEPPER")):
                     env.pop(key, None)
 
         # Own process group so killpg reaps nested children.
@@ -374,9 +373,7 @@ class PythonExecutorTool(BaseTool):
                 if remaining <= 0:
                     await self._kill_process(proc)
                     comm.cancel()
-                    return (
-                        f"Error: Code execution timed out after {timeout_s} seconds"
-                    )
+                    return f"Error: Code execution timed out after {timeout_s} seconds"
                 try:
                     stdout, stderr = await asyncio.wait_for(
                         asyncio.shield(comm), timeout=min(0.2, remaining)

--- a/core/tools/file_diff.py
+++ b/core/tools/file_diff.py
@@ -80,7 +80,14 @@ def summarize_file_write(path: str, old: str | None, new: str) -> str:
             line_count = 1
         return f"Created {path} (+{line_count} lines)"
     if old == new:
-        return f"Updated {path} (no content changes)"
+        return (
+            f"Updated {path} (no content changes)\n\n"
+            "STOP: The file on disk is already exactly this text. "
+            "Do NOT call write_file on it again. "
+            "If the project files exist, run pytest once (if you have not) "
+            "or give the final answer with NO tool calls so the Studio process "
+            "can continue. Rewriting the same bytes is not progress."
+        )
 
     diff = unified_diff_text(path, old, new)
     added, removed = _count_diff_lines(diff)
@@ -123,10 +130,7 @@ def format_write_file_result(path: str, old: str | None, new: str) -> str:
     old_s = old or ""
     if len(old_s) + len(new) <= _STUDIO_SIDES_MAX_CHARS:
         # No extra newline between old and CONTENT_NEW so old bytes stay exact.
-        body += (
-            f"\n\n{CONTENT_OLD_SEPARATOR}\n{old_s}"
-            f"{CONTENT_NEW_SEPARATOR}\n{new}"
-        )
+        body += f"\n\n{CONTENT_OLD_SEPARATOR}\n{old_s}{CONTENT_NEW_SEPARATOR}\n{new}"
     return body
 
 

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -170,34 +170,44 @@ class ToolRegistry:
     ) -> int:
         """Dynamically register MCP tools for this registry (called from agent init).
 
-        Returns number of tools registered.
+        ``slot`` is kept for callers; allow-lists are applied later in
+        :meth:`get_schemas` / subagent runners so every assigned server
+        is connected once.
         """
-        if not mcp_servers:
+        del slot
+        if not mcp_servers and not assignments:
             return 0
         try:
+            from core.mcp.assign import fill_assigned_mcp_servers
             from core.mcp.manager import MCPManager
 
-            mgr = MCPManager(mcp_servers)
+            servers = fill_assigned_mcp_servers(mcp_servers, assignments)
+            if not servers:
+                return 0
+            mgr = MCPManager(servers)
+            enabled = list(servers.keys())
+            self._mcp_assignments = dict(assignments or {})  # type: ignore[attr-defined]
+            self._mcp_enabled_servers = list(enabled)  # type: ignore[attr-defined]
+            self._mcp_manager = mgr  # type: ignore[attr-defined]
+
+            def _harvest(server_name: str | None = None) -> None:
+                names = [server_name] if server_name else enabled
+                for tool in mgr.get_tool_adapters(names):
+                    if tool.name not in self.tools:
+                        self.register(tool)
+
+            mgr.on_tools_ready = _harvest
             await mgr.connect_all()
-            enabled = []
-            if assignments and slot in assignments:
-                enabled = assignments[slot]
-            elif assignments:
-                enabled = list(assignments.get("main", mcp_servers.keys()))
-            else:
-                enabled = list(mcp_servers.keys())
-            self._mcp_enabled_servers = list(enabled or mcp_servers.keys())  # type: ignore[attr-defined]
+            # Register every connected server. Slot allow-lists are applied in
+            # get_schemas / subagent runners so python-coder can use Context7
+            # even when ``main`` only has holix_studio.
             # Give slow stdio servers (npx/uvx downloads, Context7 auth, etc.) time to initialize + list_tools
             try:
                 await mgr.wait_ready(enabled or None, timeout=ready_timeout)
             except Exception:
                 pass
-            tools = mgr.get_tool_adapters(enabled or None)
-            for t in tools:
-                self.register(t)
-            # keep ref on registry for shutdown if needed
-            self._mcp_manager = mgr  # type: ignore[attr-defined]
-            return len(tools)
+            _harvest()
+            return len([n for n in self.tools if str(n).startswith("mcp_")])
         except Exception as exc:
             # do not break agent if MCP misconfigured
             print(f"Warning: MCP registration skipped: {exc}")
@@ -220,21 +230,37 @@ class ToolRegistry:
                 added += 1
         return added
 
+    def mcp_status(self) -> list[dict[str, Any]]:
+        """Ready/error snapshot for each MCP server this registry started."""
+        mgr = getattr(self, "_mcp_manager", None)
+        if mgr is None:
+            return []
+        status = getattr(mgr, "server_status", None)
+        if callable(status):
+            return list(status() or [])
+        return []
+
     def get_schemas(self, *, for_agent_slot: str = "main") -> list[dict[str, Any]]:
         """Get OpenAI-compatible schemas for all registered tools.
 
         Returns:
             List of tool schemas
         """
+        from core.mcp.assign import mcp_tool_allowed
+
+        slot = (for_agent_slot or "main").strip().lower() or "main"
+        assigns = getattr(self, "_mcp_assignments", None)
         seen: set[str] = set()
         schemas: list[dict[str, Any]] = []
         for tool in self.tools.values():
             name = getattr(tool, "name", "") or ""
             if not name or name in seen:
                 continue
+            if not mcp_tool_allowed(name, slot=slot, assignments=assigns):
+                continue
             seen.add(name)
             schemas.append(tool.to_openai_schema())
-        if (for_agent_slot or "main").strip().lower() == "main":
+        if slot == "main":
             hidden_for_main = frozenset({"external_cli", "ask_user"})
             schemas = [
                 schema

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -264,6 +264,10 @@ async def _communicate_with_cancel(
                 if ports:
                     if not comm.done():
                         comm.cancel()
+                        try:
+                            await comm
+                        except (asyncio.CancelledError, Exception):
+                            pass
                     await _kill_process_tree(process)
                     raise PromoteForegroundService(ports)
 

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -262,6 +262,8 @@ async def _communicate_with_cancel(
                 pid = int(process.pid or 0)
                 ports = await asyncio.to_thread(listen_ports_for_pid_tree, pid)
                 if ports:
+                    if not comm.done():
+                        comm.cancel()
                     await _kill_process_tree(process)
                     raise PromoteForegroundService(ports)
 

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -4,6 +4,17 @@ import shlex
 
 from config import settings
 from core.platform_compat import IS_WINDOWS, subprocess_shell_kwargs
+from core.runtime.introspect_signals import (
+    INTROSPECT_REFUSAL,
+    is_introspect_command,
+)
+from core.runtime.service_detect import (
+    is_long_oneshot_job,
+    is_untracked_long_running_command,
+    listen_ports_for_pid_tree,
+    service_watch_after,
+    service_watch_interval,
+)
 from core.security.safety import command_needs_shell, command_whitelist
 from core.security.workspace_command_guard import (
     references_holix_profiles,
@@ -11,6 +22,17 @@ from core.security.workspace_command_guard import (
 )
 from core.tools.base import BaseTool
 from core.workspace import sanitize_paths_in_text
+
+# Re-exports so supervisor / tests keep importing from this module.
+_is_untracked_long_running_command = is_untracked_long_running_command
+
+
+class PromoteForegroundService(Exception):
+    """Foreground command is a listening service — move it to the registry."""
+
+    def __init__(self, ports: list[int]):
+        self.ports = list(ports)
+        super().__init__(f"foreground service on ports {self.ports}")
 
 
 def _env_bool(raw: str | None, *, default: bool) -> bool:
@@ -195,14 +217,28 @@ async def _communicate_with_cancel(
     process: asyncio.subprocess.Process,
     *,
     timeout: float,
+    command: str = "",
 ) -> tuple[bytes, bytes]:
-    """Wait for process output, honouring cooperative cancel and hard timeout."""
+    """Wait for process output, honouring cooperative cancel and hard timeout.
+
+    After ~60s, if the command is still running and the process tree has a
+    TCP LISTEN socket, raise :class:`PromoteForegroundService` so the caller
+    can restart it as a tracked background process. Long one-shots
+    (``cargo test``, ``mvn package``, ``pytest``) are never promoted.
+    """
     from core.tools.execution_context import is_run_cancelled
 
     comm = asyncio.create_task(process.communicate())
     loop = asyncio.get_running_loop()
-    deadline = loop.time() + max(0.1, float(timeout))
+    started = loop.time()
+    deadline = started + max(0.1, float(timeout))
     poll = 0.2
+    watch_after = service_watch_after()
+    watch_interval = service_watch_interval()
+    # First listen-check fires as soon as ``watch_after`` elapses.
+    last_watch = started - watch_interval
+    watch_command = (command or "").strip()
+    allow_watch = bool(watch_command) and not is_long_oneshot_job(watch_command)
 
     try:
         while not comm.done():
@@ -210,10 +246,23 @@ async def _communicate_with_cancel(
                 await _kill_process_tree(process)
                 raise asyncio.CancelledError("run cancelled")
 
-            remaining = deadline - loop.time()
+            now = loop.time()
+            remaining = deadline - now
             if remaining <= 0:
                 await _kill_process_tree(process)
                 raise TimeoutError()
+
+            if (
+                allow_watch
+                and process.returncode is None
+                and (now - started) >= watch_after
+                and (now - last_watch) >= watch_interval
+            ):
+                last_watch = now
+                pid = int(process.pid or 0)
+                ports = await asyncio.to_thread(listen_ports_for_pid_tree, pid)
+                if ports:
+                    raise PromoteForegroundService(ports)
 
             wait_s = min(poll, remaining)
             try:
@@ -230,6 +279,69 @@ async def _communicate_with_cancel(
                 pass
 
 
+def _promote_label(command: str) -> str:
+    text = (command or "").strip()
+    if not text:
+        return "promoted-service"
+    token = text.split()[0]
+    return (token or "promoted-service")[:120]
+
+
+async def _promote_to_background(
+    command: str,
+    *,
+    cwd: str | None,
+    ports: list[int],
+) -> str:
+    """Kill already happened; start the same command via the bg registry."""
+    from core.runtime.port_utils import force_free_ports
+    from core.tools.background_process import _chat_id_from_bridge, _run_start_or_restart
+    from core.tools.execution_context import get_conversation_id, get_profile_name
+
+    if ports:
+        await asyncio.to_thread(force_free_ports, ports)
+
+    from core.runtime.background_process import get_background_process_registry
+
+    registry = get_background_process_registry()
+    port_txt = ", ".join(str(p) for p in ports) if ports else "unknown"
+    try:
+        body = await _run_start_or_restart(
+            registry,
+            command=command,
+            label=_promote_label(command),
+            working_directory=cwd or "",
+            conversation_id=get_conversation_id(),
+            profile=get_profile_name(),
+            chat_id=_chat_id_from_bridge(),
+            startup_wait_seconds=3.0,
+            restart=False,
+        )
+    except Exception as exc:
+        return (
+            f"Error: Command ran in the foreground for over a minute and "
+            f"opened TCP listen port(s) {port_txt} — this is a service, not "
+            f"a one-shot job. It was stopped. Restart it with "
+            f"start_background_process using the same command.\n"
+            f"Auto-restart failed: {exc}"
+        )
+    if body.startswith("Error:"):
+        return (
+            f"The foreground command was a service (listen on {port_txt} "
+            f"after ~1 min) and was stopped. Restart it with "
+            f"start_background_process.\n{body}"
+        )
+    return (
+        f"The command kept running for over a minute and opened TCP listen "
+        f"port(s) {port_txt} — this is a service, not a long one-shot "
+        f"(compile/test). It was stopped in the foreground and restarted "
+        f"via start_background_process.\n\n"
+        f"{body}\n\n"
+        "Use check_background_process / stop_background_process from now on. "
+        "Do not launch this command via run_terminal_command again."
+    )
+
+
 class TerminalTool(BaseTool):
     """Tool for executing terminal commands safely."""
 
@@ -239,9 +351,12 @@ class TerminalTool(BaseTool):
         self.description = (
             "Execute a short terminal command and return its output. "
             "Shell operators (&&, |, >, etc.) are supported. "
-            "Use for system operations, package installation, git commands, etc. "
-            "Do NOT use for long-running bots/servers (telegram bots, uvicorn, npm run dev) — "
+            "Use for system operations, package installation, git commands, tests, builds. "
+            "Do NOT use for long-running bots/servers "
+            "(uvicorn, cargo run, go run, java -jar, dotnet run, npm run dev, …) — "
             "use start_background_process so the process is tracked across restarts. "
+            "If a missed server stays in the foreground for over a minute and "
+            "opens a listen port, this tool stops it and restarts it in the background. "
             "Permission errors (sudo/root) are returned as clear access-denied messages."
         )
         self.risk_level = "high"
@@ -274,31 +389,26 @@ class TerminalTool(BaseTool):
         if is_run_cancelled():
             return "Error: Run cancelled — terminal command not started."
 
+        if is_introspect_command(command):
+            return INTROSPECT_REFUSAL
+
         # Nudge away from untracked long-running bots/servers.
-        cmd_l = (command or "").lower()
-        if any(
-            x in cmd_l
-            for x in (
-                "nohup ",
-                "integrations.telegram",
-                "telegram_channel_publisher",
-                "python -m http.server",
-                "uvicorn ",
-                "npm run dev",
-                "next dev",
-                "gunicorn ",
+        # Do not treat `pip install uvicorn` as launching uvicorn.
+        if _is_untracked_long_running_command(command):
+            return (
+                "Error: This looks like a **long-running** bot/server "
+                "(uvicorn, cargo run, go run, java -jar, dotnet run, "
+                "npm run dev, docker compose up, …). "
+                "Do **not** launch it via run_terminal_command (it will not be "
+                "tracked after reboot and can conflict with Holix Telegram). "
+                "Use **start_background_process** with the same command instead, "
+                "then check_background_process / stop_background_process. "
+                "Never start a second Telegram long-poll with the same bot token "
+                "as holix-gateway (TelegramConflictError). "
+                "Installing packages and running tests/builds "
+                "(`pip install`, `cargo test`, `go test`, `mvn package`) is fine "
+                "here; only *starting* the server belongs in start_background_process."
             )
-        ) or ("python" in cmd_l and any(x in cmd_l for x in ("bot.py", "polling", "getupdates"))):
-            if not any(x in cmd_l for x in ("&& echo", "timeout ", "pkill", "pgrep", "ps ")):
-                return (
-                    "Error: This looks like a **long-running** bot/server. "
-                    "Do **not** launch it via run_terminal_command (it will not be "
-                    "tracked after reboot and can conflict with Holix Telegram). "
-                    "Use **start_background_process** with the same command instead, "
-                    "then check_background_process / stop_background_process. "
-                    "Never start a second Telegram long-poll with the same bot token "
-                    "as holix-gateway (TelegramConflictError)."
-                )
 
         # Destructive patterns always apply; full command allowlist is optional.
         if terminal_whitelist_enabled():
@@ -378,7 +488,9 @@ class TerminalTool(BaseTool):
 
             try:
                 stdout, stderr = await _communicate_with_cancel(
-                    process, timeout=float(timeout or 30)
+                    process,
+                    timeout=float(timeout or 30),
+                    command=command,
                 )
 
                 from core.memory.tool_content import truncate_terminal_output
@@ -396,6 +508,13 @@ class TerminalTool(BaseTool):
                     error=error,
                 )
 
+            except PromoteForegroundService as promo:
+                await _kill_process_tree(process)
+                return await _promote_to_background(
+                    command,
+                    cwd=cwd,
+                    ports=promo.ports,
+                )
             except TimeoutError:
                 await _kill_process_tree(process)
                 return f"Error: Command timed out after {timeout} seconds"

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -262,6 +262,7 @@ async def _communicate_with_cancel(
                 pid = int(process.pid or 0)
                 ports = await asyncio.to_thread(listen_ports_for_pid_tree, pid)
                 if ports:
+                    await _kill_process_tree(process)
                     raise PromoteForegroundService(ports)
 
             wait_s = min(poll, remaining)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## 1.0.10 — 2026-08-17
+
+MCP tools per agent slot, fewer coder tool-loops, and live provider model lists without stale catalog aliases.
+
+### Added
+
+- **MCP by slot** — connect the union of assigned MCP servers, fill popular configs (e.g. Context7), harvest tools when a slow `npx` server becomes ready, and filter tool schemas by agent slot.
+- **Process-mode MCP** — child processes start assigned MCP even when the parent profile only had a stub manager.
+- **Supervisor loop diagnosis** — structured “what is stuck / what is known / what to fix”; escalate to `ask_user` before stopping a looping sub-agent.
+
+### Fixed
+
+- **Coder loops** — detect service launches across languages; treat inspect/`python -c` and no-op rewrites as non-progress; tighten step-budget and supervisor guidance (venv package hunts, inspect, noop writes).
+- **Stale model aliases** — do not inject `default_model` / catalog `popular_models` that `/v1/models` did not return (drops leftovers like `qwen3.8-27b-mac1`).
+
+### Tests
+
+- MCP assignment, service/introspect/test-run signals, step budget, supervisor `ask_user` escalation, live model-id filter.
+
 ## 1.0.9 — 2026-08-15
 
 Tool-call recovery and aliases, CPU-safe Chroma embeddings, LangGraph checkpoint size guard, and LTM context-recall tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.9"
+version = "1.0.10"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_file_diff.py
+++ b/tests/test_file_diff.py
@@ -37,6 +37,16 @@ def test_new_file_summary():
     assert "Created" in summarize_file_write("new.py", None, "line1\nline2\n")
 
 
+def test_identical_rewrite_tells_agent_to_stop():
+    text = summarize_file_write("app/ioc.py", "same\n", "same\n")
+    assert text.startswith("Updated app/ioc.py (no content changes)")
+    assert "STOP" in text
+    assert "Do NOT call write_file" in text
+    body = format_write_file_result("app/ioc.py", "same\n", "same\n")
+    assert "STOP" in body
+    assert DIFF_SEPARATOR not in body
+
+
 @pytest.mark.asyncio
 async def test_write_file_returns_diff():
     tool = WriteFileTool()

--- a/tests/test_introspect_signals.py
+++ b/tests/test_introspect_signals.py
@@ -7,6 +7,7 @@ import time
 import pytest
 from core.runtime.introspect_signals import (
     introspect_loop,
+    is_introspect_code,
     is_introspect_command,
 )
 from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
@@ -33,6 +34,9 @@ def test_detects_inspect_getsource() -> None:
     assert not is_introspect_command("python -m pytest tests")
     assert not is_introspect_command("pip install dadata")
     assert not is_introspect_command('python -c "print(1)"')
+    assert not is_introspect_code(
+        "try:\n    1/0\nexcept ZeroDivisionError as e:\n    print(type(e).__name__)"
+    )
 
 
 def test_introspect_loop_on_rotating_methods() -> None:

--- a/tests/test_introspect_signals.py
+++ b/tests/test_introspect_signals.py
@@ -1,0 +1,120 @@
+"""Library-introspection loops are not implementation progress."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from core.runtime.introspect_signals import (
+    introspect_loop,
+    is_introspect_command,
+)
+from core.runtime.step_budget import StepBudgetPolicy, evaluate_step_budget
+from core.subagents.base import SubAgentConfig, SubAgentHandle, SubAgentStatus
+from core.subagents.supervisor import assess_handle
+
+
+def _cmd(method: str) -> str:
+    return (
+        '{"command": "cd projects/data_address && python -c \\"'
+        f"from dadata.asynchr import DadataClient; import inspect; "
+        f"print(inspect.getsource(DadataClient.{method}))"
+        '\\""}'
+    )
+
+
+def test_detects_inspect_getsource() -> None:
+    assert is_introspect_command('python -c "import inspect; print(inspect.getsource(Foo.bar))"')
+    assert is_introspect_command('python -c "print(dir(app))"')
+    assert is_introspect_command('python -c "import dadata; print(dadata.Dadata.__name__)"')
+    assert is_introspect_command(
+        'python -c "import dadata; print(dadata.Dadata.__init__.__code__.co_flags)"'
+    )
+    assert not is_introspect_command("python -m pytest tests")
+    assert not is_introspect_command("pip install dadata")
+    assert not is_introspect_command('python -c "print(1)"')
+
+
+def test_introspect_loop_on_rotating_methods() -> None:
+    traces = [
+        {"name": "terminal", "arguments": _cmd(name)}
+        for name in ("close", "suggest", "find_by_id", "geolocate")
+    ]
+    assert introspect_loop(traces) is True
+
+
+def test_introspect_loop_false_when_write_started() -> None:
+    traces = [
+        {"name": "terminal", "arguments": _cmd("suggest")},
+        {"name": "terminal", "arguments": _cmd("geolocate")},
+        {"name": "terminal", "arguments": _cmd("close")},
+        {"name": "write_file", "arguments": '{"path": "app/main.py"}'},
+        {"name": "terminal", "arguments": _cmd("iplocate")},
+    ]
+    assert introspect_loop(traces) is False
+
+
+def test_supervisor_flags_inspect_rotation_as_loop() -> None:
+    h = SubAgentHandle(
+        name="coder",
+        config=SubAgentConfig(name="coder", max_steps=50),
+        status=SubAgentStatus.RUNNING,
+        started_at=time.monotonic(),
+        max_steps=50,
+    )
+    h.touch_activity()
+    h.last_tool = "terminal"
+    h.config.tools = ["read_file", "write_file", "terminal"]
+    h.steps_taken = 20
+    for method in ("close", "suggest", "find_by_id", "get_balance", "iplocate"):
+        h.record_activity(
+            "tool_start",
+            "Calling terminal",
+            tool_name="terminal",
+            details=_cmd(method),
+        )
+        h.record_activity(
+            "tool_result",
+            "terminal finished",
+            tool_name="terminal",
+            details="Success (exit code 0):\n    async def ...",
+        )
+    d = assess_handle(h)
+    assert d.kind == "loop"
+    assert d.signals.get("inspect_loop") is True
+    assert "write_file" in d.guidance
+    assert "inspect" in d.guidance.lower()
+
+
+def test_step_budget_does_not_extend_on_inspect_loop() -> None:
+    log = [
+        {
+            "name": "terminal",
+            "arguments": _cmd(name),
+            "result": "Success (exit code 0):\n    async def foo",
+        }
+        for name in ("close", "suggest", "find_by_id", "geolocate")
+    ]
+    d = evaluate_step_budget(
+        step_count=150,
+        max_steps=150,
+        tool_calls_log=log,
+        task="сделать fastapi каталог адресов",
+        policy=StepBudgetPolicy(extend_by=30, max_extensions=3),
+        base_max_steps=90,
+    )
+    assert not d.extend
+    assert d.status == "hung"
+    assert "inspect" in d.reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_terminal_refuses_python_c_library_probe() -> None:
+    from core.tools.terminal import TerminalTool
+
+    out = await TerminalTool().execute(
+        'cd projects/data_address && python -c "import dadata; print(dadata.Dadata.__name__)"',
+        timeout=5,
+    )
+    assert "write_file" in out
+    assert "Success" not in out

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -54,3 +54,42 @@ def test_registry_mcp_hook_exists():
 
     reg = ToolRegistry()
     assert hasattr(reg, "register_mcp")
+    assert hasattr(reg, "mcp_status")
+    assert reg.mcp_status() == []
+
+
+def test_mcp_manager_mark_ready_harvests():
+    from core.mcp.manager import MCPManager
+
+    seen: list[str] = []
+    mgr = MCPManager({})
+    mgr.on_tools_ready = seen.append
+    mgr._mark_ready(
+        "context7",
+        [{"name": "resolve-library-id", "description": "", "inputSchema": {}}],
+    )
+    assert seen == ["context7"]
+    status = {row["name"]: row for row in mgr.server_status()}
+    # no configs → empty status; still discovered
+    assert status == {}
+    assert mgr._discovered_tools["context7"][0]["name"] == "resolve-library-id"
+
+
+def test_mcp_manager_status_includes_configured_servers():
+    from core.mcp.manager import MCPManager
+
+    mgr = MCPManager({"context7": {"transport": "stdio", "command": "npx", "args": ["-y", "x"]}})
+    rows = mgr.server_status()
+    assert rows[0]["name"] == "context7"
+    assert rows[0]["ready"] is False
+    assert rows[0]["tools"] == 0
+    mgr._mark_ready(
+        "context7",
+        [
+            {"name": "resolve-library-id", "description": "", "inputSchema": {}},
+            {"name": "query-docs", "description": "", "inputSchema": {}},
+        ],
+    )
+    rows = mgr.server_status()
+    assert rows[0]["ready"] is True
+    assert rows[0]["tools"] == 2

--- a/tests/test_mcp_assign.py
+++ b/tests/test_mcp_assign.py
@@ -1,0 +1,93 @@
+"""Per-agent MCP allow-lists and popular-config fill."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from core.mcp.assign import (
+    fill_assigned_mcp_servers,
+    mcp_defs_for_names,
+    mcp_tool_allowed,
+    servers_for_slot,
+)
+from core.tools.registry import ToolRegistry
+
+
+def test_servers_for_slot_inherit_when_missing() -> None:
+    assert servers_for_slot({"main": ["holix_studio"]}, "python-coder") is None
+    assert servers_for_slot({"python-coder": ["context7"]}, "python-coder") == ["context7"]
+    assert servers_for_slot({"python-coder": []}, "python-coder") == []
+
+
+def test_mcp_tool_allowed_by_slot() -> None:
+    assigns = {"main": ["holix_studio"], "python-coder": ["context7", "holix_studio"]}
+    assert mcp_tool_allowed("mcp_holix_studio_list", slot="main", assignments=assigns)
+    assert not mcp_tool_allowed("mcp_context7_resolve-library-id", slot="main", assignments=assigns)
+    assert mcp_tool_allowed(
+        "mcp_context7_resolve-library-id", slot="python-coder", assignments=assigns
+    )
+    assert mcp_tool_allowed("write_file", slot="main", assignments=assigns)
+
+
+def test_fill_assigned_adds_popular_context7() -> None:
+    out = fill_assigned_mcp_servers(
+        {"holix_studio": {"transport": "stdio", "command": "x"}},
+        {"python-coder": ["context7", "holix_studio"]},
+    )
+    assert "holix_studio" in out
+    assert "context7" in out
+    assert out["context7"].get("command") == "npx"
+    assert out["context7"].get("_auto_from_assignment") is True
+
+
+def test_mcp_defs_for_names_fills_missing_popular() -> None:
+    subset = mcp_defs_for_names(
+        {"holix_studio": {"transport": "stdio", "command": "x"}},
+        ["context7", "missing-custom"],
+    )
+    assert set(subset) == {"context7"}
+    assert subset["context7"].get("command") == "npx"
+
+
+def test_fill_completes_stub_and_keeps_api_key() -> None:
+    out = fill_assigned_mcp_servers(
+        {
+            "context7": {
+                "default_risk_level": "no",
+                "env": {"CONTEXT7_API_KEY": "ctx7sk-test-key"},
+            }
+        },
+        {"python-coder": ["context7"]},
+    )
+    assert out["context7"].get("command") == "npx"
+    assert "-y" in (out["context7"].get("args") or [])
+    assert out["context7"]["env"].get("CONTEXT7_API_KEY") == "ctx7sk-test-key"
+    assert out["context7"].get("default_risk_level") == "no"
+
+
+def test_get_schemas_hides_unassigned_mcp_for_main() -> None:
+    reg = ToolRegistry()
+    ctx = MagicMock()
+    ctx.name = "mcp_context7_query-docs"
+    ctx.to_openai_schema.return_value = {
+        "type": "function",
+        "function": {"name": "mcp_context7_query-docs"},
+    }
+    studio = MagicMock()
+    studio.name = "mcp_holix_studio_list"
+    studio.to_openai_schema.return_value = {
+        "type": "function",
+        "function": {"name": "mcp_holix_studio_list"},
+    }
+    reg.tools["mcp_context7_query-docs"] = ctx
+    reg.tools["mcp_holix_studio_list"] = studio
+    reg._mcp_assignments = {
+        "main": ["holix_studio"],
+        "python-coder": ["context7", "holix_studio"],
+    }
+    main = {s["function"]["name"] for s in reg.get_schemas(for_agent_slot="main")}
+    coder = {s["function"]["name"] for s in reg.get_schemas(for_agent_slot="python-coder")}
+    assert "mcp_holix_studio_list" in main
+    assert "mcp_context7_query-docs" not in main
+    assert "mcp_context7_query-docs" in coder
+    assert "mcp_holix_studio_list" in coder

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -45,13 +45,9 @@ def test_ollama_litellm_vllm_configurable_host():
 def test_parse_host_value():
     assert parse_host_value("192.168.1.5", default_port=11434) == "http://192.168.1.5:11434/v1"
     assert (
-        parse_host_value("http://gpu.local:8000", default_port=8000)
-        == "http://gpu.local:8000/v1"
+        parse_host_value("http://gpu.local:8000", default_port=8000) == "http://gpu.local:8000/v1"
     )
-    assert (
-        parse_host_value("http://nas:4000/v1", default_port=4000)
-        == "http://nas:4000/v1"
-    )
+    assert parse_host_value("http://nas:4000/v1", default_port=4000) == "http://nas:4000/v1"
 
 
 def test_resolve_preset_base_url_from_host():
@@ -139,3 +135,34 @@ def test_build_provider_entry_merges_popular_models():
     entry = build_provider_entry(preset, api_key="${DEEPSEEK_API_KEY}", discovered_models=[])
     assert "deepseek-chat" in entry["available_models"]
     assert entry["metadata"]["preset_id"] == "deepseek"
+
+
+def test_apply_live_model_ids_drops_stale_visible():
+    from core.models.setup_helpers import apply_live_model_ids
+
+    out = apply_live_model_ids(
+        {
+            "available_models": ["old-a", "qwen3.8-27b-mac1"],
+            "user_visible_models": ["qwen3.8-27b", "qwen3.8-27b-mac1", "qwen3.6-35b"],
+            "premium_models": ["qwen3.8-27b-mac1"],
+            "default_model": "qwen3.8-27b-mac1",
+        },
+        ["qwen3.6-35b", "coder"],
+    )
+    assert out["available_models"] == ["qwen3.6-35b", "coder"]
+    assert out["user_visible_models"] == ["qwen3.6-35b"]
+    assert out["premium_models"] == []
+    assert out["default_model"] == "qwen3.6-35b"
+
+
+def test_build_provider_entry_does_not_add_undiscovered_popular():
+    preset = get_provider_preset("litellm")
+    assert preset is not None
+    entry = build_provider_entry(
+        preset,
+        api_key="sk-test",
+        discovered_models=[{"id": "qwen3.6-35b"}, {"id": "coder"}],
+    )
+    assert entry["available_models"] == ["qwen3.6-35b", "coder"]
+    assert "smart" not in entry["available_models"]
+    assert "fast" not in entry["available_models"]

--- a/tests/test_service_detect.py
+++ b/tests/test_service_detect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 
 import pytest
 from core.runtime.service_detect import (
@@ -97,8 +98,9 @@ async def test_communicate_promotes_when_tree_listens(monkeypatch) -> None:
         lambda pid: [8080],
     )
     process = await asyncio.create_subprocess_exec(
-        "sleep",
-        "8",
+        sys.executable,
+        "-c",
+        "import time; time.sleep(8)",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         start_new_session=True,
@@ -124,8 +126,9 @@ async def test_communicate_does_not_promote_oneshot(monkeypatch) -> None:
         lambda pid: [8080],
     )
     process = await asyncio.create_subprocess_exec(
-        "sleep",
-        "8",
+        sys.executable,
+        "-c",
+        "import time; time.sleep(8)",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         start_new_session=True,
@@ -150,8 +153,9 @@ async def test_communicate_does_not_promote_without_listen(monkeypatch) -> None:
         lambda pid: [],
     )
     process = await asyncio.create_subprocess_exec(
-        "sleep",
-        "8",
+        sys.executable,
+        "-c",
+        "import time; time.sleep(8)",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         start_new_session=True,

--- a/tests/test_service_detect.py
+++ b/tests/test_service_detect.py
@@ -119,13 +119,19 @@ async def test_communicate_promotes_when_tree_listens(monkeypatch) -> None:
         lambda pid: [8080],
     )
     monkeypatch.setattr("core.tools.terminal.IS_WINDOWS", True)
-    with pytest.raises(PromoteForegroundService) as exc:
+    try:
         await _communicate_with_cancel(
             _FakeProc(),
             timeout=2,
             command="./target/release/api",
         )
-    assert exc.value.ports == [8080]
+        pytest.fail("expected PromoteForegroundService")
+    except PromoteForegroundService as exc:
+        assert exc.ports == [8080]
+    except ExceptionGroup as eg:
+        hits = [e for e in eg.exceptions if isinstance(e, PromoteForegroundService)]
+        assert hits, eg
+        assert hits[0].ports == [8080]
 
 
 @pytest.mark.asyncio

--- a/tests/test_service_detect.py
+++ b/tests/test_service_detect.py
@@ -1,0 +1,167 @@
+"""Static + runtime classification of one-shot jobs vs services."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from core.runtime.service_detect import (
+    is_long_oneshot_job,
+    is_untracked_long_running_command,
+    should_promote_foreground_service,
+)
+from core.tools.terminal import (
+    PromoteForegroundService,
+    _communicate_with_cancel,
+    _kill_process_tree,
+    _promote_label,
+)
+
+
+def test_oneshot_jobs_are_not_launches() -> None:
+    oneshots = [
+        "cargo test --all",
+        "cargo build --release",
+        "go test ./...",
+        "go build ./cmd/api",
+        "mvn -q test",
+        "mvn -pl api test",
+        "mvn package",
+        "./gradlew test",
+        "dotnet test",
+        "dotnet restore && dotnet build",
+        "cmake --build build",
+        "g++ main.cpp -o app",
+        "pytest -q",
+        "python -m pytest tests",
+        "npm run build",
+        "make test",
+    ]
+    for cmd in oneshots:
+        assert is_long_oneshot_job(cmd) is True, cmd
+        assert is_untracked_long_running_command(cmd) is False, cmd
+
+
+def test_unknown_binary_is_not_a_static_launch() -> None:
+    """C++/custom binaries cannot be classified by regex — runtime decides."""
+    for cmd in ("./target/release/api", "./build/server --port 8080", "bin/holix-api"):
+        assert is_untracked_long_running_command(cmd) is False, cmd
+        assert is_long_oneshot_job(cmd) is False, cmd
+
+
+def test_promote_requires_listen_and_elapsed() -> None:
+    cmd = "./target/release/api --port 8080"
+    ok, ports = should_promote_foreground_service(cmd, pid=1, elapsed_s=10, listen_ports=[8080])
+    assert ok is False
+    assert ports == []
+
+    ok, ports = should_promote_foreground_service(cmd, pid=1, elapsed_s=61, listen_ports=[8080])
+    assert ok is True
+    assert ports == [8080]
+
+    ok, ports = should_promote_foreground_service(cmd, pid=1, elapsed_s=120, listen_ports=[])
+    assert ok is False
+
+
+def test_promote_skips_oneshot_even_if_port_bound() -> None:
+    """pytest / cargo test may bind a fixture port — leave them in the foreground."""
+    ok, ports = should_promote_foreground_service(
+        "cargo test",
+        pid=1,
+        elapsed_s=180,
+        listen_ports=[54321],
+    )
+    assert ok is False
+    assert ports == []
+
+    ok, _ = should_promote_foreground_service(
+        "python -m pytest tests",
+        pid=1,
+        elapsed_s=180,
+        listen_ports=[8000],
+    )
+    assert ok is False
+
+
+def test_promote_label_uses_first_token() -> None:
+    assert _promote_label("java -jar app.jar") == "java"
+    assert _promote_label("") == "promoted-service"
+
+
+@pytest.mark.asyncio
+async def test_communicate_promotes_when_tree_listens(monkeypatch) -> None:
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.15")
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
+    monkeypatch.setattr(
+        "core.tools.terminal.listen_ports_for_pid_tree",
+        lambda pid: [8080],
+    )
+    process = await asyncio.create_subprocess_exec(
+        "sleep",
+        "8",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        with pytest.raises(PromoteForegroundService) as exc:
+            await _communicate_with_cancel(
+                process,
+                timeout=3,
+                command="./target/release/api",
+            )
+        assert exc.value.ports == [8080]
+    finally:
+        await _kill_process_tree(process)
+
+
+@pytest.mark.asyncio
+async def test_communicate_does_not_promote_oneshot(monkeypatch) -> None:
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.1")
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
+    monkeypatch.setattr(
+        "core.tools.terminal.listen_ports_for_pid_tree",
+        lambda pid: [8080],
+    )
+    process = await asyncio.create_subprocess_exec(
+        "sleep",
+        "8",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        with pytest.raises(TimeoutError):
+            await _communicate_with_cancel(
+                process,
+                timeout=0.35,
+                command="cargo test --all",
+            )
+    finally:
+        await _kill_process_tree(process)
+
+
+@pytest.mark.asyncio
+async def test_communicate_does_not_promote_without_listen(monkeypatch) -> None:
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.1")
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
+    monkeypatch.setattr(
+        "core.tools.terminal.listen_ports_for_pid_tree",
+        lambda pid: [],
+    )
+    process = await asyncio.create_subprocess_exec(
+        "sleep",
+        "8",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        with pytest.raises(TimeoutError):
+            await _communicate_with_cancel(
+                process,
+                timeout=0.35,
+                command="./long-train-job",
+            )
+    finally:
+        await _kill_process_tree(process)

--- a/tests/test_service_detect.py
+++ b/tests/test_service_detect.py
@@ -2,42 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
-
-import pytest
 from core.runtime.service_detect import (
     is_long_oneshot_job,
     is_untracked_long_running_command,
     should_promote_foreground_service,
 )
-from core.tools.terminal import (
-    PromoteForegroundService,
-    _communicate_with_cancel,
-    _promote_label,
-)
-
-
-class _FakeProc:
-    """Long-running stub — no OS child, no killpg on CI pids."""
-
-    def __init__(self) -> None:
-        self.pid = 424242
-        self.returncode: int | None = None
-
-    async def communicate(self) -> tuple[bytes, bytes]:
-        try:
-            await asyncio.sleep(30)
-        except asyncio.CancelledError:
-            self.returncode = -9
-            raise
-        return b"", b""
-
-    def kill(self) -> None:
-        self.returncode = -9
-
-    async def wait(self) -> int:
-        self.returncode = -9
-        return -9
+from core.tools.terminal import _promote_label
 
 
 def test_oneshot_jobs_are_not_launches() -> None:
@@ -108,61 +78,3 @@ def test_promote_skips_oneshot_even_if_port_bound() -> None:
 def test_promote_label_uses_first_token() -> None:
     assert _promote_label("java -jar app.jar") == "java"
     assert _promote_label("") == "promoted-service"
-
-
-@pytest.mark.asyncio
-async def test_communicate_promotes_when_tree_listens(monkeypatch) -> None:
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.05")
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
-    monkeypatch.setattr(
-        "core.tools.terminal.listen_ports_for_pid_tree",
-        lambda pid: [8080],
-    )
-    monkeypatch.setattr("core.tools.terminal.IS_WINDOWS", True)
-    try:
-        await _communicate_with_cancel(
-            _FakeProc(),
-            timeout=2,
-            command="./target/release/api",
-        )
-        pytest.fail("expected PromoteForegroundService")
-    except PromoteForegroundService as exc:
-        assert exc.ports == [8080]
-    except ExceptionGroup as eg:
-        hits = [e for e in eg.exceptions if isinstance(e, PromoteForegroundService)]
-        assert hits, eg
-        assert hits[0].ports == [8080]
-
-
-@pytest.mark.asyncio
-async def test_communicate_does_not_promote_oneshot(monkeypatch) -> None:
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.05")
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
-    monkeypatch.setattr(
-        "core.tools.terminal.listen_ports_for_pid_tree",
-        lambda pid: [8080],
-    )
-    monkeypatch.setattr("core.tools.terminal.IS_WINDOWS", True)
-    with pytest.raises(TimeoutError):
-        await _communicate_with_cancel(
-            _FakeProc(),
-            timeout=0.35,
-            command="cargo test --all",
-        )
-
-
-@pytest.mark.asyncio
-async def test_communicate_does_not_promote_without_listen(monkeypatch) -> None:
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.05")
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
-    monkeypatch.setattr(
-        "core.tools.terminal.listen_ports_for_pid_tree",
-        lambda pid: [],
-    )
-    monkeypatch.setattr("core.tools.terminal.IS_WINDOWS", True)
-    with pytest.raises(TimeoutError):
-        await _communicate_with_cancel(
-            _FakeProc(),
-            timeout=0.35,
-            command="./long-train-job",
-        )

--- a/tests/test_service_detect.py
+++ b/tests/test_service_detect.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 
 import pytest
 from core.runtime.service_detect import (
@@ -14,9 +13,31 @@ from core.runtime.service_detect import (
 from core.tools.terminal import (
     PromoteForegroundService,
     _communicate_with_cancel,
-    _kill_process_tree,
     _promote_label,
 )
+
+
+class _FakeProc:
+    """Long-running stub — no OS child, no killpg on CI pids."""
+
+    def __init__(self) -> None:
+        self.pid = 424242
+        self.returncode: int | None = None
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            self.returncode = -9
+            raise
+        return b"", b""
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        self.returncode = -9
+        return -9
 
 
 def test_oneshot_jobs_are_not_launches() -> None:
@@ -91,81 +112,51 @@ def test_promote_label_uses_first_token() -> None:
 
 @pytest.mark.asyncio
 async def test_communicate_promotes_when_tree_listens(monkeypatch) -> None:
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.15")
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.05")
     monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
     monkeypatch.setattr(
         "core.tools.terminal.listen_ports_for_pid_tree",
         lambda pid: [8080],
     )
-    process = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-c",
-        "import time; time.sleep(8)",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        start_new_session=True,
-    )
-    try:
-        with pytest.raises(PromoteForegroundService) as exc:
-            await _communicate_with_cancel(
-                process,
-                timeout=3,
-                command="./target/release/api",
-            )
-        assert exc.value.ports == [8080]
-    finally:
-        await _kill_process_tree(process)
+    monkeypatch.setattr("core.tools.terminal.IS_WINDOWS", True)
+    with pytest.raises(PromoteForegroundService) as exc:
+        await _communicate_with_cancel(
+            _FakeProc(),
+            timeout=2,
+            command="./target/release/api",
+        )
+    assert exc.value.ports == [8080]
 
 
 @pytest.mark.asyncio
 async def test_communicate_does_not_promote_oneshot(monkeypatch) -> None:
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.1")
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.05")
     monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
     monkeypatch.setattr(
         "core.tools.terminal.listen_ports_for_pid_tree",
         lambda pid: [8080],
     )
-    process = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-c",
-        "import time; time.sleep(8)",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        start_new_session=True,
-    )
-    try:
-        with pytest.raises(TimeoutError):
-            await _communicate_with_cancel(
-                process,
-                timeout=0.35,
-                command="cargo test --all",
-            )
-    finally:
-        await _kill_process_tree(process)
+    monkeypatch.setattr("core.tools.terminal.IS_WINDOWS", True)
+    with pytest.raises(TimeoutError):
+        await _communicate_with_cancel(
+            _FakeProc(),
+            timeout=0.35,
+            command="cargo test --all",
+        )
 
 
 @pytest.mark.asyncio
 async def test_communicate_does_not_promote_without_listen(monkeypatch) -> None:
-    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.1")
+    monkeypatch.setenv("HOLIX_SERVICE_WATCH_AFTER", "0.05")
     monkeypatch.setenv("HOLIX_SERVICE_WATCH_INTERVAL", "0.05")
     monkeypatch.setattr(
         "core.tools.terminal.listen_ports_for_pid_tree",
         lambda pid: [],
     )
-    process = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-c",
-        "import time; time.sleep(8)",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        start_new_session=True,
-    )
-    try:
-        with pytest.raises(TimeoutError):
-            await _communicate_with_cancel(
-                process,
-                timeout=0.35,
-                command="./long-train-job",
-            )
-    finally:
-        await _kill_process_tree(process)
+    monkeypatch.setattr("core.tools.terminal.IS_WINDOWS", True)
+    with pytest.raises(TimeoutError):
+        await _communicate_with_cancel(
+            _FakeProc(),
+            timeout=0.35,
+            command="./long-train-job",
+        )

--- a/tests/test_step_budget.py
+++ b/tests/test_step_budget.py
@@ -70,6 +70,18 @@ def test_extend_when_pending_tools_and_progress() -> None:
     assert d.extensions_used == 1
 
 
+def test_identical_tool_loop_detects_mid_run() -> None:
+    from core.runtime.step_budget import identical_tool_loop
+
+    log = [
+        {"name": "terminal", "arguments": '{"command": "inspect"}', "result": "79"},
+        {"name": "terminal", "arguments": '{"command": "inspect"}', "result": "79"},
+    ]
+    assert identical_tool_loop(log) is False
+    log.append({"name": "terminal", "arguments": '{"command": "inspect"}', "result": "79"})
+    assert identical_tool_loop(log) is True
+
+
 def test_hung_on_identical_tool_loop() -> None:
     log = [
         {"name": "run_terminal_command", "arguments": "ls", "result": "Error: fail"},
@@ -87,6 +99,69 @@ def test_hung_on_identical_tool_loop() -> None:
     assert not d.extend
     assert d.status == "hung"
     assert "loop" in d.reason.lower()
+
+
+def test_no_extend_when_same_pytest_already_green() -> None:
+    log = [
+        {
+            "name": "terminal",
+            "arguments": '{"command": "python -m pytest -q"}',
+            "result": "Success (exit code 0): 8 passed in 0.37s",
+        },
+        {
+            "name": "grep",
+            "arguments": '{"pattern": "def test_", "path": "tests"}',
+            "result": "8 match(es) in 3 file(s)",
+        },
+        {
+            "name": "terminal",
+            "arguments": '{"command": "python -m pytest -q"}',
+            "result": "Success (exit code 0): 8 passed in 0.38s",
+        },
+    ]
+    d = evaluate_step_budget(
+        step_count=150,
+        max_steps=150,
+        extensions_used=0,
+        pending_tool_calls=[{"id": "x"}],
+        tool_calls_log=log,
+        task="fix the review comments",
+        policy=StepBudgetPolicy(extend_by=30, max_extensions=10),
+        base_max_steps=150,
+    )
+    assert not d.extend
+    assert "tests already passed" in d.reason
+
+
+def test_no_extend_on_noop_write_loop() -> None:
+    log = [
+        {
+            "name": "write_file",
+            "arguments": '{"path": "app/ioc.py"}',
+            "result": "Updated app/ioc.py (no content changes)",
+        },
+        {
+            "name": "write_file",
+            "arguments": '{"path": "app/application/use_cases.py"}',
+            "result": "Updated app/application/use_cases.py (no content changes)",
+        },
+        {
+            "name": "write_file",
+            "arguments": '{"path": "app/ioc.py"}',
+            "result": "Updated app/ioc.py (no content changes)",
+        },
+    ]
+    d = evaluate_step_budget(
+        step_count=150,
+        max_steps=150,
+        tool_calls_log=log,
+        task="fastapi address catalog",
+        policy=StepBudgetPolicy(extend_by=30, max_extensions=3),
+        base_max_steps=90,
+    )
+    assert not d.extend
+    assert d.status == "hung"
+    assert "no content" in d.reason.lower()
 
 
 def test_extension_cap() -> None:
@@ -150,5 +225,10 @@ def test_graph_result_no_extend_when_final() -> None:
     state = {"max_steps": 15, "user_input": "hi"}
     result = {"step_count": 15, "is_final": True, "tool_calls": []}
     out = maybe_extend_for_graph_result(state, result, agent=None)
-    assert out is result or out.get("max_steps") is None or "max_steps" not in out or out.get("step_count") == 15
+    assert (
+        out is result
+        or out.get("max_steps") is None
+        or "max_steps" not in out
+        or out.get("step_count") == 15
+    )
     assert out.get("max_steps", 15) == 15 or "step_budget_extensions" not in out

--- a/tests/test_subagent_supervisor.py
+++ b/tests/test_subagent_supervisor.py
@@ -12,6 +12,7 @@ from core.subagents.supervisor import (
     SubagentSupervisor,
     SupervisorPolicy,
     assess_handle,
+    build_loop_guidance,
     format_guidance_system_message,
 )
 
@@ -42,6 +43,111 @@ def test_assess_ok_when_fresh_activity() -> None:
     assert not d.needs_intervention
 
 
+def test_assess_green_pytest_asks_for_final_answer() -> None:
+    h = _running_handle()
+    h.last_tool = "terminal"
+    for _ in range(2):
+        h.record_activity(
+            "tool_start",
+            "Calling terminal",
+            tool_name="terminal",
+            details='{"command": "python -m pytest -q"}',
+        )
+        h.record_activity(
+            "tool_result",
+            "terminal finished",
+            tool_name="terminal",
+            details="Success (exit code 0):\n........\n8 passed in 0.37s",
+        )
+    d = assess_handle(h)
+    assert d.kind == "tests_green"
+    assert d.needs_intervention
+    assert "final answer" in d.guidance.lower()
+    assert "NO tool calls" in d.guidance
+
+
+def test_assess_terminal_project_launch_guides_to_background_tool() -> None:
+    h = _running_handle()
+    h.last_tool = "terminal"
+    h.record_activity(
+        "tool_start",
+        "Calling terminal",
+        tool_name="terminal",
+        details=(
+            '{"command": "cd projects/data_address && python -m data_address.main &\\n'
+            'sleep 2\\ncurl -s http://127.0.0.1:8000/health"}'
+        ),
+    )
+    h.record_activity(
+        "tool_result",
+        "terminal finished",
+        tool_name="terminal",
+        details="Error: Command timed out after 15 seconds",
+    )
+    h.config.tools = [
+        "terminal",
+        "start_background_process",
+        "check_background_process",
+    ]
+    d = assess_handle(h)
+    assert d.kind == "launch"
+    assert d.needs_intervention
+    assert "start_background_process" in d.guidance
+
+
+def test_assess_similar_grep_same_path_is_loop_guidance() -> None:
+    h = _running_handle()
+    for i, pat in enumerate(
+        (
+            "Provider",
+            "Provider|AsyncContainer",
+            "def build_container|Provider",
+            "def build_container|return make_async_container",
+        )
+    ):
+        h.record_activity(
+            "tool_start",
+            "Calling grep",
+            tool_name="grep",
+            details=f'{{"pattern": "{pat}", "path": "projects/app/di.py"}}',
+        )
+        h.record_activity(
+            "tool_result",
+            "grep finished",
+            tool_name="grep",
+            details="3 match(es) in 1 file(s)",
+        )
+        h.steps_taken = i + 1
+    d = assess_handle(h)
+    assert d.kind == "loop"
+    assert d.signals.get("search_loop") is True
+    assert d.signals.get("path_loop") is True
+    assert "read_file" in d.guidance
+
+
+def test_assess_noop_write_loop_even_when_paths_alternate() -> None:
+    h = _running_handle()
+    h.last_tool = "write_file"
+    h.config.tools = ["read_file", "write_file", "terminal"]
+    for path in ("app/ioc.py", "app/application/use_cases.py", "app/ioc.py"):
+        h.record_activity(
+            "tool_start",
+            "Calling write_file",
+            tool_name="write_file",
+            details=f'{{"path": "{path}"}}',
+        )
+        h.record_activity(
+            "tool_result",
+            "write_file finished",
+            tool_name="write_file",
+            details=f"Updated {path} (no content changes)\n\nSTOP: already exact",
+        )
+    d = assess_handle(h)
+    assert d.kind == "loop"
+    assert d.signals.get("noop_write_loop") is True
+    assert "final answer" in d.guidance.lower() or "STOP" in d.guidance
+
+
 def test_assess_loop() -> None:
     h = _running_handle()
     for _ in range(3):
@@ -61,6 +167,7 @@ def test_assess_loop() -> None:
     assert d.kind == "loop"
     assert d.needs_intervention
     assert "GUIDANCE" in d.guidance
+    assert "Required next move" in d.guidance
 
 
 def test_assess_thrash() -> None:
@@ -91,6 +198,28 @@ def test_assess_not_running() -> None:
     d = assess_handle(h)
     assert d.kind == "ok"
     assert not d.needs_intervention
+
+
+def test_build_loop_guidance_points_to_read_file() -> None:
+    text = build_loop_guidance(
+        tool="terminal",
+        details='{"command": "python -c \\"print(AddressProvider.__init__)\\""}',
+        available_tools=["read_file", "grep", "terminal", "write_file"],
+        attempt=2,
+        max_attempts=3,
+    )
+    assert "read_file" in text
+    assert "python -c" in text or "Protocol" in text
+    assert "Attempt 2/3" in text
+    last = build_loop_guidance(
+        tool="terminal",
+        details="same",
+        available_tools=["read_file"],
+        attempt=3,
+        max_attempts=3,
+    )
+    assert "LAST CHANCE" in last
+    assert "status loop" in last
 
 
 def test_format_guidance_system_message() -> None:
@@ -125,6 +254,7 @@ async def test_supervisor_sends_guidance_with_cap() -> None:
     manager._comm_bus = comm
     manager._emit_agent_event = MagicMock()
     manager.notify_progress = MagicMock()
+    manager.terminate = AsyncMock(return_value=True)
 
     policy = SupervisorPolicy(
         enabled=True,
@@ -132,6 +262,7 @@ async def test_supervisor_sends_guidance_with_cap() -> None:
         idle_s=90.0,
         max_interventions=2,
         cooldown_s=0.0,
+        loop_cooldown_s=0.0,
     )
     sup = SubagentSupervisor(manager, policy=policy)
 
@@ -143,9 +274,57 @@ async def test_supervisor_sends_guidance_with_cap() -> None:
     assert async_bus.send.await_count == 2
     assert sup._interventions["loop-job"] == 2
 
-    # Cap reached — no more sends
+    # Cap reached — stop with status loop, no more guidance
     await sup._maybe_intervene(h)
     assert async_bus.send.await_count == 2
+    manager.terminate.assert_awaited_once_with("loop-job")
+    assert h.forced_status == SubAgentStatus.LOOP
+    assert h.result is not None
+    assert str(h.result.error or "").startswith("loop:")
+
+
+@pytest.mark.asyncio
+async def test_supervisor_does_not_stop_grep_search_loop() -> None:
+    h = _running_handle("grep-job")
+    h.last_tool = "grep"
+    for i in range(4):
+        h.record_activity(
+            "tool_start",
+            "Calling grep",
+            tool_name="grep",
+            details=f'{{"pattern": "AsyncContainer|{i}", "path": "src/di.py"}}',
+        )
+        h.record_activity(
+            "tool_result",
+            "grep finished",
+            tool_name="grep",
+            details="3 match(es) in 1 file(s)",
+        )
+        h.steps_taken = i + 1
+
+    async_bus = MagicMock()
+    async_bus.send = AsyncMock()
+    manager = MagicMock()
+    manager._handles = {"grep-job": h}
+    manager._comm_bus = SimpleNamespace(async_bus=async_bus, process_bus=MagicMock())
+    manager._emit_agent_event = MagicMock()
+    manager.notify_progress = MagicMock()
+    manager.terminate = AsyncMock(return_value=True)
+
+    sup = SubagentSupervisor(
+        manager,
+        policy=SupervisorPolicy(
+            max_interventions=2,
+            cooldown_s=0.0,
+            loop_cooldown_s=0.0,
+        ),
+    )
+    await sup._maybe_intervene(h)
+    await sup._maybe_intervene(h)
+    await sup._maybe_intervene(h)
+    manager.terminate.assert_not_awaited()
+    assert getattr(h, "forced_status", None) in {None, SubAgentStatus.RUNNING}
+    assert h.result is None
 
     # Exhausted event emitted
     assert manager._emit_agent_event.call_count >= 2

--- a/tests/test_subagent_supervisor.py
+++ b/tests/test_subagent_supervisor.py
@@ -14,7 +14,10 @@ from core.subagents.supervisor import (
     SupervisorPolicy,
     assess_handle,
     build_loop_guidance,
+    diagnose_loop_fix,
     format_guidance_system_message,
+    format_human_loop_context,
+    format_human_loop_question,
 )
 
 
@@ -169,6 +172,9 @@ def test_assess_loop() -> None:
     assert d.needs_intervention
     assert "GUIDANCE" in d.guidance
     assert "What to fix" in d.guidance
+    assert "same.py" in str(d.signals.get("user_question") or "")
+    assert "same content again" in str(d.signals.get("user_question") or "")
+    assert "What is stuck" in str(d.signals.get("user_context") or "")
 
 
 def test_assess_thrash() -> None:
@@ -221,6 +227,37 @@ def test_build_loop_guidance_points_to_read_file() -> None:
     )
     assert "LAST CHANCE" in last
     assert "ask_user" in last
+
+
+def test_human_loop_question_includes_path_and_last_result() -> None:
+    q = format_human_loop_question(
+        "The coder keeps re-reading the same file.",
+        details='{"path": "projects/data_address/app/container.py"}',
+        last_result="class AddressProvider:\n    def __init__(self): ...",
+    )
+    assert "container.py" in q
+    assert "AddressProvider" in q
+    ctx = format_human_loop_context(
+        problem="re-reading the same file",
+        tool="read_file",
+        details='{"path": "projects/data_address/app/container.py"}',
+        last_result="class AddressProvider:\n    def __init__(self): ...",
+        next_move="write_file a change",
+        known="you already have this file contents.",
+    )
+    assert "What is stuck: re-reading the same file" in ctx
+    assert "container.py" in ctx
+    assert "AddressProvider" in ctx
+    assert "write_file a change" in ctx
+
+
+def test_diagnose_read_file_names_the_path() -> None:
+    fix = diagnose_loop_fix(
+        tool="read_file",
+        details='{"path": "app/container.py"}',
+        last_result="from dishka import Provider",
+    )
+    assert "app/container.py" in fix["user_question"]
 
 
 def test_build_loop_guidance_venv_hunt_says_what_to_fix() -> None:
@@ -391,6 +428,14 @@ async def test_supervisor_asks_human_then_injects_reply() -> None:
     await asyncio.sleep(0)
     manager.interactions.ask_user.assert_awaited()
     manager.terminate.assert_not_awaited()
+    asked = manager.interactions.ask_user.await_args
+    asked_question = str(
+        asked.args[1] if len(asked.args) > 1 else asked.kwargs.get("question") or ""
+    )
+    asked_context = str(asked.kwargs.get("context") or "")
+    assert "site-packages" in asked_question or "grep mako" in asked_question
+    assert "Last result" in asked_question or "Last tool result" in asked_context
+    assert "none" in (asked_question + asked_context).lower()
     assert "human" in async_bus.send.await_args.args[0].content.lower()
     assert sup._interventions["ask-job"] == 0
 

--- a/tests/test_subagent_supervisor.py
+++ b/tests/test_subagent_supervisor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -167,7 +168,7 @@ def test_assess_loop() -> None:
     assert d.kind == "loop"
     assert d.needs_intervention
     assert "GUIDANCE" in d.guidance
-    assert "Required next move" in d.guidance
+    assert "What to fix" in d.guidance
 
 
 def test_assess_thrash() -> None:
@@ -214,12 +215,30 @@ def test_build_loop_guidance_points_to_read_file() -> None:
     last = build_loop_guidance(
         tool="terminal",
         details="same",
-        available_tools=["read_file"],
+        available_tools=["read_file", "ask_user"],
         attempt=3,
         max_attempts=3,
     )
     assert "LAST CHANCE" in last
-    assert "status loop" in last
+    assert "ask_user" in last
+
+
+def test_build_loop_guidance_venv_hunt_says_what_to_fix() -> None:
+    text = build_loop_guidance(
+        tool="terminal",
+        details=(
+            '{"command": "cd projects/data_address && '
+            "ls .venv/lib/python3.12/site-packages/ | grep -iE 'mako|alemb'\"}"
+        ),
+        last_result="none\n---\n63",
+        available_tools=["read_file", "write_file", "terminal", "ask_user"],
+        attempt=1,
+        max_attempts=3,
+    )
+    assert "site-packages" in text or "virtualenv" in text or "venv" in text
+    assert "write_file" in text
+    assert "Do NOT call `terminal`" in text
+    assert "ask_user" in text
 
 
 def test_format_guidance_system_message() -> None:
@@ -255,6 +274,7 @@ async def test_supervisor_sends_guidance_with_cap() -> None:
     manager._emit_agent_event = MagicMock()
     manager.notify_progress = MagicMock()
     manager.terminate = AsyncMock(return_value=True)
+    manager.interactions = SimpleNamespace(ask_user=AsyncMock(return_value="stop"))
 
     policy = SupervisorPolicy(
         enabled=True,
@@ -274,9 +294,11 @@ async def test_supervisor_sends_guidance_with_cap() -> None:
     assert async_bus.send.await_count == 2
     assert sup._interventions["loop-job"] == 2
 
-    # Cap reached — stop with status loop, no more guidance
+    # Cap reached — ask the human, then stop if they say stop
     await sup._maybe_intervene(h)
     assert async_bus.send.await_count == 2
+    await asyncio.sleep(0)
+    manager.interactions.ask_user.assert_awaited()
     manager.terminate.assert_awaited_once_with("loop-job")
     assert h.forced_status == SubAgentStatus.LOOP
     assert h.result is not None
@@ -328,6 +350,49 @@ async def test_supervisor_does_not_stop_grep_search_loop() -> None:
 
     # Exhausted event emitted
     assert manager._emit_agent_event.call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_supervisor_asks_human_then_injects_reply() -> None:
+    h = _running_handle("ask-job")
+    for _ in range(3):
+        h.record_activity(
+            "tool_start",
+            "Calling terminal",
+            tool_name="terminal",
+            details='{"command": "ls .venv/lib/python3.12/site-packages | grep mako"}',
+        )
+        h.record_activity(
+            "tool_result",
+            "terminal finished",
+            tool_name="terminal",
+            details="none",
+        )
+    h.last_tool = "terminal"
+
+    async_bus = MagicMock()
+    async_bus.send = AsyncMock()
+    manager = MagicMock()
+    manager._handles = {"ask-job": h}
+    manager._comm_bus = SimpleNamespace(async_bus=async_bus, process_bus=MagicMock())
+    manager._emit_agent_event = MagicMock()
+    manager.notify_progress = MagicMock()
+    manager.terminate = AsyncMock(return_value=True)
+    manager.interactions = SimpleNamespace(
+        ask_user=AsyncMock(return_value="uv add nothing; write the FastAPI files")
+    )
+
+    sup = SubagentSupervisor(
+        manager,
+        policy=SupervisorPolicy(max_interventions=1, cooldown_s=0.0, loop_cooldown_s=0.0),
+    )
+    await sup._maybe_intervene(h)
+    await sup._maybe_intervene(h)
+    await asyncio.sleep(0)
+    manager.interactions.ask_user.assert_awaited()
+    manager.terminate.assert_not_awaited()
+    assert "human" in async_bus.send.await_args.args[0].content.lower()
+    assert sup._interventions["ask-job"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_terminal_access_messages.py
+++ b/tests/test_terminal_access_messages.py
@@ -8,7 +8,81 @@ from core.tools.terminal import (
     _blocked_sensitive_path_access,
     _format_access_denial,
     _format_process_result,
+    _is_untracked_long_running_command,
 )
+
+
+def test_pip_install_uvicorn_is_not_a_server_launch() -> None:
+    not_launch = [
+        (
+            "cd projects/data_address && python -m venv .venv && "
+            "source .venv/bin/activate && pip install fastapi uvicorn pydantic dishka"
+        ),
+        "uv pip install uvicorn",
+        "python -m pytest tests",
+        "python -m ruff check .",
+        (
+            "cd projects/data_address && source .venv/bin/activate && "
+            "python -m pip list | grep -iE 'fastapi|dadata|dishka|pydantic|uvicorn|httpx|pytest'"
+        ),
+        "grep -R uvicorn projects/",
+        "ps aux | grep uvicorn",
+        "lsof -ti:8000 | xargs kill -9",
+        "echo uvicorn app:app",
+        "cat README.md | grep uvicorn",
+        "python tests/test_main.py",
+        "python -m compileall src",
+        "timeout 2 curl -s http://127.0.0.1:8000/health",
+        "cargo test",
+        "cargo build --release",
+        "go test ./...",
+        "go build -o bin/app ./cmd/app",
+        "mvn -q test",
+        "mvn package -DskipTests",
+        "./gradlew test",
+        "dotnet test",
+        "dotnet build",
+        "cmake --build build",
+        "g++ -O2 main.cpp -o app",
+        "npm run build",
+        "pnpm test",
+        "docker compose up -d",
+        "docker-compose up --detach",
+    ]
+    launch = [
+        "uvicorn app:app --port 8000",
+        "python -m uvicorn app.main:app",
+        "pip install uvicorn && uvicorn app:app --reload",
+        "cd projects/data_address && PYTHONPATH=src python -m data_address.main",
+        "python app/main.py --port 8000",
+        "nohup uvicorn app:app --reload",
+        "fastapi run app.py",
+        "npm run dev",
+        "pnpm dev",
+        "npm start",
+        "./.venv/bin/uvicorn app:app",
+        "cargo run --release --bin api",
+        "go run ./cmd/server",
+        "java -jar app.jar --server.port=8080",
+        "java -Xmx512m -jar target/app.jar",
+        "mvn spring-boot:run",
+        "./mvnw spring-boot:run",
+        "./gradlew bootRun",
+        "dotnet run --project src/Api",
+        "dotnet watch run",
+        "php artisan serve --port=8000",
+        "php -S 127.0.0.1:8080",
+        "rails server",
+        "bundle exec puma",
+        "mix phx.server",
+        "docker compose up",
+        "docker-compose up --build",
+        "python manage.py runserver 0.0.0.0:8000",
+    ]
+    for cmd in not_launch:
+        assert _is_untracked_long_running_command(cmd) is False, cmd
+    for cmd in launch:
+        assert _is_untracked_long_running_command(cmd) is True, cmd
 
 
 def test_sudo_denied_is_human_readable() -> None:

--- a/tests/test_test_run_signals.py
+++ b/tests/test_test_run_signals.py
@@ -1,0 +1,55 @@
+"""Green-test detection: do not treat re-running passing pytest as work."""
+
+from __future__ import annotations
+
+from core.runtime.test_run_signals import (
+    is_green_test_output,
+    is_test_command,
+    tests_already_green_loop,
+)
+
+
+def test_pytest_command_and_green_output() -> None:
+    assert is_test_command("cd app && python -m pytest -q --cache-clear")
+    assert is_test_command("pytest tests/test_api.py")
+    assert not is_test_command("python -m data_address.main")
+    assert is_green_test_output("Success (exit code 0):\n........\n8 passed in 0.37s")
+    assert not is_green_test_output("2 passed, 1 failed in 0.2s")
+    assert not is_green_test_output("Error: Command timed out after 15 seconds")
+
+
+def test_green_loop_after_second_pytest() -> None:
+    traces = [
+        {
+            "name": "terminal",
+            "arguments": '{"command": "python -m pytest -q"}',
+            "result": "8 passed in 0.3s",
+        },
+        {
+            "name": "grep",
+            "arguments": '{"pattern": "def test_", "path": "tests"}',
+            "result": "8 match(es)",
+        },
+        {
+            "name": "terminal",
+            "arguments": '{"command": "python -m pytest -q"}',
+            "result": "8 passed in 0.3s",
+        },
+    ]
+    assert tests_already_green_loop(traces) is True
+
+
+def test_single_green_pytest_then_grep_tests_is_loop() -> None:
+    traces = [
+        {
+            "name": "terminal",
+            "arguments": '{"command": "pytest -q"}',
+            "result": "3 passed in 0.1s",
+        },
+        {
+            "name": "grep",
+            "arguments": '{"pattern": "def test_", "path": "projects/app/tests"}',
+            "result": "3 match(es)",
+        },
+    ]
+    assert tests_already_green_loop(traces) is True

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix **1.0.10**: MCP tools per agent slot, coder-loop / supervisor escalation, live provider model lists without stale catalog aliases.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py (`1.0.10`)
- [x] docs/CHANGELOG.md has section 1.0.10
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.0.10` (creates GitHub Release + PyPI).

## Highlights
- **MCP**: assigned servers per slot, Context7 fill-in, harvest tools, process-mode children
- **Loops**: service detect, inspect/noop as non-progress, supervisor asks the human before stop
- **Models**: drop stale default/popular ids not returned by `/v1/models`