### PR TITLE
Holix 1.0.12

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.11"
+__version__ = "1.0.12"

--- a/cli/main.py
+++ b/cli/main.py
@@ -13,6 +13,7 @@ install(show_locals=True)
 from core.profile_keys import ProfileNotFoundError
 from integrations.bootstrap import register_integration_hooks
 
+from cli import __version__ as _CLI_VERSION
 from cli.core import get_profile_manager, init_profile, resolve_active_profile_name
 from cli.utils.rich_console import print_info
 
@@ -23,7 +24,7 @@ app = typer.Typer(
     name="holix",
     help="Holix - Self-Improving AI Agent with Memory and Skills",
     add_completion=False,
-    rich_markup_mode="rich"
+    rich_markup_mode="rich",
 )
 
 _BASE_COMMANDS_REGISTERED = False
@@ -113,12 +114,30 @@ def _register_commands(argv: list[str] | None = None) -> None:
         _register_heavy_commands()
 
 
+def _version_callback(value: bool) -> None:
+    """Print the installed package version and exit (no profile init)."""
+    if value:
+        typer.echo(f"Holix {_package_version()}")
+        raise typer.Exit()
+
+
+def _package_version() -> str:
+    """Version of the running Holix distribution (PyPI metadata, else cli.__version__)."""
+    try:
+        from importlib.metadata import version
+
+        return version("Holix")
+    except Exception:
+        return _CLI_VERSION
+
+
 @app.callback()
 def _app_callback(
     ctx: typer.Context,
     profile: str | None = typer.Option(
         None,
-        "--profile", "-p",
+        "--profile",
+        "-p",
         help="Profile name (required in production; implicit default is dev-only)",
     ),
     profile_key: str | None = typer.Option(
@@ -133,16 +152,25 @@ def _app_callback(
         envvar="HOLIX_UNLOCK_KEY",
         help="Encryption unlock key for an encrypted profile",
     ),
-    verbose: bool = typer.Option(
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
+    version: bool = typer.Option(
         False,
-        "--verbose", "-v",
-        help="Enable verbose output"
+        "--version",
+        "-V",
+        help="Show Holix package version and exit",
+        is_eager=True,
+        callback=_version_callback,
     ),
 ):
     """Holix AI Agent CLI.
 
     A powerful, self-improving AI agent with memory, skills, and tool-calling capabilities.
     """
+    del version
+    # ``holix version`` / ``holix --help`` must not require a profile.
+    if ctx.invoked_subcommand in {"version"} or ctx.resilient_parsing:
+        return
+
     # Initialize profile
     from core.crypto.profile_crypto import ProfileCryptoError
     from core.profile_keys import ProfileKeyError
@@ -184,7 +212,9 @@ def _app_callback(
 def chat_command(
     ctx: typer.Context,
     model: str | None = typer.Option(None, "--model", "-m", help="Override model"),
-    temperature: float | None = typer.Option(None, "--temperature", "-t", help="Override temperature"),
+    temperature: float | None = typer.Option(
+        None, "--temperature", "-t", help="Override temperature"
+    ),
     max_steps: int | None = typer.Option(None, "--max-steps", help="Override max steps"),
     exec_command: str | None = typer.Option(
         None,
@@ -240,8 +270,12 @@ def run_command(
     ctx: typer.Context,
     query: str = typer.Argument(..., help="Query to execute"),
     model: str | None = typer.Option(None, "--model", "-m", help="Override model"),
-    temperature: float | None = typer.Option(None, "--temperature", "-t", help="Override temperature"),
-    conversation_id: str = typer.Option("cli_oneshot", "--conversation-id", "-c", help="Conversation ID"),
+    temperature: float | None = typer.Option(
+        None, "--temperature", "-t", help="Override temperature"
+    ),
+    conversation_id: str = typer.Option(
+        "cli_oneshot", "--conversation-id", "-c", help="Conversation ID"
+    ),
 ):
     """Execute a single query and exit.
 
@@ -350,11 +384,11 @@ def clear(
 @app.command()
 def version():
     """Show Holix version information."""
-    from cli import __version__
     from cli.utils.rich_console import print_panel
 
+    ver = _package_version()
     info = f"""[bold cyan]Holix AI Agent[/bold cyan]
-Version: {__version__}
+Version: {ver}
 Homepage: https://github.com/javded-itres/Holix
 License: MIT
 """
@@ -365,10 +399,7 @@ License: MIT
 def tui(
     ctx: typer.Context,
     profile: str = typer.Option(
-        "default",
-        "--profile", "-p",
-        help="Profile to use",
-        show_default=True
+        "default", "--profile", "-p", help="Profile to use", show_default=True
     ),
     web: bool = typer.Option(
         False,
@@ -438,6 +469,7 @@ def tui(
         return
 
     from cli.tui.app import run_tui
+
     run_tui(profile=profile)
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`holix --version` / `-V`** — print the installed package version and exit (no profile required). `holix version` still shows the panel.
+- **`Holix[all]` on PyPI** — drop unpublished `holix-extension-demo` from the `all` extra so `uv tool install "Holix[all]"` resolves to the latest release instead of backtracking to 0.1.21.
+
 ## 1.0.11 — 2026-08-19
 
 Staged skill proposals (no live write until approve), child jobs on the same ReAct engine as main, and skill-review UX in CLI, API, Telegram, and MAX.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Unreleased
 
+## 1.0.12 — 2026-08-20
+
+`uv tool install "Holix[all]"` installs the latest release, and `holix --version` prints the package version.
+
 ### Fixed
 
+- **`Holix[all]` on PyPI** — drop unpublished `holix-extension-demo` from the `all` extra so the resolver no longer backtracks to 0.1.21.
 - **`holix --version` / `-V`** — print the installed package version and exit (no profile required). `holix version` still shows the panel.
-- **`Holix[all]` on PyPI** — drop unpublished `holix-extension-demo` from the `all` extra so `uv tool install "Holix[all]"` resolves to the latest release instead of backtracking to 0.1.21.
 
 ## 1.0.11 — 2026-08-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Workspace-only package (not on PyPI). Do not add to ``all`` — uv/pip would
+# backtrack to the last public release whose extras still resolve (0.1.21).
 demo = ["holix-extension-demo>=0.1.0"]
 # holix-studio is a separate private package (not on public PyPI).
 # Install from its GitHub release / private index; do not pin via git in this lock
@@ -72,7 +74,6 @@ otel = [
     "opentelemetry-exporter-otlp-proto-http>=1.27.0",
 ]
 all = [
-    "holix-extension-demo>=0.1.0",
     "playwright>=1.49.0",
     "aiogram>=3.15.0",
     "textual-serve>=1.1.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.11"
+version = "1.0.12"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,26 @@
+"""holix --version / holix version (no profile required)."""
+
+from __future__ import annotations
+
+from cli.main import _package_version, app
+from typer.testing import CliRunner
+
+
+def test_version_flag_prints_package_version() -> None:
+    result = CliRunner().invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert _package_version() in result.stdout
+    assert result.stdout.strip().startswith("Holix ")
+
+
+def test_version_short_flag() -> None:
+    result = CliRunner().invoke(app, ["-V"])
+    assert result.exit_code == 0
+    assert _package_version() in result.stdout
+
+
+def test_version_subcommand() -> None:
+    result = CliRunner().invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "Version:" in result.stdout
+    assert _package_version() in result.stdout

--- a/tests/test_pypi_extras.py
+++ b/tests/test_pypi_extras.py
@@ -1,0 +1,27 @@
+"""Public extras must resolve on PyPI (no workspace-only packages)."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_UNPUBLISHED = frozenset({"holix-extension-demo", "holix-studio"})
+
+
+def _optional_deps() -> dict[str, list[str]]:
+    data = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return dict(data["project"]["optional-dependencies"])
+
+
+def test_all_extra_has_no_unpublished_packages() -> None:
+    extras = _optional_deps()
+    assert "all" in extras
+    joined = " ".join(extras["all"]).lower()
+    for name in _UNPUBLISHED:
+        assert name not in joined, f"{name} must not be in Holix[all] (not on PyPI)"
+
+
+def test_demo_extra_keeps_workspace_package() -> None:
+    extras = _optional_deps()
+    assert any("holix-extension-demo" in dep for dep in extras["demo"])

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.11"
+version = "1.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,6 @@ dependencies = [
 all = [
     { name = "aiogram" },
     { name = "faster-whisper" },
-    { name = "holix-extension-demo" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
@@ -1156,7 +1155,6 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.136.3" },
     { name = "faster-whisper", marker = "extra == 'all'", specifier = ">=1.1.0" },
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.1.0" },
-    { name = "holix-extension-demo", marker = "extra == 'all'", editable = "packages/holix-extension-demo" },
     { name = "holix-extension-demo", marker = "extra == 'demo'", editable = "packages/holix-extension-demo" },
     { name = "holix-sdk", specifier = "==0.1.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },


### PR DESCRIPTION
## Summary
Release Holix 1.0.12.

Drop unpublished `holix-extension-demo` from `Holix[all]` so `uv tool install "Holix[all]"` resolves to the latest PyPI release instead of backtracking to 0.1.21. Add `holix --version` / `-V`.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py
- [x] docs/CHANGELOG.md has section 1.0.12
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.0.12` (creates GitHub Release + PyPI).