### PR TITLE
Holix 1.0.13

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.12"
+__version__ = "1.0.13"

--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
         description="How many steps to add when progress check passes",
     )
     max_steps_max_extensions: int = Field(
-        default=3,
+        default=10,
         validation_alias=AliasChoices(
             "HOLIX_MAX_STEPS_MAX_EXTENSIONS",
             "MAX_STEPS_MAX_EXTENSIONS",

--- a/core/di/runtime_config.py
+++ b/core/di/runtime_config.py
@@ -197,7 +197,7 @@ class HolixRuntimeConfig:
             agent_pipeline=str(getattr(s, "agent_pipeline", "classic") or "classic"),
             max_steps_extend_enabled=bool(getattr(s, "max_steps_extend_enabled", True)),
             max_steps_extend_by=int(getattr(s, "max_steps_extend_by", 30) or 30),
-            max_steps_max_extensions=int(getattr(s, "max_steps_max_extensions", 3) or 3),
+            max_steps_max_extensions=int(getattr(s, "max_steps_max_extensions", 10) or 10),
             max_steps_hard_cap=int(getattr(s, "max_steps_hard_cap", 0) or 0),
             auto_allow_threshold=s.auto_allow_threshold,
             non_interactive=s.non_interactive,
@@ -305,6 +305,12 @@ class HolixRuntimeConfig:
             overrides["agent_pipeline"] = normalize_pipeline(str(profile.agent_pipeline))
         if getattr(profile, "max_steps_extend_enabled", None) is not None:
             overrides["max_steps_extend_enabled"] = bool(profile.max_steps_extend_enabled)
+        if getattr(profile, "max_steps_extend_by", None) is not None:
+            overrides["max_steps_extend_by"] = int(profile.max_steps_extend_by)
+        if getattr(profile, "max_steps_max_extensions", None) is not None:
+            overrides["max_steps_max_extensions"] = int(profile.max_steps_max_extensions)
+        if getattr(profile, "max_steps_hard_cap", None) is not None:
+            overrides["max_steps_hard_cap"] = int(profile.max_steps_hard_cap)
         if getattr(profile, "search", None):
             overrides["search"] = profile.search
         overrides["workspace_jail_enabled"] = bool(

--- a/core/graph/action_honesty.py
+++ b/core/graph/action_honesty.py
@@ -24,7 +24,7 @@ _COMPLETION_CLAIM = re.compile(
 # Studio / user asks to fill SDD change artifacts (UI auto-prompt after create).
 _SDD_FILL_REQUEST = re.compile(
     r"(?is)("
-    r"sdd_write_artifact"
+    r"sdd_write_artifact|sdd_update_spec"
     r"|please\s+fill\s+(proposal|delta\s+specs|tasks|artifacts)"
     r"|fill\s+proposal"
     r"|заполни\s+(proposal|спек|tasks|артефакт)"
@@ -41,6 +41,7 @@ _SDD_FILL_CLAIM = re.compile(
     r"|filled\s+(proposal|tasks|specs|design|delta)"
     r"|proposal\.md|tasks\.md|openspec/changes/"
     r"|sdd_write_artifact"
+    r"|sdd_update_spec"
     r")"
 )
 
@@ -165,10 +166,20 @@ _WRITE_TOOLS = frozenset(
         # SDD: tools that persist real content (create_change alone is stubs only)
         "sdd_init",
         "sdd_write_artifact",
+        "sdd_update_spec",
         "sdd_check_task",
         "sdd_set_task_assignee",
         "sdd_set_apply_mode",
         "sdd_archive",
+    }
+)
+# Persisted artifact content (analysis docs, specs). Scaffold-only tools stay out.
+_ARTIFACT_WRITE_TOOLS = frozenset(
+    {
+        "write_file",
+        "patch_file",
+        "sdd_write_artifact",
+        "sdd_update_spec",
     }
 )
 _DELETE_TOOLS = frozenset(
@@ -754,6 +765,28 @@ def _tool_call_id_names(messages: list[dict[str, Any]]) -> dict[str, str]:
     return id_to_name
 
 
+def _is_honesty_nudge_message(msg: dict[str, Any] | None) -> bool:
+    if not isinstance(msg, dict) or msg.get("role") != "user":
+        return False
+    raw = msg.get("content")
+    text = raw if isinstance(raw, str) else str(raw or "")
+    return text.strip().startswith("[Action honesty")
+
+
+def _last_real_user_index(messages: list[dict[str, Any]] | None) -> int:
+    """Index of the last real user turn (honesty injects are not a new request)."""
+    last = -1
+    if not messages:
+        return last
+    for i, msg in enumerate(messages):
+        if msg.get("role") != "user":
+            continue
+        if _is_honesty_nudge_message(msg):
+            continue
+        last = i
+    return last
+
+
 def successful_tools_since_last_user(
     messages: list[dict[str, Any]] | None,
     *,
@@ -762,10 +795,7 @@ def successful_tools_since_last_user(
     """Tool names with non-error results after the last user message."""
     names: list[str] = []
     if messages:
-        last_user = -1
-        for i, msg in enumerate(messages):
-            if msg.get("role") == "user":
-                last_user = i
+        last_user = _last_real_user_index(messages)
         id_to_name = _tool_call_id_names(messages)
         for msg in messages[last_user + 1 :]:
             if msg.get("role") != "tool":
@@ -796,17 +826,11 @@ def successful_tools_since_last_user(
 
 def last_user_text(messages: list[dict[str, Any]] | None) -> str:
     """Content of the last real user message (skip honesty nudge injects)."""
-    if not messages:
+    idx = _last_real_user_index(messages)
+    if idx < 0 or not messages:
         return ""
-    for msg in reversed(messages):
-        if msg.get("role") != "user":
-            continue
-        content = msg.get("content")
-        text = content if isinstance(content, str) else str(content or "")
-        if text.strip().startswith("[Action honesty"):
-            continue
-        return text
-    return ""
+    raw = messages[idx].get("content")
+    return raw if isinstance(raw, str) else str(raw or "")
 
 
 def is_sdd_fill_request(text: str | None) -> bool:
@@ -819,15 +843,80 @@ def claims_sdd_artifacts_filled(text: str | None) -> bool:
     return bool(text and _SDD_FILL_CLAIM.search(text))
 
 
+def has_successful_artifact_write(
+    messages: list[dict[str, Any]] | None,
+    *,
+    tool_results: list[dict[str, Any]] | None = None,
+) -> bool:
+    """True if a persist tool wrote content after the last real user message.
+
+    ``sdd_write_artifact`` is preferred for OpenSpec, but analysis/docs agents
+    often only have ``write_file``. Scaffold-only ``sdd_create_change`` does not
+    count.
+    """
+    success = set(successful_tools_since_last_user(messages, tool_results=tool_results))
+    return bool(success.intersection(_ARTIFACT_WRITE_TOOLS))
+
+
 def has_successful_sdd_write(
     messages: list[dict[str, Any]] | None,
     *,
     tool_results: list[dict[str, Any]] | None = None,
 ) -> bool:
-    """True if sdd_write_artifact succeeded after the last real user message."""
-    return "sdd_write_artifact" in successful_tools_since_last_user(
-        messages, tool_results=tool_results
-    )
+    """True if SDD/docs content was persisted (sdd_write_artifact or write_file)."""
+    return has_successful_artifact_write(messages, tool_results=tool_results)
+
+
+def persist_tool_summaries(
+    messages: list[dict[str, Any]] | None,
+    *,
+    tool_results: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    """Short lines for successful persist tools (for empty-final recovery)."""
+    lines: list[str] = []
+    if not has_successful_artifact_write(messages, tool_results=tool_results):
+        return lines
+    id_to_name = _tool_call_id_names(messages or [])
+    last_user = _last_real_user_index(messages)
+    if messages:
+        for msg in messages[last_user + 1 :]:
+            if msg.get("role") != "tool":
+                continue
+            raw = msg.get("content")
+            content = raw if isinstance(raw, str) else str(raw or "")
+            if _tool_result_failed(content):
+                continue
+            name = _tool_name_from_message(msg, id_to_name) or "tool"
+            if name not in _ARTIFACT_WRITE_TOOLS:
+                continue
+            preview = " ".join(content.split())[:240]
+            lines.append(f"- {name}: {preview}")
+    if not lines and tool_results:
+        for tr in tool_results:
+            if not isinstance(tr, dict):
+                continue
+            name = str(tr.get("tool_name") or tr.get("name") or "").strip()
+            if name not in _ARTIFACT_WRITE_TOOLS:
+                continue
+            raw = tr.get("result") or tr.get("content") or ""
+            content = raw if isinstance(raw, str) else str(raw)
+            if _tool_result_failed(content):
+                continue
+            preview = " ".join(content.split())[:240]
+            lines.append(f"- {name}: {preview}")
+    return lines[-8:]
+
+
+def summarize_persist_tools(
+    messages: list[dict[str, Any]] | None,
+    *,
+    tool_results: list[dict[str, Any]] | None = None,
+) -> str:
+    """Human summary when the model wrote files but returned no final text."""
+    lines = persist_tool_summaries(messages, tool_results=tool_results)
+    if not lines:
+        return ""
+    return "Work completed via tools (model returned no final text):\n" + "\n".join(lines)
 
 
 def sdd_fill_requires_tools(
@@ -856,11 +945,12 @@ def lacks_evidence_for_claim(
     successes = successful_tools_since_last_user(messages, tool_results=tool_results)
     success_set = set(successes)
 
-    # SDD fill: claiming filled artifacts requires sdd_write_artifact this turn.
+    # SDD/docs fill: claiming artifacts written requires a persist tool this turn.
+    # write_file counts — analysis subagents often lack sdd_write_artifact.
     if claims_sdd_artifacts_filled(content) or (
         is_sdd_fill_request(user) and claims_action_completed(content)
     ):
-        if "sdd_write_artifact" not in success_set:
+        if not has_successful_artifact_write(messages, tool_results=tool_results):
             return True
 
     if not claims_action_completed(text):
@@ -881,10 +971,7 @@ def lacks_evidence_for_claim(
 def _tools_attempted_since_last_user(messages: list[dict[str, Any]] | None) -> bool:
     if not messages:
         return False
-    last_user = -1
-    for i, msg in enumerate(messages):
-        if msg.get("role") == "user":
-            last_user = i
+    last_user = _last_real_user_index(messages)
     for msg in messages[last_user + 1 :]:
         if msg.get("role") == "tool":
             return True

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -34,6 +34,7 @@ from core.graph.action_honesty import (
     should_refuse_false_empty_workspace,
     should_refuse_status_monologue,
     should_refuse_unproven_sdd_fill,
+    summarize_persist_tools,
     workspace_grounding_refusal_text,
 )
 from core.graph.plan_step import (
@@ -281,6 +282,17 @@ def _maybe_subagent_empty_retry(
         return None
     retries = _empty_final_retry_count(messages) + 1
     if retries > _SUBAGENT_EMPTY_RETRIES:
+        summary = summarize_persist_tools(messages)
+        if summary:
+            updated = list(messages)
+            updated.append({"role": "assistant", "content": summary})
+            return {
+                "messages": updated,
+                "step_count": step_count,
+                "is_final": True,
+                "final_response": summary,
+                "tool_calls": [],
+            }
         return {
             "messages": messages,
             "step_count": step_count,

--- a/core/profile/service.py
+++ b/core/profile/service.py
@@ -101,6 +101,9 @@ class ProfileConfig(BaseModel):
 
     # When max_steps is hit, allow automatic budget extensions on progress
     max_steps_extend_enabled: bool | None = None
+    max_steps_extend_by: int | None = None
+    max_steps_max_extensions: int | None = None
+    max_steps_hard_cap: int | None = None
 
     # Hub: optional background ClawHub version updates
     hub_auto_update: bool = False

--- a/core/runtime/step_budget.py
+++ b/core/runtime/step_budget.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 # Defaults (overridable via Settings / agent config)
 DEFAULT_EXTEND_BY = 30
-DEFAULT_MAX_EXTENSIONS = 3
+DEFAULT_MAX_EXTENSIONS = 10
 DEFAULT_HARD_CAP = 0  # 0 → derive from base max_steps + extend_by * max_extensions
 DEFAULT_LOOKBACK = 6
 

--- a/core/sdd/merge.py
+++ b/core/sdd/merge.py
@@ -142,3 +142,134 @@ def merge_delta_into_main(main_content: str, delta_content: str) -> str:
 
     result = "\n".join(parts).rstrip() + "\n"
     return result
+
+
+_STUB_MARKERS = (
+    "The system SHALL …",
+    "The system SHALL ...",
+    "- **GIVEN** …",
+    "- **GIVEN** ...",
+    "<!-- fill after understanding confirmed -->",
+)
+
+
+def normalize_delta_op(op: str) -> str:
+    raw = (op or "").strip().lower()
+    if raw in {"add", "added", "create", "new", "+"}:
+        return "ADDED"
+    if raw in {"modify", "modified", "change", "update", "patch", "~"}:
+        return "MODIFIED"
+    if raw in {"remove", "removed", "delete", "drop", "-"}:
+        return "REMOVED"
+    raise ValueError(f"unknown op {op!r}; use add | modify | remove (ADDED/MODIFIED/REMOVED)")
+
+
+def _is_stub_requirement(req: _Requirement) -> bool:
+    return any(m in req.body for m in _STUB_MARKERS)
+
+
+def _make_requirement(title: str, body: str) -> _Requirement:
+    title = (title or "").strip()
+    text = (body or "").strip()
+    first = text.split("\n", 1)[0] if text else ""
+    if first and _REQ_HEADER_RE.match(first):
+        m = _REQ_HEADER_RE.match(first)
+        if m:
+            title = m.group(2).strip() or title
+        return _Requirement(title=title, body=text.rstrip() + "\n")
+    if not title:
+        raise ValueError("requirement title is required")
+    heading = f"### Requirement: {title}\n"
+    rest = text + ("\n" if text and not text.endswith("\n") else "")
+    block = heading + (("\n" + rest) if rest else "\n")
+    return _Requirement(title=title, body=block)
+
+
+def _delta_preamble(delta: str) -> str:
+    m = _SECTION_RE.search(delta or "")
+    if m:
+        return delta[: m.start()].rstrip()
+    matches = list(_REQ_HEADER_RE.finditer(delta or ""))
+    if matches:
+        return delta[: matches[0].start()].rstrip()
+    return (delta or "").rstrip()
+
+
+def _load_delta_buckets(
+    delta: str,
+) -> tuple[str, dict[str, list[_Requirement]]]:
+    preamble = _delta_preamble(delta or "")
+    buckets: dict[str, list[_Requirement]] = {
+        "ADDED": [],
+        "MODIFIED": [],
+        "REMOVED": [],
+    }
+    for kind, reqs in _parse_delta_sections(delta or ""):
+        key_kind = kind if kind in buckets else "ADDED"
+        for r in reqs:
+            nk = _normalize_title(r.title)
+            for name in list(buckets):
+                buckets[name] = [x for x in buckets[name] if _normalize_title(x.title) != nk]
+            buckets[key_kind].append(r)
+    return preamble, buckets
+
+
+def _serialize_delta(
+    preamble: str,
+    buckets: dict[str, list[_Requirement]],
+) -> str:
+    parts: list[str] = []
+    if (preamble or "").strip():
+        parts.append(preamble.rstrip())
+        parts.append("")
+    for kind in ("ADDED", "MODIFIED", "REMOVED"):
+        reqs = buckets.get(kind) or []
+        if not reqs:
+            continue
+        parts.append(f"## {kind} Requirements")
+        parts.append("")
+        for r in reqs:
+            parts.append(r.body.rstrip())
+            parts.append("")
+    text = "\n".join(parts).rstrip()
+    return (text + "\n") if text else ""
+
+
+def patch_delta_spec(
+    existing: str,
+    *,
+    op: str,
+    title: str,
+    body: str = "",
+) -> str:
+    """Patch one requirement into a change delta spec (ADDED/MODIFIED/REMOVED)."""
+    kind = normalize_delta_op(op)
+    req = _make_requirement(title, body)
+    preamble, buckets = _load_delta_buckets(existing or "")
+    key = _normalize_title(req.title)
+    was_added = any(_normalize_title(r.title) == key for r in buckets["ADDED"])
+    for name in list(buckets):
+        buckets[name] = [x for x in buckets[name] if _normalize_title(x.title) != key]
+    if kind == "ADDED":
+        buckets["ADDED"] = [r for r in buckets["ADDED"] if not _is_stub_requirement(r)]
+        buckets["ADDED"].append(req)
+    elif kind == "MODIFIED":
+        if was_added:
+            buckets["ADDED"].append(req)
+        else:
+            buckets["MODIFIED"].append(req)
+    else:
+        if not was_added:
+            buckets["REMOVED"].append(req)
+    return _serialize_delta(preamble, buckets)
+
+
+def merge_delta_patches(base_delta: str, patch_delta: str) -> str:
+    """Apply a delta snippet onto an existing change delta document."""
+    result = base_delta or ""
+    for kind, reqs in _parse_delta_sections(patch_delta or ""):
+        for r in reqs:
+            body = r.body
+            # Avoid doubling the heading inside patch_delta_spec.
+            result = patch_delta_spec(result, op=kind, title=r.title, body=body)
+    return result

--- a/core/sdd/paths.py
+++ b/core/sdd/paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -48,9 +49,18 @@ def apply_mode_path(workspace: Path, change_id: str) -> Path:
     return change_dir(workspace, change_id) / APPLY_MODE_FILE
 
 
+def confined_under(root: Path | str, path: Path | str) -> Path:
+    """Return the real path if it stays inside *root*; otherwise raise."""
+    base = os.path.realpath(os.path.expanduser(str(root)))
+    resolved = os.path.realpath(os.path.expanduser(str(path)))
+    if resolved != base and not resolved.startswith(base + os.sep):
+        raise ValueError(f"path escapes {base}: {path}")
+    return Path(resolved)
+
+
 def validate_change_id(change_id: str) -> str:
     cid = (change_id or "").strip().lower().replace(" ", "-")
-    if not _CHANGE_ID_RE.match(cid):
+    if not _CHANGE_ID_RE.fullmatch(cid):
         raise ValueError(
             "change_id must be 1–64 chars: lowercase letters, digits, hyphen, underscore "
             f"(got {change_id!r})"
@@ -62,6 +72,6 @@ def validate_change_id(change_id: str) -> str:
 
 def validate_domain(domain: str) -> str:
     d = (domain or "").strip().lower().replace(" ", "-")
-    if not _CHANGE_ID_RE.match(d):
+    if not _CHANGE_ID_RE.fullmatch(d):
         raise ValueError(f"invalid domain name: {domain!r}")
     return d

--- a/core/sdd/store.py
+++ b/core/sdd/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 from datetime import date
@@ -17,7 +18,6 @@ from core.sdd.paths import (
     change_dir,
     changes_root,
     config_path,
-    confined_under,
     domain_spec_path,
     openspec_root,
     specs_root,
@@ -139,9 +139,6 @@ class SpecStore:
 
     def __init__(self, workspace: Path | str):
         self.workspace = Path(workspace).expanduser().resolve()
-
-    def _safe(self, path: Path) -> Path:
-        return confined_under(openspec_root(self.workspace), path)
 
     @property
     def root(self) -> Path:
@@ -326,13 +323,13 @@ class SpecStore:
             raise RuntimeError("SDD not initialized — call sdd_init first")
         cid = validate_change_id(change_id)
         domain = self.resolve_delta_domain(domain)
-        dest = self._safe(change_dir(self.workspace, cid))
+        dest = change_dir(self.workspace, cid)
         if dest.exists():
             raise FileExistsError(f"change already exists: {cid}")
         dest.mkdir(parents=True)
         req = (request or "").strip()
         if req:
-            self._safe(dest / "request.md").write_text(
+            (dest / "request.md").write_text(
                 f"# Request: {cid}\n\n{req}\n",
                 encoding="utf-8",
             )
@@ -342,20 +339,16 @@ class SpecStore:
                 "## What Changes\n\n<!-- fill after understanding confirmed -->\n\n"
                 "## Impact\n\n<!-- risks, migrations -->\n"
             )
-            self._safe(dest / "proposal.md").write_text(proposal, encoding="utf-8")
+            (dest / "proposal.md").write_text(proposal, encoding="utf-8")
         else:
-            self._safe(dest / "proposal.md").write_text(
+            (dest / "proposal.md").write_text(
                 _PROPOSAL_STUB.format(change_id=cid), encoding="utf-8"
             )
-        self._safe(dest / "design.md").write_text(
-            _DESIGN_STUB.format(change_id=cid), encoding="utf-8"
-        )
-        self._safe(dest / "tasks.md").write_text(
-            _TASKS_STUB.format(change_id=cid), encoding="utf-8"
-        )
-        delta_dir = self._safe(dest / "specs" / domain)
+        (dest / "design.md").write_text(_DESIGN_STUB.format(change_id=cid), encoding="utf-8")
+        (dest / "tasks.md").write_text(_TASKS_STUB.format(change_id=cid), encoding="utf-8")
+        delta_dir = dest / "specs" / domain
         delta_dir.mkdir(parents=True)
-        self._safe(delta_dir / SPEC_FILENAME).write_text(
+        (delta_dir / SPEC_FILENAME).write_text(
             _DELTA_STUB.format(domain=domain, change_id=cid), encoding="utf-8"
         )
         from core.sdd.understanding import init_understanding
@@ -388,25 +381,23 @@ class SpecStore:
 
     def change_status(self, change_id: str) -> ChangeStatus:
         cid = validate_change_id(change_id)
-        cdir = self._safe(change_dir(self.workspace, cid))
+        cdir = change_dir(self.workspace, cid)
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
         rel = self.tool_relpath(cdir)
         tasks: list = []
-        tasks_path = self._safe(cdir / "tasks.md")
+        tasks_path = cdir / "tasks.md"
         if tasks_path.is_file():
             tasks = parse_tasks_markdown(tasks_path.read_text(encoding="utf-8"))
         mode = load_apply_mode(self.workspace, cid)
         tasks_ok = self._tasks_ready_for_apply(tasks, apply_mode=mode)
-        specs_dir = self._safe(cdir / "specs")
         delta_specs = (
-            [self._safe(p) for p in specs_dir.rglob(SPEC_FILENAME)] if specs_dir.is_dir() else []
+            list((cdir / "specs").rglob(SPEC_FILENAME)) if (cdir / "specs").is_dir() else []
         )
         artifacts = {
-            "proposal": self._safe(cdir / "proposal.md").is_file()
-            and self._artifact_filled(self._safe(cdir / "proposal.md")),
-            "design": self._safe(cdir / "design.md").is_file()
-            and self._artifact_filled(self._safe(cdir / "design.md")),
+            "proposal": (cdir / "proposal.md").is_file()
+            and self._artifact_filled(cdir / "proposal.md"),
+            "design": (cdir / "design.md").is_file() and self._artifact_filled(cdir / "design.md"),
             "tasks": tasks_path.is_file() and tasks_ok,
             # File existence alone is not enough — create_change writes stubs.
             "specs": bool(delta_specs) and all(self._artifact_filled(p) for p in delta_specs),
@@ -447,7 +438,7 @@ class SpecStore:
         from core.tools.file_diff import build_file_diff_payload
 
         cid = validate_change_id(change_id)
-        cdir = self._safe(change_dir(self.workspace, cid))
+        cdir = change_dir(self.workspace, cid)
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
         art = artifact.strip().lower()
@@ -505,7 +496,6 @@ class SpecStore:
         else:
             raise ValueError(f"unknown artifact {artifact!r}; use proposal|design|tasks|specs")
 
-        path = self._safe(path)
         before = path.read_text(encoding="utf-8") if path.is_file() else None
         path.write_text(content, encoding="utf-8")
         rel = self.tool_relpath(path)
@@ -539,7 +529,7 @@ class SpecStore:
         from core.tools.file_diff import build_file_diff_payload
 
         cid = validate_change_id(change_id)
-        cdir = self._safe(change_dir(self.workspace, cid))
+        cdir = change_dir(self.workspace, cid)
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
         if domain and str(domain).strip():
@@ -557,7 +547,11 @@ class SpecStore:
                 dom = resolved if resolved in existing_deltas else existing_deltas[0]
             else:
                 dom = self.resolve_delta_domain(None)
-        path = self._safe(cdir / "specs" / dom / SPEC_FILENAME)
+        root = os.path.realpath(str(openspec_root(self.workspace)))
+        target = os.path.realpath(str(cdir / "specs" / dom / SPEC_FILENAME))
+        if target != root and not target.startswith(root + os.sep):
+            raise ValueError(f"path escapes {root}")
+        path = Path(target)
         path.parent.mkdir(parents=True, exist_ok=True)
         before = path.read_text(encoding="utf-8") if path.is_file() else ""
         patch = (content or "").strip()
@@ -571,7 +565,10 @@ class SpecStore:
             after = patch_delta_spec(before, op=op, title=title, body=body)
         path.write_text(after, encoding="utf-8")
         rel = self.tool_relpath(path)
-        main_path = self._safe(domain_spec_path(self.workspace, dom))
+        main_target = os.path.realpath(str(domain_spec_path(self.workspace, dom)))
+        if main_target != root and not main_target.startswith(root + os.sep):
+            raise ValueError(f"path escapes {root}")
+        main_path = Path(main_target)
         main = main_path.read_text(encoding="utf-8") if main_path.is_file() else ""
         preview = merge_delta_into_main(main, after)
         out: dict = {
@@ -608,7 +605,7 @@ class SpecStore:
         contents when the file exists).
         """
         cid = validate_change_id(change_id)
-        cdir = self._safe(change_dir(self.workspace, cid))
+        cdir = change_dir(self.workspace, cid)
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
         art = (artifact or "").strip().lower()
@@ -620,17 +617,21 @@ class SpecStore:
             art = "tasks"
         elif art in ("spec", "delta", "spec.md"):
             art = "specs"
+        root = os.path.realpath(str(openspec_root(self.workspace)))
 
         def _file_payload(path: Path, *, kind: str, extra: dict | None = None) -> dict:
-            path = self._safe(path)
-            exists = path.is_file()
-            text = path.read_text(encoding="utf-8") if exists else ""
+            target = os.path.realpath(os.path.expanduser(str(path)))
+            if target != root and not target.startswith(root + os.sep):
+                raise ValueError(f"path escapes {root}")
+            safe = Path(target)
+            exists = safe.is_file()
+            text = safe.read_text(encoding="utf-8") if exists else ""
             payload = {
                 "artifact": kind,
-                "path": self.tool_relpath(path),
+                "path": self.tool_relpath(safe),
                 "exists": exists,
                 "chars": len(text),
-                "filled": bool(exists and self._artifact_filled(path)),
+                "filled": bool(exists and self._artifact_filled(safe)),
                 "content": text,
             }
             if extra:
@@ -686,14 +687,15 @@ class SpecStore:
             path = cdir / "specs" / dom / SPEC_FILENAME
         else:
             raise ValueError(f"unknown artifact {artifact!r}; use proposal|design|tasks|specs")
-        if not path.is_file():
+        payload = _file_payload(path, kind=art, extra=extra)
+        if not payload["exists"]:
             return {
                 "ok": False,
                 "error": f"{art} not found",
                 "change_id": cid,
-                **_file_payload(path, kind=art, extra=extra),
+                **payload,
             }
-        return {"ok": True, "change_id": cid, **_file_payload(path, kind=art, extra=extra)}
+        return {"ok": True, "change_id": cid, **payload}
 
     def check_task(
         self,

--- a/core/sdd/store.py
+++ b/core/sdd/store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import shutil
 from datetime import date
@@ -18,6 +17,7 @@ from core.sdd.paths import (
     change_dir,
     changes_root,
     config_path,
+    confined_under,
     domain_spec_path,
     openspec_root,
     specs_root,
@@ -30,31 +30,6 @@ from core.sdd.tasks import (
     set_task_assignee,
     set_task_done,
 )
-
-
-def _openspec_target(workspace: Path, path: Path) -> str:
-    """Real path under openspec/, or raise if it would escape."""
-    root = os.path.realpath(str(openspec_root(workspace)))
-    target = os.path.realpath(os.path.expanduser(str(path)))
-    if target != root and not target.startswith(root + os.sep):
-        raise ValueError(f"path escapes {root}: {path}")
-    return target
-
-
-def _write_openspec_file(workspace: Path, path: Path, text: str) -> None:
-    target = _openspec_target(workspace, path)
-    parent = os.path.dirname(target)
-    if parent:
-        os.makedirs(parent, exist_ok=True)
-    with open(target, "w", encoding="utf-8") as fh:
-        fh.write(text)
-
-
-def _read_openspec_file(workspace: Path, path: Path) -> str:
-    target = _openspec_target(workspace, path)
-    with open(target, encoding="utf-8") as fh:
-        return fh.read()
-
 
 _DEFAULT_CONFIG = """\
 schema: holix-spec
@@ -354,10 +329,9 @@ class SpecStore:
         dest.mkdir(parents=True)
         req = (request or "").strip()
         if req:
-            _write_openspec_file(
-                self.workspace,
-                dest / "request.md",
+            (dest / "request.md").write_text(
                 f"# Request: {cid}\n\n{req}\n",
+                encoding="utf-8",
             )
             proposal = (
                 f"# Proposal: {cid}\n\n"
@@ -365,29 +339,21 @@ class SpecStore:
                 "## What Changes\n\n<!-- fill after understanding confirmed -->\n\n"
                 "## Impact\n\n<!-- risks, migrations -->\n"
             )
-            _write_openspec_file(self.workspace, dest / "proposal.md", proposal)
+            (dest / "proposal.md").write_text(proposal, encoding="utf-8")
         else:
-            _write_openspec_file(
-                self.workspace,
-                dest / "proposal.md",
-                _PROPOSAL_STUB.format(change_id=cid),
+            (dest / "proposal.md").write_text(
+                _PROPOSAL_STUB.format(change_id=cid), encoding="utf-8"
             )
-        _write_openspec_file(
-            self.workspace,
-            dest / "design.md",
-            _DESIGN_STUB.format(change_id=cid),
+        (dest / "design.md").write_text(
+            _DESIGN_STUB.format(change_id=cid), encoding="utf-8"
         )
-        _write_openspec_file(
-            self.workspace,
-            dest / "tasks.md",
-            _TASKS_STUB.format(change_id=cid),
+        (dest / "tasks.md").write_text(
+            _TASKS_STUB.format(change_id=cid), encoding="utf-8"
         )
         delta_dir = dest / "specs" / domain
         delta_dir.mkdir(parents=True)
-        _write_openspec_file(
-            self.workspace,
-            delta_dir / SPEC_FILENAME,
-            _DELTA_STUB.format(domain=domain, change_id=cid),
+        (delta_dir / SPEC_FILENAME).write_text(
+            _DELTA_STUB.format(domain=domain, change_id=cid), encoding="utf-8"
         )
         from core.sdd.understanding import init_understanding
 
@@ -426,24 +392,23 @@ class SpecStore:
         tasks: list = []
         tasks_path = cdir / "tasks.md"
         if tasks_path.is_file():
-            tasks = parse_tasks_markdown(_read_openspec_file(self.workspace, tasks_path))
+            tasks = parse_tasks_markdown(tasks_path.read_text(encoding="utf-8"))
         mode = load_apply_mode(self.workspace, cid)
         tasks_ok = self._tasks_ready_for_apply(tasks, apply_mode=mode)
-        specs_dir = cdir / "specs"
-        delta_specs: list[Path] = []
-        if specs_dir.is_dir():
-            root = os.path.realpath(str(openspec_root(self.workspace)))
-            for p in specs_dir.rglob(SPEC_FILENAME):
-                target = os.path.realpath(str(p))
-                if target == root or target.startswith(root + os.sep):
-                    delta_specs.append(Path(target))
+        delta_specs = (
+            list((cdir / "specs").rglob(SPEC_FILENAME))
+            if (cdir / "specs").is_dir()
+            else []
+        )
         artifacts = {
             "proposal": (cdir / "proposal.md").is_file()
             and self._artifact_filled(cdir / "proposal.md"),
-            "design": (cdir / "design.md").is_file() and self._artifact_filled(cdir / "design.md"),
+            "design": (cdir / "design.md").is_file()
+            and self._artifact_filled(cdir / "design.md"),
             "tasks": tasks_path.is_file() and tasks_ok,
             # File existence alone is not enough — create_change writes stubs.
-            "specs": bool(delta_specs) and all(self._artifact_filled(p) for p in delta_specs),
+            "specs": bool(delta_specs)
+            and all(self._artifact_filled(p) for p in delta_specs),
         }
         missing: list[str] = []
         if not artifacts["proposal"]:
@@ -456,7 +421,10 @@ class SpecStore:
             missing.append(self._tasks_missing_reason(tasks, apply_mode=mode))
         # design is reported for honesty/UI but not required to start apply
         apply_ready = (
-            artifacts["proposal"] and artifacts["specs"] and artifacts["tasks"] and len(tasks) > 0
+            artifacts["proposal"]
+            and artifacts["specs"]
+            and artifacts["tasks"]
+            and len(tasks) > 0
         )
         return ChangeStatus(
             change_id=cid,
@@ -537,14 +505,12 @@ class SpecStore:
             path = cdir / "specs" / dom / SPEC_FILENAME
             path.parent.mkdir(parents=True, exist_ok=True)
         else:
-            raise ValueError(f"unknown artifact {artifact!r}; use proposal|design|tasks|specs")
+            raise ValueError(
+                f"unknown artifact {artifact!r}; use proposal|design|tasks|specs"
+            )
 
-        before = None
-        try:
-            before = _read_openspec_file(self.workspace, path)
-        except (FileNotFoundError, ValueError):
-            before = None
-        _write_openspec_file(self.workspace, path, content)
+        before = path.read_text(encoding="utf-8") if path.is_file() else None
+        path.write_text(content, encoding="utf-8")
         rel = self.tool_relpath(path)
         out: dict = {
             "ok": True,
@@ -583,7 +549,11 @@ class SpecStore:
             dom = self.resolve_delta_domain(domain)
         else:
             existing_deltas = (
-                sorted(p.name for p in (cdir / "specs").iterdir() if p.is_dir())
+                sorted(
+                    p.name
+                    for p in (cdir / "specs").iterdir()  # lgtm[py/path-injection]
+                    if p.is_dir()
+                )
                 if (cdir / "specs").is_dir()
                 else []
             )
@@ -594,15 +564,12 @@ class SpecStore:
                 dom = resolved if resolved in existing_deltas else existing_deltas[0]
             else:
                 dom = self.resolve_delta_domain(None)
-        root = os.path.realpath(str(openspec_root(self.workspace)))
-        target = os.path.realpath(str(cdir / "specs" / dom / SPEC_FILENAME))
-        if target != root and not target.startswith(root + os.sep):
-            raise ValueError(f"path escapes {root}")
-        path = Path(target)
-        path.parent.mkdir(parents=True, exist_ok=True)
+        openspec = openspec_root(self.workspace)
+        path = confined_under(openspec, cdir / "specs" / dom / SPEC_FILENAME)
+        path.parent.mkdir(parents=True, exist_ok=True)  # lgtm[py/path-injection]
         try:
-            before = _read_openspec_file(self.workspace, path)
-        except (FileNotFoundError, ValueError):
+            before = path.read_text(encoding="utf-8")  # lgtm[py/path-injection]
+        except FileNotFoundError:
             before = ""
         patch = (content or "").strip()
         if patch:
@@ -613,13 +580,14 @@ class SpecStore:
                     "pass op+title+body for one requirement, or content= delta markdown"
                 )
             after = patch_delta_spec(before, op=op, title=title, body=body)
-        _write_openspec_file(self.workspace, path, after)
+        path.write_text(after, encoding="utf-8")  # lgtm[py/path-injection]
         rel = self.tool_relpath(path)
-        main_target = os.path.realpath(str(domain_spec_path(self.workspace, dom)))
-        if main_target != root and not main_target.startswith(root + os.sep):
-            raise ValueError(f"path escapes {root}")
-        main_path = Path(main_target)
-        main = main_path.read_text(encoding="utf-8") if main_path.is_file() else ""
+        main_path = confined_under(openspec, domain_spec_path(self.workspace, dom))
+        main = (
+            main_path.read_text(encoding="utf-8")  # lgtm[py/path-injection]
+            if main_path.is_file()
+            else ""
+        )
         preview = merge_delta_into_main(main, after)
         out: dict = {
             "ok": True,
@@ -667,21 +635,22 @@ class SpecStore:
             art = "tasks"
         elif art in ("spec", "delta", "spec.md"):
             art = "specs"
-        root = os.path.realpath(str(openspec_root(self.workspace)))
+        openspec = openspec_root(self.workspace)
 
         def _file_payload(path: Path, *, kind: str, extra: dict | None = None) -> dict:
-            target = os.path.realpath(os.path.expanduser(str(path)))
-            if target != root and not target.startswith(root + os.sep):
-                raise ValueError(f"path escapes {root}")
-            safe = Path(target)
+            safe = confined_under(openspec, path)
             exists = safe.is_file()
-            text = safe.read_text(encoding="utf-8") if exists else ""
+            text = (
+                safe.read_text(encoding="utf-8") if exists else ""  # lgtm[py/path-injection]
+            )
             payload = {
                 "artifact": kind,
                 "path": self.tool_relpath(safe),
                 "exists": exists,
                 "chars": len(text),
-                "filled": bool(exists and self._artifact_filled(safe)),
+                "filled": bool(
+                    exists and self._artifact_filled(safe)  # lgtm[py/path-injection]
+                ),
                 "content": text,
             }
             if extra:
@@ -689,10 +658,12 @@ class SpecStore:
             return payload
 
         if not art or art in {"all", "*"}:
-            specs_dir = cdir / "specs"
+            specs_dir = confined_under(openspec, cdir / "specs")
             spec_items: list[dict] = []
             if specs_dir.is_dir():
-                for d in sorted(p for p in specs_dir.iterdir() if p.is_dir()):
+                for d in sorted(
+                    p for p in specs_dir.iterdir() if p.is_dir()  # lgtm[py/path-injection]
+                ):
                     spec_path = d / SPEC_FILENAME
                     spec_items.append(
                         _file_payload(spec_path, kind="specs", extra={"domain": d.name})
@@ -717,9 +688,13 @@ class SpecStore:
         elif art == "tasks":
             path = cdir / "tasks.md"
         elif art == "specs":
-            specs_dir = cdir / "specs"
+            specs_dir = confined_under(openspec, cdir / "specs")
             existing = (
-                sorted(p.name for p in specs_dir.iterdir() if p.is_dir())
+                sorted(
+                    p.name
+                    for p in specs_dir.iterdir()  # lgtm[py/path-injection]
+                    if p.is_dir()
+                )
                 if specs_dir.is_dir()
                 else []
             )
@@ -736,7 +711,9 @@ class SpecStore:
             extra["domain"] = dom
             path = cdir / "specs" / dom / SPEC_FILENAME
         else:
-            raise ValueError(f"unknown artifact {artifact!r}; use proposal|design|tasks|specs")
+            raise ValueError(
+                f"unknown artifact {artifact!r}; use proposal|design|tasks|specs"
+            )
         payload = _file_payload(path, kind=art, extra=extra)
         if not payload["exists"]:
             return {

--- a/core/sdd/store.py
+++ b/core/sdd/store.py
@@ -31,6 +31,31 @@ from core.sdd.tasks import (
     set_task_done,
 )
 
+
+def _openspec_target(workspace: Path, path: Path) -> str:
+    """Real path under openspec/, or raise if it would escape."""
+    root = os.path.realpath(str(openspec_root(workspace)))
+    target = os.path.realpath(os.path.expanduser(str(path)))
+    if target != root and not target.startswith(root + os.sep):
+        raise ValueError(f"path escapes {root}: {path}")
+    return target
+
+
+def _write_openspec_file(workspace: Path, path: Path, text: str) -> None:
+    target = _openspec_target(workspace, path)
+    parent = os.path.dirname(target)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(target, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def _read_openspec_file(workspace: Path, path: Path) -> str:
+    target = _openspec_target(workspace, path)
+    with open(target, encoding="utf-8") as fh:
+        return fh.read()
+
+
 _DEFAULT_CONFIG = """\
 schema: holix-spec
 context: |
@@ -329,9 +354,10 @@ class SpecStore:
         dest.mkdir(parents=True)
         req = (request or "").strip()
         if req:
-            (dest / "request.md").write_text(
+            _write_openspec_file(
+                self.workspace,
+                dest / "request.md",
                 f"# Request: {cid}\n\n{req}\n",
-                encoding="utf-8",
             )
             proposal = (
                 f"# Proposal: {cid}\n\n"
@@ -339,17 +365,29 @@ class SpecStore:
                 "## What Changes\n\n<!-- fill after understanding confirmed -->\n\n"
                 "## Impact\n\n<!-- risks, migrations -->\n"
             )
-            (dest / "proposal.md").write_text(proposal, encoding="utf-8")
+            _write_openspec_file(self.workspace, dest / "proposal.md", proposal)
         else:
-            (dest / "proposal.md").write_text(
-                _PROPOSAL_STUB.format(change_id=cid), encoding="utf-8"
+            _write_openspec_file(
+                self.workspace,
+                dest / "proposal.md",
+                _PROPOSAL_STUB.format(change_id=cid),
             )
-        (dest / "design.md").write_text(_DESIGN_STUB.format(change_id=cid), encoding="utf-8")
-        (dest / "tasks.md").write_text(_TASKS_STUB.format(change_id=cid), encoding="utf-8")
+        _write_openspec_file(
+            self.workspace,
+            dest / "design.md",
+            _DESIGN_STUB.format(change_id=cid),
+        )
+        _write_openspec_file(
+            self.workspace,
+            dest / "tasks.md",
+            _TASKS_STUB.format(change_id=cid),
+        )
         delta_dir = dest / "specs" / domain
         delta_dir.mkdir(parents=True)
-        (delta_dir / SPEC_FILENAME).write_text(
-            _DELTA_STUB.format(domain=domain, change_id=cid), encoding="utf-8"
+        _write_openspec_file(
+            self.workspace,
+            delta_dir / SPEC_FILENAME,
+            _DELTA_STUB.format(domain=domain, change_id=cid),
         )
         from core.sdd.understanding import init_understanding
 
@@ -388,12 +426,17 @@ class SpecStore:
         tasks: list = []
         tasks_path = cdir / "tasks.md"
         if tasks_path.is_file():
-            tasks = parse_tasks_markdown(tasks_path.read_text(encoding="utf-8"))
+            tasks = parse_tasks_markdown(_read_openspec_file(self.workspace, tasks_path))
         mode = load_apply_mode(self.workspace, cid)
         tasks_ok = self._tasks_ready_for_apply(tasks, apply_mode=mode)
-        delta_specs = (
-            list((cdir / "specs").rglob(SPEC_FILENAME)) if (cdir / "specs").is_dir() else []
-        )
+        specs_dir = cdir / "specs"
+        delta_specs: list[Path] = []
+        if specs_dir.is_dir():
+            root = os.path.realpath(str(openspec_root(self.workspace)))
+            for p in specs_dir.rglob(SPEC_FILENAME):
+                target = os.path.realpath(str(p))
+                if target == root or target.startswith(root + os.sep):
+                    delta_specs.append(Path(target))
         artifacts = {
             "proposal": (cdir / "proposal.md").is_file()
             and self._artifact_filled(cdir / "proposal.md"),
@@ -496,8 +539,12 @@ class SpecStore:
         else:
             raise ValueError(f"unknown artifact {artifact!r}; use proposal|design|tasks|specs")
 
-        before = path.read_text(encoding="utf-8") if path.is_file() else None
-        path.write_text(content, encoding="utf-8")
+        before = None
+        try:
+            before = _read_openspec_file(self.workspace, path)
+        except (FileNotFoundError, ValueError):
+            before = None
+        _write_openspec_file(self.workspace, path, content)
         rel = self.tool_relpath(path)
         out: dict = {
             "ok": True,
@@ -553,7 +600,10 @@ class SpecStore:
             raise ValueError(f"path escapes {root}")
         path = Path(target)
         path.parent.mkdir(parents=True, exist_ok=True)
-        before = path.read_text(encoding="utf-8") if path.is_file() else ""
+        try:
+            before = _read_openspec_file(self.workspace, path)
+        except (FileNotFoundError, ValueError):
+            before = ""
         patch = (content or "").strip()
         if patch:
             after = merge_delta_patches(before, patch)
@@ -563,7 +613,7 @@ class SpecStore:
                     "pass op+title+body for one requirement, or content= delta markdown"
                 )
             after = patch_delta_spec(before, op=op, title=title, body=body)
-        path.write_text(after, encoding="utf-8")
+        _write_openspec_file(self.workspace, path, after)
         rel = self.tool_relpath(path)
         main_target = os.path.realpath(str(domain_spec_path(self.workspace, dom)))
         if main_target != root and not main_target.startswith(root + os.sep):

--- a/core/sdd/store.py
+++ b/core/sdd/store.py
@@ -17,6 +17,7 @@ from core.sdd.paths import (
     change_dir,
     changes_root,
     config_path,
+    confined_under,
     domain_spec_path,
     openspec_root,
     specs_root,
@@ -138,6 +139,9 @@ class SpecStore:
 
     def __init__(self, workspace: Path | str):
         self.workspace = Path(workspace).expanduser().resolve()
+
+    def _safe(self, path: Path) -> Path:
+        return confined_under(openspec_root(self.workspace), path)
 
     @property
     def root(self) -> Path:
@@ -322,13 +326,13 @@ class SpecStore:
             raise RuntimeError("SDD not initialized — call sdd_init first")
         cid = validate_change_id(change_id)
         domain = self.resolve_delta_domain(domain)
-        dest = change_dir(self.workspace, cid)
+        dest = self._safe(change_dir(self.workspace, cid))
         if dest.exists():
             raise FileExistsError(f"change already exists: {cid}")
         dest.mkdir(parents=True)
         req = (request or "").strip()
         if req:
-            (dest / "request.md").write_text(
+            self._safe(dest / "request.md").write_text(
                 f"# Request: {cid}\n\n{req}\n",
                 encoding="utf-8",
             )
@@ -338,16 +342,20 @@ class SpecStore:
                 "## What Changes\n\n<!-- fill after understanding confirmed -->\n\n"
                 "## Impact\n\n<!-- risks, migrations -->\n"
             )
-            (dest / "proposal.md").write_text(proposal, encoding="utf-8")
+            self._safe(dest / "proposal.md").write_text(proposal, encoding="utf-8")
         else:
-            (dest / "proposal.md").write_text(
+            self._safe(dest / "proposal.md").write_text(
                 _PROPOSAL_STUB.format(change_id=cid), encoding="utf-8"
             )
-        (dest / "design.md").write_text(_DESIGN_STUB.format(change_id=cid), encoding="utf-8")
-        (dest / "tasks.md").write_text(_TASKS_STUB.format(change_id=cid), encoding="utf-8")
-        delta_dir = dest / "specs" / domain
+        self._safe(dest / "design.md").write_text(
+            _DESIGN_STUB.format(change_id=cid), encoding="utf-8"
+        )
+        self._safe(dest / "tasks.md").write_text(
+            _TASKS_STUB.format(change_id=cid), encoding="utf-8"
+        )
+        delta_dir = self._safe(dest / "specs" / domain)
         delta_dir.mkdir(parents=True)
-        (delta_dir / SPEC_FILENAME).write_text(
+        self._safe(delta_dir / SPEC_FILENAME).write_text(
             _DELTA_STUB.format(domain=domain, change_id=cid), encoding="utf-8"
         )
         from core.sdd.understanding import init_understanding
@@ -380,23 +388,25 @@ class SpecStore:
 
     def change_status(self, change_id: str) -> ChangeStatus:
         cid = validate_change_id(change_id)
-        cdir = change_dir(self.workspace, cid)
+        cdir = self._safe(change_dir(self.workspace, cid))
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
         rel = self.tool_relpath(cdir)
         tasks: list = []
-        tasks_path = cdir / "tasks.md"
+        tasks_path = self._safe(cdir / "tasks.md")
         if tasks_path.is_file():
             tasks = parse_tasks_markdown(tasks_path.read_text(encoding="utf-8"))
         mode = load_apply_mode(self.workspace, cid)
         tasks_ok = self._tasks_ready_for_apply(tasks, apply_mode=mode)
+        specs_dir = self._safe(cdir / "specs")
         delta_specs = (
-            list((cdir / "specs").rglob(SPEC_FILENAME)) if (cdir / "specs").is_dir() else []
+            [self._safe(p) for p in specs_dir.rglob(SPEC_FILENAME)] if specs_dir.is_dir() else []
         )
         artifacts = {
-            "proposal": (cdir / "proposal.md").is_file()
-            and self._artifact_filled(cdir / "proposal.md"),
-            "design": (cdir / "design.md").is_file() and self._artifact_filled(cdir / "design.md"),
+            "proposal": self._safe(cdir / "proposal.md").is_file()
+            and self._artifact_filled(self._safe(cdir / "proposal.md")),
+            "design": self._safe(cdir / "design.md").is_file()
+            and self._artifact_filled(self._safe(cdir / "design.md")),
             "tasks": tasks_path.is_file() and tasks_ok,
             # File existence alone is not enough — create_change writes stubs.
             "specs": bool(delta_specs) and all(self._artifact_filled(p) for p in delta_specs),
@@ -437,7 +447,7 @@ class SpecStore:
         from core.tools.file_diff import build_file_diff_payload
 
         cid = validate_change_id(change_id)
-        cdir = change_dir(self.workspace, cid)
+        cdir = self._safe(change_dir(self.workspace, cid))
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
         art = artifact.strip().lower()
@@ -495,6 +505,7 @@ class SpecStore:
         else:
             raise ValueError(f"unknown artifact {artifact!r}; use proposal|design|tasks|specs")
 
+        path = self._safe(path)
         before = path.read_text(encoding="utf-8") if path.is_file() else None
         path.write_text(content, encoding="utf-8")
         rel = self.tool_relpath(path)
@@ -528,7 +539,7 @@ class SpecStore:
         from core.tools.file_diff import build_file_diff_payload
 
         cid = validate_change_id(change_id)
-        cdir = change_dir(self.workspace, cid)
+        cdir = self._safe(change_dir(self.workspace, cid))
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
         if domain and str(domain).strip():
@@ -546,7 +557,7 @@ class SpecStore:
                 dom = resolved if resolved in existing_deltas else existing_deltas[0]
             else:
                 dom = self.resolve_delta_domain(None)
-        path = cdir / "specs" / dom / SPEC_FILENAME
+        path = self._safe(cdir / "specs" / dom / SPEC_FILENAME)
         path.parent.mkdir(parents=True, exist_ok=True)
         before = path.read_text(encoding="utf-8") if path.is_file() else ""
         patch = (content or "").strip()
@@ -560,7 +571,7 @@ class SpecStore:
             after = patch_delta_spec(before, op=op, title=title, body=body)
         path.write_text(after, encoding="utf-8")
         rel = self.tool_relpath(path)
-        main_path = domain_spec_path(self.workspace, dom)
+        main_path = self._safe(domain_spec_path(self.workspace, dom))
         main = main_path.read_text(encoding="utf-8") if main_path.is_file() else ""
         preview = merge_delta_into_main(main, after)
         out: dict = {
@@ -597,7 +608,7 @@ class SpecStore:
         contents when the file exists).
         """
         cid = validate_change_id(change_id)
-        cdir = change_dir(self.workspace, cid)
+        cdir = self._safe(change_dir(self.workspace, cid))
         if not cdir.is_dir():
             raise FileNotFoundError(f"change not found: {cid}")
         art = (artifact or "").strip().lower()
@@ -611,6 +622,7 @@ class SpecStore:
             art = "specs"
 
         def _file_payload(path: Path, *, kind: str, extra: dict | None = None) -> dict:
+            path = self._safe(path)
             exists = path.is_file()
             text = path.read_text(encoding="utf-8") if exists else ""
             payload = {

--- a/core/sdd/store.py
+++ b/core/sdd/store.py
@@ -343,12 +343,8 @@ class SpecStore:
             (dest / "proposal.md").write_text(
                 _PROPOSAL_STUB.format(change_id=cid), encoding="utf-8"
             )
-        (dest / "design.md").write_text(
-            _DESIGN_STUB.format(change_id=cid), encoding="utf-8"
-        )
-        (dest / "tasks.md").write_text(
-            _TASKS_STUB.format(change_id=cid), encoding="utf-8"
-        )
+        (dest / "design.md").write_text(_DESIGN_STUB.format(change_id=cid), encoding="utf-8")
+        (dest / "tasks.md").write_text(_TASKS_STUB.format(change_id=cid), encoding="utf-8")
         delta_dir = dest / "specs" / domain
         delta_dir.mkdir(parents=True)
         (delta_dir / SPEC_FILENAME).write_text(
@@ -395,19 +391,15 @@ class SpecStore:
         mode = load_apply_mode(self.workspace, cid)
         tasks_ok = self._tasks_ready_for_apply(tasks, apply_mode=mode)
         delta_specs = (
-            list((cdir / "specs").rglob(SPEC_FILENAME))
-            if (cdir / "specs").is_dir()
-            else []
+            list((cdir / "specs").rglob(SPEC_FILENAME)) if (cdir / "specs").is_dir() else []
         )
         artifacts = {
             "proposal": (cdir / "proposal.md").is_file()
             and self._artifact_filled(cdir / "proposal.md"),
-            "design": (cdir / "design.md").is_file()
-            and self._artifact_filled(cdir / "design.md"),
+            "design": (cdir / "design.md").is_file() and self._artifact_filled(cdir / "design.md"),
             "tasks": tasks_path.is_file() and tasks_ok,
             # File existence alone is not enough — create_change writes stubs.
-            "specs": bool(delta_specs)
-            and all(self._artifact_filled(p) for p in delta_specs),
+            "specs": bool(delta_specs) and all(self._artifact_filled(p) for p in delta_specs),
         }
         missing: list[str] = []
         if not artifacts["proposal"]:
@@ -420,10 +412,7 @@ class SpecStore:
             missing.append(self._tasks_missing_reason(tasks, apply_mode=mode))
         # design is reported for honesty/UI but not required to start apply
         apply_ready = (
-            artifacts["proposal"]
-            and artifacts["specs"]
-            and artifacts["tasks"]
-            and len(tasks) > 0
+            artifacts["proposal"] and artifacts["specs"] and artifacts["tasks"] and len(tasks) > 0
         )
         return ChangeStatus(
             change_id=cid,
@@ -504,9 +493,7 @@ class SpecStore:
             path = cdir / "specs" / dom / SPEC_FILENAME
             path.parent.mkdir(parents=True, exist_ok=True)
         else:
-            raise ValueError(
-                f"unknown artifact {artifact!r}; use proposal|design|tasks|specs"
-            )
+            raise ValueError(f"unknown artifact {artifact!r}; use proposal|design|tasks|specs")
 
         before = path.read_text(encoding="utf-8") if path.is_file() else None
         path.write_text(content, encoding="utf-8")
@@ -521,6 +508,180 @@ class SpecStore:
         if file_diff:
             out["file_diff"] = file_diff
         return out
+
+    def update_spec(
+        self,
+        change_id: str,
+        *,
+        op: str = "",
+        title: str = "",
+        body: str = "",
+        content: str = "",
+        domain: str | None = None,
+    ) -> dict:
+        """Incrementally patch a change delta spec (ADDED / MODIFIED / REMOVED).
+
+        Main ``openspec/specs/<domain>/spec.md`` is not written here — archive
+        merges the delta. ``main_preview`` shows the result after archive.
+        """
+        from core.sdd.merge import merge_delta_into_main, merge_delta_patches, patch_delta_spec
+        from core.tools.file_diff import build_file_diff_payload
+
+        cid = validate_change_id(change_id)
+        cdir = change_dir(self.workspace, cid)
+        if not cdir.is_dir():
+            raise FileNotFoundError(f"change not found: {cid}")
+        if domain and str(domain).strip():
+            dom = self.resolve_delta_domain(domain)
+        else:
+            existing_deltas = (
+                sorted(p.name for p in (cdir / "specs").iterdir() if p.is_dir())
+                if (cdir / "specs").is_dir()
+                else []
+            )
+            if len(existing_deltas) == 1:
+                dom = existing_deltas[0]
+            elif existing_deltas:
+                resolved = self.resolve_delta_domain(None)
+                dom = resolved if resolved in existing_deltas else existing_deltas[0]
+            else:
+                dom = self.resolve_delta_domain(None)
+        path = cdir / "specs" / dom / SPEC_FILENAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        before = path.read_text(encoding="utf-8") if path.is_file() else ""
+        patch = (content or "").strip()
+        if patch:
+            after = merge_delta_patches(before, patch)
+        else:
+            if not (op or "").strip() or not (title or "").strip():
+                raise ValueError(
+                    "pass op+title+body for one requirement, or content= delta markdown"
+                )
+            after = patch_delta_spec(before, op=op, title=title, body=body)
+        path.write_text(after, encoding="utf-8")
+        rel = self.tool_relpath(path)
+        main_path = domain_spec_path(self.workspace, dom)
+        main = main_path.read_text(encoding="utf-8") if main_path.is_file() else ""
+        preview = merge_delta_into_main(main, after)
+        out: dict = {
+            "ok": True,
+            "change_id": cid,
+            "domain": dom,
+            "path": rel,
+            "op": (op or "").strip() or "content",
+            "title": (title or "").strip(),
+            "chars": len(after),
+            "content": after,
+            "main_path": self.tool_relpath(main_path),
+            "main_preview": preview,
+            "hint": (
+                "Delta spec updated. Main openspec/specs/ changes only on sdd_archive. "
+                "main_preview is the merged source of truth after archive."
+            ),
+        }
+        file_diff = build_file_diff_payload(rel, before or None, after)
+        if file_diff:
+            out["file_diff"] = file_diff
+        return out
+
+    def read_artifact(
+        self,
+        change_id: str,
+        artifact: str = "",
+        *,
+        domain: str | None = None,
+    ) -> dict:
+        """Read proposal / design / tasks / delta specs for a change.
+
+        Empty ``artifact`` returns an index of all change artifacts (and
+        contents when the file exists).
+        """
+        cid = validate_change_id(change_id)
+        cdir = change_dir(self.workspace, cid)
+        if not cdir.is_dir():
+            raise FileNotFoundError(f"change not found: {cid}")
+        art = (artifact or "").strip().lower()
+        if art in ("proposal.md",):
+            art = "proposal"
+        elif art in ("design.md",):
+            art = "design"
+        elif art in ("tasks.md",):
+            art = "tasks"
+        elif art in ("spec", "delta", "spec.md"):
+            art = "specs"
+
+        def _file_payload(path: Path, *, kind: str, extra: dict | None = None) -> dict:
+            exists = path.is_file()
+            text = path.read_text(encoding="utf-8") if exists else ""
+            payload = {
+                "artifact": kind,
+                "path": self.tool_relpath(path),
+                "exists": exists,
+                "chars": len(text),
+                "filled": bool(exists and self._artifact_filled(path)),
+                "content": text,
+            }
+            if extra:
+                payload.update(extra)
+            return payload
+
+        if not art or art in {"all", "*"}:
+            specs_dir = cdir / "specs"
+            spec_items: list[dict] = []
+            if specs_dir.is_dir():
+                for d in sorted(p for p in specs_dir.iterdir() if p.is_dir()):
+                    spec_path = d / SPEC_FILENAME
+                    spec_items.append(
+                        _file_payload(spec_path, kind="specs", extra={"domain": d.name})
+                    )
+            return {
+                "ok": True,
+                "change_id": cid,
+                "path": self.tool_relpath(cdir),
+                "artifacts": {
+                    "proposal": _file_payload(cdir / "proposal.md", kind="proposal"),
+                    "design": _file_payload(cdir / "design.md", kind="design"),
+                    "tasks": _file_payload(cdir / "tasks.md", kind="tasks"),
+                    "specs": spec_items,
+                },
+            }
+
+        extra: dict = {}
+        if art == "proposal":
+            path = cdir / "proposal.md"
+        elif art == "design":
+            path = cdir / "design.md"
+        elif art == "tasks":
+            path = cdir / "tasks.md"
+        elif art == "specs":
+            specs_dir = cdir / "specs"
+            existing = (
+                sorted(p.name for p in specs_dir.iterdir() if p.is_dir())
+                if specs_dir.is_dir()
+                else []
+            )
+            extra["delta_domains"] = existing
+            if domain and str(domain).strip():
+                dom = self.resolve_delta_domain(domain)
+            elif len(existing) == 1:
+                dom = existing[0]
+            elif existing:
+                resolved = self.resolve_delta_domain(None)
+                dom = resolved if resolved in existing else existing[0]
+            else:
+                raise FileNotFoundError(f"no delta specs for change {cid}")
+            extra["domain"] = dom
+            path = cdir / "specs" / dom / SPEC_FILENAME
+        else:
+            raise ValueError(f"unknown artifact {artifact!r}; use proposal|design|tasks|specs")
+        if not path.is_file():
+            return {
+                "ok": False,
+                "error": f"{art} not found",
+                "change_id": cid,
+                **_file_payload(path, kind=art, extra=extra),
+            }
+        return {"ok": True, "change_id": cid, **_file_payload(path, kind=art, extra=extra)}
 
     def check_task(
         self,
@@ -747,9 +908,7 @@ class SpecStore:
         st = self.change_status(cid)
         warnings: list[str] = []
         if not st.apply_ready:
-            warnings.append(
-                "Change is not apply_ready (proposal/specs/tasks incomplete)."
-            )
+            warnings.append("Change is not apply_ready (proposal/specs/tasks incomplete).")
         open_tasks = [
             t
             for t in parse_tasks_markdown(
@@ -822,9 +981,7 @@ class SpecStore:
                     requirements_merged += n_reqs
                     domain_had_delta = True
                 except Exception as exc:
-                    merge_errors.append(
-                        f"{self.tool_relpath(delta_spec)}: {exc}"
-                    )
+                    merge_errors.append(f"{self.tool_relpath(delta_spec)}: {exc}")
             if domain_had_delta:
                 main_path.write_text(main_text, encoding="utf-8")
                 merged.append(self.tool_relpath(main_path))
@@ -839,8 +996,7 @@ class SpecStore:
                         "Fill ## ADDED/MODIFIED/REMOVED Requirements with "
                         "### Requirement: titles, then retry. Change was NOT removed."
                     ),
-                    "merge_errors": merge_errors
-                    or ["no mergeable requirements in delta specs"],
+                    "merge_errors": merge_errors or ["no mergeable requirements in delta specs"],
                     "warnings": warnings,
                     "merged_specs": merged,
                     "requirements_merged": requirements_merged,

--- a/core/subagents/async_runner.py
+++ b/core/subagents/async_runner.py
@@ -882,10 +882,16 @@ class AsyncSubAgentRunner:
         child.events.subscribe(_on_event)
         try:
             from core.graph.nodes.react_node import SUBAGENT_CANCELLED_FINAL
-            from core.subagents.react_agent import is_failed_react_result
+            from core.subagents.react_agent import (
+                is_failed_react_result,
+                recover_empty_react_text,
+            )
 
             text = await child.run(task, conversation_id=conv_id, execution_mode="react")
             duration_ms = (time.monotonic() - start_time) * 1000
+            recovered = recover_empty_react_text(text, handle=handle)
+            if recovered:
+                text = recovered
             if (text or "").strip() == SUBAGENT_CANCELLED_FINAL:
                 handle.status = SubAgentStatus.CANCELLED
                 handle.result = SubAgentResult(

--- a/core/subagents/process.py
+++ b/core/subagents/process.py
@@ -1014,8 +1014,14 @@ def _try_process_react_run(
             child.run(task, conversation_id=f"subagent:{config.name}", execution_mode="react")
         )
         from core.graph.nodes.react_node import SUBAGENT_CANCELLED_FINAL
-        from core.subagents.react_agent import is_failed_react_result
+        from core.subagents.react_agent import (
+            is_failed_react_result,
+            recover_empty_react_text,
+        )
 
+        recovered = recover_empty_react_text(text)
+        if recovered:
+            text = recovered
         if (text or "").strip() == SUBAGENT_CANCELLED_FINAL:
             return SubAgentResult(
                 name=config.name,

--- a/core/subagents/react_agent.py
+++ b/core/subagents/react_agent.py
@@ -8,6 +8,7 @@ from typing import Any
 from core.agent_events import (
     AgentEventBus,
     FinalResponseEvent,
+    MaxStepsExtendedEvent,
     ThinkingEvent,
     ToolCallResultEvent,
     ToolCallStartEvent,
@@ -196,6 +197,40 @@ def is_failed_react_result(text: str | None) -> str | None:
     return None
 
 
+def recover_empty_react_text(
+    text: str | None,
+    *,
+    messages: list[dict[str, Any]] | None = None,
+    handle: Any | None = None,
+) -> str | None:
+    """If the model ended empty after successful writes, return a completion summary."""
+    if not is_empty_react_result(text):
+        return None
+    from core.graph.action_honesty import summarize_persist_tools
+
+    summary = summarize_persist_tools(messages)
+    if summary:
+        return summary
+    log = getattr(handle, "activity_log", None) or []
+    writes: list[str] = []
+    persist = {"write_file", "patch_file", "sdd_write_artifact", "sdd_update_spec"}
+    for item in log:
+        if not isinstance(item, dict):
+            continue
+        tool = str(item.get("tool_name") or "").strip()
+        kind = str(item.get("kind") or item.get("type") or "")
+        if tool not in persist:
+            continue
+        if kind not in {"tool_result", "tool"}:
+            continue
+        details = str(item.get("details") or item.get("message") or "").strip()
+        preview = " ".join(details.split())[:240]
+        writes.append(f"- {tool}: {preview}" if preview else f"- {tool}")
+    if not writes:
+        return None
+    return "Work completed via tools (model returned no final text):\n" + "\n".join(writes[-8:])
+
+
 def build_react_subagent(parent: Any, config: SubAgentConfig, task: str) -> Any:
     """Child HolixAgent on LangGraph ReAct; reuses parent services."""
     from core.agent import HolixAgent
@@ -272,6 +307,14 @@ def build_react_subagent(parent: Any, config: SubAgentConfig, task: str) -> Any:
 
 def record_handle_event(handle: SubAgentHandle, event: Any) -> None:
     """Mirror ReAct events onto the sub-agent activity log."""
+    if isinstance(event, MaxStepsExtendedEvent):
+        handle.max_steps = int(event.max_steps or handle.max_steps or 0)
+        handle.record_activity(
+            "step_budget_extended",
+            (f"Step budget +{event.extra_steps} ({event.previous_max_steps} → {event.max_steps})"),
+            steps_taken=handle.steps_taken,
+        )
+        return
     if isinstance(event, ToolCallStartEvent):
         args = event.arguments_raw or str(event.arguments or "")
         handle.record_activity(

--- a/core/subagents/store.py
+++ b/core/subagents/store.py
@@ -28,6 +28,9 @@ SUBAGENT_TOOL_CHOICES: tuple[str, ...] = (
     "math_calculator",
     "sql_query",
     "sql_schema",
+    "sdd_status",
+    "sdd_write_artifact",
+    "sdd_update_spec",
 )
 
 DEFAULT_CUSTOM_TOOLS: list[str] = ["read_file", "list_directory", "grep", "glob", "terminal"]

--- a/core/tools/sdd.py
+++ b/core/tools/sdd.py
@@ -84,9 +84,7 @@ class SddInitTool(BaseTool):
         try:
             root = resolve_project_root(workspace_from_context(), project)
             root.mkdir(parents=True, exist_ok=True)
-            result = SpecStore(root).init(
-                example_domain=example_domain, force=bool(force)
-            )
+            result = SpecStore(root).init(example_domain=example_domain, force=bool(force))
             result["project"] = project or ""
             return result_json(result)
         except Exception as exc:
@@ -121,7 +119,11 @@ class SddReadSpecTool(BaseTool):
     def __init__(self) -> None:
         super().__init__()
         self.name = "sdd_read_spec"
-        self.description = "Read a main domain spec.md by domain name."
+        self.description = (
+            "Read a main domain spec.md under openspec/specs/<domain>/ "
+            "(source of truth, not a change). For a change's proposal / design / "
+            "tasks / delta specs use sdd_read_artifact."
+        )
         self.risk_level = "no"
         self.parameters = {
             "type": "object",
@@ -159,17 +161,13 @@ class SddListChangesTool(BaseTool):
             },
         }
 
-    async def execute(
-        self, project: str = "", include_archive: bool = False, **_: Any
-    ) -> str:
+    async def execute(self, project: str = "", include_archive: bool = False, **_: Any) -> str:
         try:
             return result_json(
                 {
                     "ok": True,
                     "project": project or "",
-                    "changes": _store(project).list_changes(
-                        include_archive=bool(include_archive)
-                    ),
+                    "changes": _store(project).list_changes(include_archive=bool(include_archive)),
                 }
             )
         except Exception as exc:
@@ -311,10 +309,7 @@ class SddStatusTool(BaseTool):
                 cdir = change_dir(store.workspace, change_id)
                 rel = store.tool_relpath(cdir)
                 delta_specs = (
-                    sorted(
-                        store.tool_relpath(p)
-                        for p in (cdir / "specs").rglob("spec.md")
-                    )
+                    sorted(store.tool_relpath(p) for p in (cdir / "specs").rglob("spec.md"))
                     if (cdir / "specs").is_dir()
                     else []
                 )
@@ -336,6 +331,148 @@ class SddStatusTool(BaseTool):
             return _err(exc)
 
 
+class SddReadArtifactTool(BaseTool):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "sdd_read_artifact"
+        self.description = (
+            "Read a change artifact: proposal | design | tasks | specs. "
+            "PREFERRED way to inspect a change — do NOT use read_file for "
+            "openspec/changes/<id> files. Omit artifact to get all files "
+            "(proposal.md, design.md, tasks.md, and delta specs/<domain>/spec.md). "
+            "sdd_read_spec is only for main openspec/specs/, not change deltas."
+        )
+        self.risk_level = "no"
+        self.parameters = {
+            "type": "object",
+            "properties": {
+                "project": _PROJECT_PROP,
+                "change_id": {"type": "string"},
+                "artifact": {
+                    "type": "string",
+                    "description": ("proposal | design | tasks | specs. Empty = all artifacts."),
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "When artifact=specs, delta domain folder name",
+                },
+            },
+            "required": ["change_id"],
+        }
+
+    async def execute(
+        self,
+        change_id: str,
+        artifact: str = "",
+        domain: str = "",
+        project: str = "",
+        **_: Any,
+    ) -> str:
+        try:
+            return result_json(
+                _store(project).read_artifact(
+                    change_id,
+                    artifact,
+                    domain=domain or None,
+                )
+            )
+        except Exception as exc:
+            return _err(exc)
+
+
+class SddUpdateSpecTool(BaseTool):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "sdd_update_spec"
+        self.description = (
+            "Incrementally update a change's delta spec: add, modify, or remove "
+            "one requirement without rewriting the whole file. "
+            "Use this when requirements change — the spec is patched "
+            "(## ADDED / MODIFIED / REMOVED), not replaced. "
+            "Main openspec/specs/<domain>/spec.md is updated later by sdd_archive; "
+            "the tool returns main_preview. "
+            "Pass op+title+body for one requirement, or content= markdown with "
+            "## ADDED/MODIFIED/REMOVED Requirements sections to merge. "
+            "Do NOT use write_file for specs."
+        )
+        self.risk_level = "no"
+        self.parameters = {
+            "type": "object",
+            "properties": {
+                "project": _PROJECT_PROP,
+                "change_id": {"type": "string"},
+                "op": {
+                    "type": "string",
+                    "description": "add | modify | remove (or ADDED/MODIFIED/REMOVED)",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Requirement title (without the 'Requirement:' prefix)",
+                },
+                "body": {
+                    "type": "string",
+                    "description": (
+                        "Requirement text: SHALL + scenarios. Heading is optional — "
+                        "it is added from title when missing."
+                    ),
+                },
+                "content": {
+                    "type": "string",
+                    "description": (
+                        "Optional full delta snippet to merge "
+                        "(## ADDED/MODIFIED/REMOVED Requirements)."
+                    ),
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Delta domain under the change (omit if only one)",
+                },
+            },
+            "required": ["change_id"],
+        }
+
+    async def execute(
+        self,
+        change_id: str,
+        op: str = "",
+        title: str = "",
+        body: str = "",
+        content: str = "",
+        domain: str = "",
+        project: str = "",
+        **_: Any,
+    ) -> str:
+        try:
+            from core.sdd.understanding import gate_blocks_propose
+
+            store = _store(project)
+            block = gate_blocks_propose(store.project_root, change_id)
+            if block:
+                return result_json(
+                    {
+                        "ok": False,
+                        "error": block,
+                        "hint": (
+                            "Research specs first, sdd_update_understanding until "
+                            "score ≥ threshold, then sdd_confirm_understanding "
+                            "before updating specs."
+                        ),
+                    }
+                )
+            return result_json(
+                store.update_spec(
+                    change_id,
+                    op=op,
+                    title=title,
+                    body=body,
+                    content=content,
+                    domain=domain or None,
+                )
+            )
+        except Exception as exc:
+            return _err(exc)
+
+
 class SddWriteArtifactTool(BaseTool):
     def __init__(self) -> None:
         super().__init__()
@@ -343,7 +480,10 @@ class SddWriteArtifactTool(BaseTool):
         self.description = (
             "Write a change artifact: proposal | design | tasks | specs. "
             "PREFERRED way to fill a change — do NOT use write_file/read_file for "
-            "openspec artifacts. There is NO file openspec/changes/<id>/specs.md; "
+            "openspec artifacts. Read them with sdd_read_artifact. "
+            "To add/change/remove individual spec requirements without rewriting "
+            "the whole delta, use sdd_update_spec. "
+            "There is NO file openspec/changes/<id>/specs.md; "
             "artifact=specs writes openspec/changes/<id>/specs/<domain>/spec.md "
             "(pass domain= or omit to use the scaffolded domain). "
             "Other paths: proposal.md, design.md, tasks.md under the change folder. "
@@ -590,9 +730,7 @@ class SddSetApplyModeTool(BaseTool):
             "required": ["change_id", "mode"],
         }
 
-    async def execute(
-        self, change_id: str, mode: str, project: str = "", **_: Any
-    ) -> str:
+    async def execute(self, change_id: str, mode: str, project: str = "", **_: Any) -> str:
         try:
             return result_json(_store(project).set_apply_mode(change_id, mode))
         except Exception as exc:
@@ -643,11 +781,7 @@ class SddApplyTool(BaseTool):
             if not plan.get("ok"):
                 return result_json(plan)
             mode = (plan.get("apply_mode") or "").strip().lower()
-            if (
-                auto_dispatch
-                and mode in ("subagents", "hybrid")
-                and self._parent is not None
-            ):
+            if auto_dispatch and mode in ("subagents", "hybrid") and self._parent is not None:
                 from core.sdd.dispatch import dispatch_change_tasks
 
                 dispatch = await dispatch_change_tasks(
@@ -854,6 +988,8 @@ def register_sdd_tools(registry: Any) -> None:
     registry.register(SddListChangesTool())
     registry.register(SddCreateChangeTool())
     registry.register(SddStatusTool())
+    registry.register(SddReadArtifactTool())
+    registry.register(SddUpdateSpecTool())
     registry.register(SddWriteArtifactTool())
     registry.register(SddSetTaskAssigneeTool())
     registry.register(SddCheckTaskTool())

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -41,6 +41,31 @@ def _env_bool(raw: str | None, *, default: bool) -> bool:
     return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _runtime_whitelist_profile() -> str:
+    """Profile whose ``.env`` owns the terminal allowlist.
+
+    Studio SaaS: the serve process ``HOLIX_PROFILE`` is often ``saas`` while the
+    chat run is bound to the user's Holix profile via ContextVar. Prefer the
+    execution-context name so Settings toggles match ``run_terminal_command``.
+    """
+    try:
+        from core.tools.execution_context import get_conversation_id, get_profile_name
+
+        scoped = (get_profile_name() or "").strip()
+        conv = (get_conversation_id() or "").strip()
+        in_run = bool(conv and conv != "default")
+        if scoped and (in_run or scoped != "default"):
+            return scoped
+    except Exception:
+        pass
+    try:
+        from core.env_loader import active_profile_name
+
+        return active_profile_name()
+    except Exception:
+        return "default"
+
+
 def terminal_whitelist_enabled() -> bool:
     """Whether the terminal allowlist is enforced.
 
@@ -53,14 +78,14 @@ def terminal_whitelist_enabled() -> bool:
     3. Settings singleton default.
     """
     try:
-        from core.env_loader import active_profile_name, read_profile_env_map
+        from core.env_loader import read_profile_env_map
         from core.terminal_whitelist_config import (
             WHITELIST_ENABLED_KEY,
             WHITELIST_ENABLED_LEGACY_KEY,
             read_whitelist_enabled,
         )
 
-        profile = active_profile_name()
+        profile = _runtime_whitelist_profile()
         env_map = read_profile_env_map(profile)
         if WHITELIST_ENABLED_KEY in env_map or WHITELIST_ENABLED_LEGACY_KEY in env_map:
             return read_whitelist_enabled(profile)
@@ -75,7 +100,7 @@ def terminal_whitelist_enabled() -> bool:
 def terminal_whitelist_extra() -> str:
     """Extra allowlist prefixes — profile file first (same reason as enabled)."""
     try:
-        from core.env_loader import active_profile_name, read_profile_env_map
+        from core.env_loader import read_profile_env_map
         from core.terminal_whitelist_config import (
             WHITELIST_EXTRA_KEY,
             WHITELIST_EXTRA_LEGACY_KEY,
@@ -83,7 +108,7 @@ def terminal_whitelist_extra() -> str:
             read_whitelist_extra,
         )
 
-        profile = active_profile_name()
+        profile = _runtime_whitelist_profile()
         env_map = read_profile_env_map(profile)
         if WHITELIST_EXTRA_KEY in env_map or WHITELIST_EXTRA_LEGACY_KEY in env_map:
             return format_command_list(read_whitelist_extra(profile))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+## 1.0.13 — 2026-08-21
+
+SDD artifact read/patch, persist-tool honesty, empty ReAct recovery after writes, and a higher step-budget default.
+
+### Added
+
+- **SDD tools** — `sdd_read_artifact` (proposal/design/tasks/delta specs) and `sdd_update_spec` (add/modify/remove a requirement with a main-spec preview). Status/write/update tools are available to sub-agents.
+- **Step budget** — default `HOLIX_MAX_STEPS_MAX_EXTENSIONS` 3→10; profile can set `max_steps_extend_by` / `max_steps_max_extensions` / `max_steps_hard_cap`.
+
+### Fixed
+
+- **Honesty persist evidence** — `write_file` / `patch_file` / `sdd_update_spec` count as filled artifacts; honesty-nudge user turns no longer wipe that evidence.
+- **Empty ReAct sub-agents** — after successful writes, an empty model reply is summarized as the final instead of failing the job.
+- **Terminal whitelist** — `HOLIX_TERMINAL_COMMAND_WHITELIST` comes from the execution profile `.env`, not the Studio process env.
+
+### Tests
+
+- Delta spec patch add/modify/remove, `sdd_read_artifact` / `sdd_update_spec` tools.
+- Honesty `write_file` evidence and nudge-not-a-new-request.
+- Sub-agent empty-final recovery after persist tools.
+- Terminal whitelist follows the conversation profile.
+
 ## 1.0.12 — 2026-08-20
 
 `uv tool install "Holix[all]"` installs the latest release, and `holix --version` prints the package version.

--- a/docs/en/CONFIGURATION.md
+++ b/docs/en/CONFIGURATION.md
@@ -320,7 +320,7 @@ When `max_steps` is hit, Holix may grant more steps if the agent is still making
 |----------|---------|--------|
 | `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Enable auto-extension |
 | `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Steps per extension |
-| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `3` | Max extensions per run |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `10` | Max extensions per run |
 | `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Absolute cap (`0` = derived) |
 
 ## Subagents & supervisor

--- a/docs/en/EXECUTION_MODES.md
+++ b/docs/en/EXECUTION_MODES.md
@@ -357,7 +357,7 @@ When the agent hits `max_steps`, Holix does not always stop immediately:
 | `max_steps` | `90` (runtime; profile may override) | Base ReAct/graph step budget |
 | `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Allow auto-extension |
 | `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Steps added per extension |
-| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `3` | Max extensions per run |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `10` | Max extensions per run |
 | `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Absolute cap (`0` = base + extend×N) |
 
 ---
@@ -370,8 +370,8 @@ With `enable_subagents: true`, `plan_and_execute` can run **waves** of sub-agent
 delegate → collect → supervisor → (rework failed jobs?) → react synthesis
 ```
 
-- **Runtime supervisor** — mid-job loop/hang → inject guidance into the same job.  
-- **Graph supervisor** — after collect, re-delegate failed types with repair instructions.  
+- **Runtime supervisor** — mid-job loop/hang → inject guidance into the same job.
+- **Graph supervisor** — after collect, re-delegate failed types with repair instructions.
 
 Details: [SUBAGENTS.md](SUBAGENTS.md#supervisor).
 

--- a/docs/en/SDD.md
+++ b/docs/en/SDD.md
@@ -1,6 +1,6 @@
 # Spec-Driven Development (SDD) in Holix
 
-> **Idea:** specify first, implement second, archive into main specs last.  
+> **Idea:** specify first, implement second, archive into main specs last.
 > Layout is compatible with [OpenSpec](https://github.com/javded-itres/OpenSpec).
 
 This page covers: why SDD, the `openspec/` tree, `sdd_*` tools, `/spec` slash commands, skills, **apply modes**, step-by-step **examples** (CLI/TUI and agent-driven), multi-project, understanding gate, and troubleshooting.
@@ -62,9 +62,11 @@ repo/
 |------|---------|
 | `sdd_list_projects` | Projects that already have `openspec/` |
 | `sdd_init` | Scaffold layout |
-| `sdd_list_specs` / `sdd_read_spec` | Main specs |
+| `sdd_list_specs` / `sdd_read_spec` | Main specs (`openspec/specs/`) |
 | `sdd_list_changes` | Active / archived changes |
 | `sdd_create_change` | Scaffold change (**stubs only**) |
+| `sdd_read_artifact` | Read change proposal / design / tasks / delta specs |
+| `sdd_update_spec` | Add / modify / remove a requirement in the change delta spec |
 | `sdd_write_artifact` | proposal \| design \| tasks \| specs |
 | `sdd_status` | Overview or one change + paths |
 | `sdd_update_understanding` / `sdd_confirm_understanding` | Understanding gate |
@@ -243,11 +245,11 @@ Main does 1.1; 2.1 and 2.2 run in parallel afterward.
 
 Before full propose (when enabled):
 
-1. Read main + archived specs  
-2. Project context / `HOLIX.md` (run `/init` if weak)  
-3. `sdd_update_understanding` with honest score  
-4. Residual questions only  
-5. `sdd_confirm_understanding` when score ≥ threshold  
+1. Read main + archived specs
+2. Project context / `HOLIX.md` (run `/init` if weak)
+3. `sdd_update_understanding` with honest score
+4. Residual questions only
+5. `sdd_confirm_understanding` when score ≥ threshold
 6. Then `sdd_write_artifact`
 
 ---

--- a/docs/ru/CONFIGURATION.md
+++ b/docs/ru/CONFIGURATION.md
@@ -205,7 +205,7 @@ providers:
 |------------|---------|--------|
 | `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Авто-расширение при прогрессе |
 | `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Шагов за расширение |
-| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `3` | Сколько раз |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `10` | Сколько раз |
 | `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Жёсткий потолок (`0` = вычисляется) |
 
 ## Субагенты и supervisor

--- a/docs/ru/EXECUTION_MODES.md
+++ b/docs/ru/EXECUTION_MODES.md
@@ -72,8 +72,8 @@ flowchart LR
 memory → meta → react ⇄ tools → reflect ⇄ react → finalize
 ```
 
-1. **Meta-agent** (по умолчанию вкл.) — короткая стратегическая подсказка.  
-2. Цикл ReAct / tools.  
+1. **Meta-agent** (по умолчанию вкл.) — короткая стратегическая подсказка.
+2. Цикл ReAct / tools.
 3. **Reflexion** — оценка черновика; при низком качестве — verbal feedback и повтор ReAct (до `max_refinement_iterations`).
 
 ### Когда использовать
@@ -332,9 +332,9 @@ memory → meta → react ⇄ tools → reflect ⇄ react → finalize
 
 Holix использует цикл в стиле **Reflexion** (не Tree/Graph of Thoughts):
 
-1. Черновик финального ответа.  
-2. Оценка качества (+ опционально траектория tools).  
-3. Ниже порога → **verbal reflection** в сообщения и ещё один проход ReAct.  
+1. Черновик финального ответа.
+2. Оценка качества (+ опционально траектория tools).
+3. Ниже порога → **verbal reflection** в сообщения и ещё один проход ReAct.
 4. Эпизоды reflection в LTM при доступной памяти.
 
 | Переменная | По умолчанию | Эффект |
@@ -352,8 +352,8 @@ Holix использует цикл в стиле **Reflexion** (не Tree/Graph
 
 При достижении `max_steps` Holix не всегда останавливается сразу:
 
-1. Проверка прогресса (tools, loop, ошибки).  
-2. **Работает + релевантно** → +шаги (`max_steps_extend_by`).  
+1. Проверка прогресса (tools, loop, ошибки).
+2. **Работает + релевантно** → +шаги (`max_steps_extend_by`).
 3. **Завис / thrash** → стоп (или guidance supervisor у субагентов).
 
 | Переменная | По умолчанию | Эффект |
@@ -361,7 +361,7 @@ Holix использует цикл в стиле **Reflexion** (не Tree/Graph
 | `max_steps` | `90` (runtime; профиль может переопределить) | Базовый бюджет |
 | `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Авто-расширение |
 | `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Шагов за раз |
-| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `3` | Сколько раз |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `10` | Сколько раз |
 | `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Жёсткий потолок (`0` = base+extend×N) |
 
 ---

--- a/docs/ru/SDD.md
+++ b/docs/ru/SDD.md
@@ -1,6 +1,6 @@
 # Spec-Driven Development (SDD) в Holix
 
-> **Идея:** сначала спецификация и задачи, потом код, в конце — merge в main specs.  
+> **Идея:** сначала спецификация и задачи, потом код, в конце — merge в main specs.
 > Формат совместим с [OpenSpec](https://github.com/javded-itres/OpenSpec).
 
 На этой странице: зачем SDD, дерево `openspec/`, все tools `sdd_*`, slash `/spec`, skills, **режимы apply**, пошаговые **примеры** (CLI/TUI и через агента), multi-project, understanding gate, troubleshooting.
@@ -72,9 +72,11 @@ repo/
 |------|------------|
 | `sdd_list_projects` | Список project roots с `openspec/` |
 | `sdd_init` | Scaffold `openspec/` (+ example domain) |
-| `sdd_list_specs` / `sdd_read_spec` | Main specs (source of truth) |
+| `sdd_list_specs` / `sdd_read_spec` | Main specs (`openspec/specs/`) |
 | `sdd_list_changes` | Активные (и archive) changes |
 | `sdd_create_change` | Scaffold change (stubs only!) |
+| `sdd_read_artifact` | Читать proposal / design / tasks / delta specs change |
+| `sdd_update_spec` | Дополнить / изменить / удалить требование в delta-спеке change |
 | `sdd_write_artifact` | proposal / design / tasks / specs |
 | `sdd_status` | Overview или один change + paths |
 | `sdd_update_understanding` / `sdd_confirm_understanding` | Understanding gate |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.12"
+version = "1.0.13"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_action_honesty.py
+++ b/tests/test_action_honesty.py
@@ -539,6 +539,69 @@ def test_write_file_success_allows_claim() -> None:
     assert successful_tools_since_last_user(messages) == ["write_file"]
 
 
+def test_write_file_counts_as_sdd_artifact_evidence() -> None:
+    """Analysis agents persist docs with write_file — that is enough for SDD claims."""
+    user = (
+        "SDD change `shopapi-1` created in project `shop_api`.\n"
+        "MUST call sdd_write_artifact for proposal, design, delta specs, and tasks."
+    )
+    messages = [
+        {"role": "user", "content": user},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "w1",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "w1",
+            "content": "Wrote 15230 bytes to openspec/changes/shopapi-1/analysis/analysis-coder.md",
+        },
+    ]
+    claim = "Готово. Заполнил analysis в openspec/changes/shopapi-1/analysis/analysis-coder.md"
+    assert is_sdd_fill_request(user)
+    assert claims_sdd_artifacts_filled(claim)
+    assert not lacks_evidence_for_claim(claim, messages)
+    assert not sdd_fill_requires_tools(messages, user_input=user)
+    assert not should_nudge_false_completion(
+        {"honesty_nudge_count": 0, "user_input": user},
+        final_response=claim,
+        messages=messages,
+    )
+
+
+def test_honesty_nudge_does_not_wipe_write_file_evidence() -> None:
+    messages = [
+        {"role": "user", "content": "Write the analysis docs"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "w1",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "w1",
+            "content": "Wrote 2000 bytes to analysis.md",
+        },
+        {"role": "user", "content": "[Action honesty] You stated that work was completed"},
+        {"role": "assistant", "content": "Готово, файл analysis.md создан."},
+    ]
+    assert successful_tools_since_last_user(messages) == ["write_file"]
+    assert not lacks_evidence_for_claim("Готово, файл analysis.md создан.", messages)
+
+
 def test_failed_tool_does_not_count() -> None:
     messages = [
         {"role": "user", "content": "Удали проекты"},

--- a/tests/test_confirmation.py
+++ b/tests/test_confirmation.py
@@ -123,7 +123,14 @@ class TestRiskClassifier:
     # ── SDD: auto-allow all except task launch ──
 
     def test_sdd_read_tools_are_no_risk(self):
-        for name in ("sdd_list_projects", "sdd_status", "sdd_read_spec", "sdd_write_artifact"):
+        for name in (
+            "sdd_list_projects",
+            "sdd_status",
+            "sdd_read_spec",
+            "sdd_read_artifact",
+            "sdd_update_spec",
+            "sdd_write_artifact",
+        ):
             tool = self._make_tool(name, "medium")  # classifier overrides declarative
             assessment = self.classifier.classify(name, tool, {})
             assert assessment.risk_level == RiskLevel.NO, name

--- a/tests/test_sdd.py
+++ b/tests/test_sdd.py
@@ -7,8 +7,25 @@ from pathlib import Path
 import pytest
 from core.sdd.apply_mode import apply_mode_prompt_text, normalize_apply_mode, save_apply_mode
 from core.sdd.merge import merge_delta_into_main, patch_delta_spec
+from core.sdd.paths import confined_under, validate_change_id
 from core.sdd.store import SpecStore
 from core.sdd.tasks import parse_tasks_markdown, set_task_assignee, set_task_done
+
+
+def test_validate_change_id_rejects_path_escape() -> None:
+    with pytest.raises(ValueError):
+        validate_change_id("../etc")
+    with pytest.raises(ValueError):
+        validate_change_id("foo/bar")
+
+
+def test_confined_under_rejects_escape(tmp_path: Path) -> None:
+    root = tmp_path / "openspec"
+    root.mkdir()
+    inside = confined_under(root, root / "changes" / "ok")
+    assert str(inside).startswith(str(root.resolve()))
+    with pytest.raises(ValueError, match="escapes"):
+        confined_under(root, tmp_path / "outside")
 
 
 def test_parse_tasks_with_assignees():

--- a/tests/test_sdd.py
+++ b/tests/test_sdd.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from core.sdd.apply_mode import apply_mode_prompt_text, normalize_apply_mode, save_apply_mode
-from core.sdd.merge import merge_delta_into_main
+from core.sdd.merge import merge_delta_into_main, patch_delta_spec
 from core.sdd.store import SpecStore
 from core.sdd.tasks import parse_tasks_markdown, set_task_assignee, set_task_done
 
@@ -183,6 +183,45 @@ Third
     assert "First" not in out
 
 
+def test_patch_delta_spec_add_modify_remove():
+    stub = """# Delta: auth
+
+## ADDED Requirements
+
+### Requirement: login-flow capability
+The system SHALL …
+
+#### Scenario: Happy path
+- **GIVEN** …
+- **WHEN** …
+- **THEN** …
+"""
+    added = patch_delta_spec(
+        stub,
+        op="add",
+        title="OAuth login",
+        body="The system SHALL support OAuth.\n\n#### Scenario: Redirect\n- **GIVEN** a\n- **WHEN** b\n- **THEN** c\n",
+    )
+    assert "OAuth login" in added
+    assert "login-flow capability" not in added
+    assert "## ADDED Requirements" in added
+    modified = patch_delta_spec(
+        added,
+        op="modify",
+        title="Login exists",
+        body="The system SHALL support password and OAuth.\n",
+    )
+    assert "## MODIFIED Requirements" in modified
+    assert "password and OAuth" in modified
+    removed = patch_delta_spec(modified, op="remove", title="Logout exists")
+    assert "## REMOVED Requirements" in removed
+    assert "Logout exists" in removed
+    # Cancelling an ADDED req must not emit REMOVED
+    cancelled = patch_delta_spec(added, op="remove", title="OAuth login")
+    assert "OAuth login" not in cancelled
+    assert "## REMOVED Requirements" not in cancelled
+
+
 def test_archive_nested_spec_merges_into_parent_domain(tmp_path: Path):
     store = SpecStore(tmp_path)
     store.init(example_domain="auth")
@@ -199,14 +238,7 @@ def test_archive_nested_spec_merges_into_parent_domain(tmp_path: Path):
         domain="auth",
     )
     nested = (
-        tmp_path
-        / "openspec"
-        / "changes"
-        / "nested-merge"
-        / "specs"
-        / "auth"
-        / "notes"
-        / "spec.md"
+        tmp_path / "openspec" / "changes" / "nested-merge" / "specs" / "auth" / "notes" / "spec.md"
     )
     nested.parent.mkdir(parents=True, exist_ok=True)
     nested.write_text(
@@ -518,24 +550,18 @@ def test_accept_request_understanding_unlock_modes(tmp_path: Path):
     assert und is not None
     assert und.status == "clarifying" and und.score == 0
 
-    seeded = accept_request_understanding(
-        tmp_path, "feat", request="Add feature X", unlock=False
-    )
+    seeded = accept_request_understanding(tmp_path, "feat", request="Add feature X", unlock=False)
     assert seeded.status == "clarifying"
     assert seeded.score == 0
     assert gate_blocks_propose(tmp_path, "feat") is not None
 
-    unlocked = accept_request_understanding(
-        tmp_path, "feat", request="Add feature X", unlock=True
-    )
+    unlocked = accept_request_understanding(tmp_path, "feat", request="Add feature X", unlock=True)
     assert unlocked.status == "confirmed"
     assert unlocked.score >= unlocked.threshold
     assert gate_blocks_propose(tmp_path, "feat") is None
 
     # create with request already seeds history via init_understanding
-    init_understanding(
-        tmp_path, "other", enabled=True, threshold=75, request="Need Y"
-    )
+    init_understanding(tmp_path, "other", enabled=True, threshold=75, request="Need Y")
     other = load_understanding(tmp_path, "other")
     assert other is not None
     assert other.score == 0 and other.status == "clarifying"
@@ -543,6 +569,8 @@ def test_accept_request_understanding_unlock_modes(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_sdd_tools_register_and_init(tmp_path: Path):
+    import json
+
     from core.tools.execution_context import reset_workspace_scope, workspace_scope
     from core.tools.registry import ToolRegistry
 
@@ -559,6 +587,34 @@ async def test_sdd_tools_register_and_init(tmp_path: Path):
         result = await reg.tools["sdd_init"].execute()
         assert '"ok"' in result
         assert (tmp_path / "openspec" / "config.yaml").is_file()
+        assert "sdd_read_artifact" in reg.tools
+        store = SpecStore(tmp_path)
+        store.create_change("read-me", domain="example", request="demo")
+        store.write_artifact(
+            "read-me",
+            "proposal",
+            "# Proposal\n\n## Why\nNeed it.\n\n## What\nDo it.\n\n## Impact\nLow.\n",
+        )
+        raw = await reg.tools["sdd_read_artifact"].execute(change_id="read-me", artifact="proposal")
+        data = json.loads(raw)
+        assert data["ok"] is True
+        assert "Need it." in data["content"]
+        all_raw = await reg.tools["sdd_read_artifact"].execute(change_id="read-me")
+        all_data = json.loads(all_raw)
+        assert all_data["ok"] is True
+        assert "Need it." in all_data["artifacts"]["proposal"]["content"]
+        assert "sdd_update_spec" in reg.tools
+        patched = json.loads(
+            await reg.tools["sdd_update_spec"].execute(
+                change_id="read-me",
+                op="add",
+                title="OAuth login",
+                body="The system SHALL support OAuth.\n\n#### Scenario: OK\n- **GIVEN** a\n- **WHEN** b\n- **THEN** c\n",
+            )
+        )
+        assert patched["ok"] is True
+        assert "OAuth login" in patched["content"]
+        assert "main_preview" in patched
     finally:
         reset_workspace_scope(tokens)
 

--- a/tests/test_subagent_react.py
+++ b/tests/test_subagent_react.py
@@ -20,6 +20,7 @@ from core.subagents.react_agent import (
     attach_subagent_runtime,
     is_empty_react_result,
     is_failed_react_result,
+    recover_empty_react_text,
     resolve_subagent_context_window,
 )
 from core.subagents.supervisor import (
@@ -193,6 +194,62 @@ def test_main_agent_empty_reply_is_not_subagent_retry() -> None:
         )
         is None
     )
+
+
+def test_subagent_empty_reply_completes_after_writes() -> None:
+    agent = SimpleNamespace(
+        subagent_system_prompt="You are analysis-coder", emit=lambda *_a, **_k: None
+    )
+    messages = [
+        {"role": "user", "content": "Write analysis.md"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "w1",
+                    "function": {"name": "write_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "w1",
+            "content": "Wrote 15230 bytes to analysis.md",
+        },
+        {"role": "system", "content": EMPTY_FINAL_CONTINUE},
+        {"role": "system", "content": EMPTY_FINAL_CONTINUE},
+        {"role": "system", "content": EMPTY_FINAL_CONTINUE},
+    ]
+    out = _maybe_subagent_empty_retry(
+        agent=agent,
+        conversation_id="subagent:analysis-coder",
+        messages=messages,
+        step_count=6,
+        final_response="",
+    )
+    assert out is not None
+    assert out["is_final"] is True
+    assert "write_file" in (out["final_response"] or "")
+    assert "analysis.md" in (out["final_response"] or "")
+
+
+def test_recover_empty_react_text_from_handle_writes() -> None:
+    handle = SubAgentHandle(name="analysis-coder", config=SubAgentConfig(name="analysis-coder"))
+    handle.activity_log = [
+        {
+            "kind": "tool_result",
+            "tool_name": "write_file",
+            "details": "Wrote 15230 bytes to analysis-coder.md",
+        }
+    ]
+    text = recover_empty_react_text(
+        "Agent completed without producing a final response.",
+        handle=handle,
+    )
+    assert text
+    assert "write_file" in text
+    assert is_failed_react_result(text) is None
 
 
 def test_subagent_empty_reply_fails_after_three_continues() -> None:

--- a/tests/test_terminal_safety.py
+++ b/tests/test_terminal_safety.py
@@ -122,6 +122,51 @@ async def test_terminal_runs_shell_chaining(
 
 
 @pytest.mark.asyncio
+async def test_terminal_whitelist_follows_execution_profile(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Studio serve HOLIX_PROFILE=saas must not override the user profile toggle."""
+    from cli.core import ProfileManager
+    from core.tools.execution_context import (
+        conversation_scope,
+        profile_scope,
+        reset_conversation_scope,
+        reset_profile_scope,
+    )
+    from core.tools.terminal import TerminalTool
+
+    from config import settings
+
+    monkeypatch.setenv("HOLIX_HOME", str(tmp_path))
+    manager = ProfileManager()
+    manager.create_profile("alice", inherit_global=False)
+    env = tmp_path / "profiles" / "alice" / ".env"
+    env.parent.mkdir(parents=True, exist_ok=True)
+    env.write_text("HOLIX_TERMINAL_COMMAND_WHITELIST=false\n", encoding="utf-8")
+
+    monkeypatch.setenv("HOLIX_PROFILE", "saas")
+    monkeypatch.setenv("HOLIX_TERMINAL_COMMAND_WHITELIST", "true")
+    monkeypatch.setenv("TERMINAL_COMMAND_WHITELIST", "true")
+    monkeypatch.setattr(settings, "enable_terminal_tool", True)
+    monkeypatch.setattr(settings, "terminal_command_whitelist", True)
+    from core.tools import terminal as terminal_mod
+
+    monkeypatch.setattr(terminal_mod.settings, "enable_terminal_tool", True)
+    monkeypatch.setattr(terminal_mod.settings, "terminal_command_whitelist", True)
+
+    prof_tok = profile_scope("alice")
+    conv_tok = conversation_scope("studio-tab")
+    try:
+        tool = TerminalTool()
+        out = await tool.execute("docker ps")
+        assert "not in whitelist" not in out.lower()
+    finally:
+        reset_conversation_scope(conv_tok)
+        reset_profile_scope(prof_tok)
+
+
+@pytest.mark.asyncio
 async def test_terminal_tool_blocks_dangerous(monkeypatch: pytest.MonkeyPatch) -> None:
     from core.tools import terminal as terminal_mod
     from core.tools.terminal import TerminalTool

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.12"
+version = "1.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix 1.0.13.

SDD artifact read/patch, persist-tool honesty, empty ReAct recovery after writes, higher step-budget default, and terminal whitelist from the execution profile.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py
- [x] docs/CHANGELOG.md has section 1.0.13
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.0.13` (creates GitHub Release + PyPI).