### PR TITLE
feat(telegram,max): live sub-agent watch, process pins, honesty retry

### DIFF
--- a/cli/commands/subagent.py
+++ b/cli/commands/subagent.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import typer
 
-from cli.utils.rich_console import print_error, print_info, print_success
+from cli.utils.rich_console import console, print_error, print_info, print_success
 
 app = typer.Typer(help="Spawn and manage background sub-agents", no_args_is_help=True)
 
@@ -85,7 +85,9 @@ def subagent_spawn(
                 if text:
                     print_info(text)
             elif wait:
-                print_info(f"Job {handle.name} still running. Try: holix subagent result {handle.name} --wait")
+                print_info(
+                    f"Job {handle.name} still running. Try: holix subagent result {handle.name} --wait"
+                )
             return 0
         except Exception as exc:
             print_error(f"spawn failed: {exc}")
@@ -99,22 +101,13 @@ def subagent_spawn(
 
 @app.command("list")
 def subagent_list(ctx: typer.Context) -> None:
-    """List running sub-agents."""
+    """List running sub-agents for this profile (Telegram, Studio, CLI, gateway)."""
     profile = _profile(ctx)
-    config = _config(ctx)
+    from core.subagents.manager import format_jobs_status_text
+    from core.subagents.runtime_registry import list_jobs
 
-    async def _run() -> None:
-        from cli.shared.commands.subagent_commands import run_subagents_command
-
-        agent, container = await _with_agent(config)
-        try:
-            host = _CliSubagentHost(agent, profile)
-            await run_subagents_command(host, "/subagents")
-        finally:
-            if container is not None:
-                await container.close()
-
-    asyncio.run(_run())
+    jobs = list_jobs(profile, include_done=True)
+    console.print(format_jobs_status_text(jobs, profile=profile), markup=False)
 
 
 @app.command("result")

--- a/cli/main.py
+++ b/cli/main.py
@@ -36,17 +36,19 @@ _HEAVY_ROOT_COMMANDS = frozenset({"chat", "run", "tui", "skills", "memory", "sub
 
 def _needs_heavy_commands(argv: list[str]) -> bool:
     """Return True when argv invokes agent/memory-heavy CLI modules."""
-    if not argv or argv[0].startswith("-"):
+    if not argv:
         return False
-    root = argv[0]
-    if root in _HEAVY_ROOT_COMMANDS:
-        return True
-    # ``holix --profile X chat`` / ``holix -p X run ...``
-    for index, token in enumerate(argv):
-        if token in {"--profile", "-p"} and index + 1 < len(argv):
+    skip_next = False
+    for token in argv:
+        if skip_next:
+            skip_next = False
             continue
-        if token in _HEAVY_ROOT_COMMANDS:
-            return True
+        if token in {"--profile", "-p", "--profile-key", "--unlock-key"}:
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        return token in _HEAVY_ROOT_COMMANDS
     return False
 
 
@@ -138,6 +140,7 @@ def _app_callback(
         None,
         "--profile",
         "-p",
+        envvar="HOLIX_PROFILE",
         help="Profile name (required in production; implicit default is dev-only)",
     ),
     profile_key: str | None = typer.Option(

--- a/core/graph/modes/react.py
+++ b/core/graph/modes/react.py
@@ -38,6 +38,7 @@ def build_react_graph(
         route_after_react,
         {
             "tool_execution": "tool_execution",
+            "react": "react",
             "reflect": "reflect",
             "finalize": "finalize",
         },

--- a/core/graph/routers.py
+++ b/core/graph/routers.py
@@ -17,6 +17,11 @@ def route_after_react(state: HolixGraphState) -> str:
 
     if tool_calls and not is_final and step_count < max_steps:
         return "tool_execution"
+    # Honesty / empty-final retries keep the turn open (is_final=False, no tools).
+    # Sending those to reflect immediately finalizes: reflect_node treats an
+    # empty final_response as "nothing to evaluate" and clears needs_refinement.
+    if not is_final and not tool_calls and step_count < max_steps:
+        return "react"
     # Draft answer or step budget exhausted → Reflexion evaluate (may loop to react)
     if is_final or step_count >= max_steps or not tool_calls:
         return "reflect"

--- a/core/i18n/messages.py
+++ b/core/i18n/messages.py
@@ -47,6 +47,16 @@ MESSAGES: dict[str, dict[str, str]] = {
         "tg.subagents_picker_body": (
             "When off, the main agent cannot delegate work (delegate_to_subagent / plan waves)."
         ),
+        "tg.subagent_watch.pick": "Sub-agents — tap one to watch live",
+        "tg.subagent_watch.none": "No sub-agents in this profile.",
+        "tg.subagent_watch.title": "Watching {name} [{status}] · steps {steps}",
+        "tg.subagent_watch.no_steps": "No steps yet…",
+        "tg.subagent_watch.stop": "⏹ Stop sub-agent",
+        "tg.subagent_watch.exit": "✕ Exit watch",
+        "tg.subagent_watch.closed": "Watch closed.",
+        "tg.subagent_watch.gone": "Sub-agent is no longer available.",
+        "tg.subagent_watch.stopped": "Sub-agent stop requested.",
+        "tg.subagent_watch.busy": "Already watching another sub-agent — switched.",
         "tg.reflexion": "Reflexion: {state}",
         "tg.reflexion_on": "Reflexion On",
         "tg.reflexion_off": "Off",
@@ -676,6 +686,16 @@ When finished, confirm the absolute path written and give a 5–10 line summary 
             "Когда выключено, главный агент не может делегировать задачи "
             "(delegate_to_subagent / волны в plan)."
         ),
+        "tg.subagent_watch.pick": "Субагенты — нажмите, чтобы смотреть вживую",
+        "tg.subagent_watch.none": "В этом профиле нет субагентов.",
+        "tg.subagent_watch.title": "Просмотр {name} [{status}] · шаги {steps}",
+        "tg.subagent_watch.no_steps": "Шагов пока нет…",
+        "tg.subagent_watch.stop": "⏹ Остановить субагента",
+        "tg.subagent_watch.exit": "✕ Выйти из просмотра",
+        "tg.subagent_watch.closed": "Просмотр закрыт.",
+        "tg.subagent_watch.gone": "Субагент больше недоступен.",
+        "tg.subagent_watch.stopped": "Остановка субагента запрошена.",
+        "tg.subagent_watch.busy": "Уже смотрите другого субагента — переключили.",
         "tg.reflexion": "Reflexion: {state}",
         "tg.reflexion_on": "Reflexion Вкл",
         "tg.reflexion_off": "Выкл",

--- a/core/runtime/background_process.py
+++ b/core/runtime/background_process.py
@@ -26,6 +26,29 @@ from core.runtime.background_process_health import (
 
 logger = logging.getLogger(__name__)
 
+_process_stop_hooks: list[Any] = []
+
+
+def register_process_stop_hook(hook: Any) -> None:
+    """Notify messengers when a background process is stopped (any registry)."""
+    if hook not in _process_stop_hooks:
+        _process_stop_hooks.append(hook)
+
+
+def unregister_process_stop_hook(hook: Any) -> None:
+    try:
+        _process_stop_hooks.remove(hook)
+    except ValueError:
+        pass
+
+
+def _notify_process_stopped(rec: BackgroundProcessRecord) -> None:
+    for hook in list(_process_stop_hooks):
+        try:
+            hook(rec)
+        except Exception:
+            logger.debug("background process stop hook failed", exc_info=True)
+
 
 @dataclass(slots=True)
 class BackgroundProcessRecord:
@@ -95,9 +118,7 @@ class BackgroundProcessRegistry:
         for rec in candidates:
             if rec.process_id in seen_ids:
                 continue
-            port_conflict = bool(
-                target_ports and set(self._ports_for_record(rec)) & target_ports
-            )
+            port_conflict = bool(target_ports and set(self._ports_for_record(rec)) & target_ports)
             if port_conflict:
                 to_stop.append(rec)
                 seen_ids.add(rec.process_id)
@@ -265,7 +286,9 @@ class BackgroundProcessRegistry:
         await self._stop_all_records([rec])
         return rec
 
-    async def stop_for_scope(self, *, profile: str, conversation_id: str) -> BackgroundProcessRecord | None:
+    async def stop_for_scope(
+        self, *, profile: str, conversation_id: str
+    ) -> BackgroundProcessRecord | None:
         """Stop the newest running process in this chat session (or most recent if all stopped)."""
         rec = self.active_for_scope(profile=profile, conversation_id=conversation_id)
         if rec is None:
@@ -308,7 +331,9 @@ class BackgroundProcessRegistry:
             await asyncio.to_thread(force_free_ports, all_ports)
         return candidates[0]
 
-    def active_for_scope(self, *, profile: str, conversation_id: str) -> BackgroundProcessRecord | None:
+    def active_for_scope(
+        self, *, profile: str, conversation_id: str
+    ) -> BackgroundProcessRecord | None:
         for rec in self.list_for_scope(profile=profile, conversation_id=conversation_id):
             if rec.is_running():
                 return rec
@@ -422,6 +447,7 @@ class BackgroundProcessRegistry:
             logger.warning("Failed to remove background process from index: %s", exc)
         async with self._lock:
             self._records.pop(rec.process_id, None)
+        _notify_process_stopped(rec)
 
     def hydrate_from_disk(self, profile: str | None = None) -> int:
         """Load process rows started by other Holix processes (Telegram/Studio/CLI).
@@ -439,8 +465,7 @@ class BackgroundProcessRegistry:
             profiles.add((profile or "").strip() or "default")
         else:
             profiles.update(
-                (rec.profile or "default").strip() or "default"
-                for rec in self._records.values()
+                (rec.profile or "default").strip() or "default" for rec in self._records.values()
             )
             if not profiles:
                 profiles.update(iter_profile_names_with_index())
@@ -489,7 +514,9 @@ class BackgroundProcessRegistry:
         self.hydrate_from_disk(profile)
         return sorted(self._records_for_profile(profile), key=lambda r: r.started_at, reverse=True)
 
-    def list_for_scope(self, *, profile: str, conversation_id: str) -> list[BackgroundProcessRecord]:
+    def list_for_scope(
+        self, *, profile: str, conversation_id: str
+    ) -> list[BackgroundProcessRecord]:
         self.hydrate_from_disk(profile)
         scope = self._scope_key(profile, conversation_id)
         out: list[BackgroundProcessRecord] = []

--- a/core/runtime/process_script_key.py
+++ b/core/runtime/process_script_key.py
@@ -1,0 +1,90 @@
+"""Identity of a background process by script / npm task, not by OS pid."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+from core.platform_compat import IS_WINDOWS
+
+_SCRIPT_EXT = {
+    ".py",
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".tsx",
+    ".jsx",
+    ".sh",
+    ".bash",
+    ".rb",
+    ".go",
+    ".php",
+}
+_NPM_RUN = re.compile(
+    r"\b(?:npm|pnpm|yarn|bun)(?:\.cmd)?(?:\s+run)?\s+([@\w:./-]+)",
+    re.I,
+)
+_PY_MODULE = re.compile(
+    r"\bpython(?:\d+(?:\.\d+)?)?\s+-m\s+([\w.]+)",
+    re.I,
+)
+_ASGI = re.compile(
+    r"\b(?:uvicorn|gunicorn|hypercorn|granian)\s+([\w.:]+)",
+    re.I,
+)
+_UV_RUN = re.compile(r"\buv\s+run\s+(?:--\S+\s+)*([\w./-]+)", re.I)
+
+
+def process_script_key(command: str, *, cwd: str = "") -> str:
+    """Stable key so the same script replaces its pin; different scripts coexist."""
+    normalized = " ".join((command or "").split())
+    identity = _script_identity(normalized) or normalized.lower()
+    cwd_key = ""
+    raw_cwd = (cwd or "").strip()
+    if raw_cwd:
+        try:
+            cwd_key = str(Path(raw_cwd).expanduser().resolve())
+        except OSError:
+            cwd_key = raw_cwd
+    return f"{cwd_key}::{identity}" if cwd_key else identity
+
+
+def _script_identity(command: str) -> str:
+    if not command:
+        return ""
+    npm = _NPM_RUN.search(command)
+    if npm:
+        name = npm.group(1).strip().lower()
+        if name not in {"run", "exec", "dlx"}:
+            return f"npm:{name}"
+    pym = _PY_MODULE.search(command)
+    if pym:
+        return f"py-m:{pym.group(1).strip().lower()}"
+    asgi = _ASGI.search(command)
+    if asgi:
+        return f"asgi:{asgi.group(1).strip().lower()}"
+    uv = _UV_RUN.search(command)
+    if uv:
+        token = uv.group(1).strip()
+        if token:
+            return Path(token).name.lower()
+    try:
+        argv = shlex.split(command, posix=not IS_WINDOWS)
+    except ValueError:
+        argv = command.split()
+    for token in argv:
+        if not token or token.startswith("-"):
+            continue
+        suffix = Path(token).suffix.lower()
+        if suffix in _SCRIPT_EXT:
+            return Path(token).name.lower()
+    for token in argv:
+        if not token or token.startswith("-"):
+            continue
+        name = Path(token).name.lower()
+        if name in {"python", "python3", "node", "nodejs", "bash", "sh", "uv", "poetry"}:
+            continue
+        return name
+    return command.lower()

--- a/core/subagents/manager.py
+++ b/core/subagents/manager.py
@@ -26,6 +26,70 @@ from core.subagents.process import SubAgentProcessManager, SubAgentProcessSpawnE
 
 logger = logging.getLogger(__name__)
 
+
+def format_jobs_status_text(
+    jobs: list[dict[str, Any]],
+    *,
+    html: bool = False,
+    pending_questions: list[dict[str, Any]] | None = None,
+    profile: str | None = None,
+) -> str:
+    """Render sub-agent job dicts (local handles or profile registry) as text."""
+    profile_name = (profile or "").strip()
+    if not jobs:
+        empty = f"No sub-agents for profile '{profile_name}'." if profile_name else "No sub-agents."
+        return f"<i>{empty}</i>" if html else empty
+
+    title = f"Sub-agents (profile {profile_name})" if profile_name else "Sub-agents"
+    lines: list[str] = [f"<b>{title}</b>" if html else title]
+
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        label = str(job.get("id") or job.get("name") or "?").strip() or "?"
+        status = str(job.get("status") or "?").strip() or "?"
+        mode = str(job.get("process_mode") or "").strip()
+        pid_raw = job.get("process_id")
+        pid = f" pid={pid_raw}" if pid_raw not in (None, "", 0) else ""
+        source = str(job.get("source") or "").strip()
+        src = f" {source}" if source and source not in {"host", "local"} else ""
+        try:
+            elapsed = int(float(job.get("elapsed_ms") or 0))
+        except (TypeError, ValueError):
+            elapsed = 0
+        preview = " ".join(str(job.get("task_preview") or "").split())[:60]
+        if html:
+            extra = f" {mode}{pid}{src} {elapsed}ms".rstrip()
+            lines.append(f"• <code>{label}</code> [{status}]{extra}")
+            if preview:
+                lines.append(f"  <i>{preview}</i>")
+        else:
+            extra = f"{mode}{pid}{src}".strip()
+            suffix = f" {extra}" if extra else ""
+            line = f"  {label} [{status}]{suffix} {elapsed}ms"
+            if preview:
+                line += f" — {preview}"
+            lines.append(line)
+
+    if pending_questions:
+        if html:
+            lines.append("")
+            lines.append("<b>Pending questions</b>")
+            for item in pending_questions:
+                q = str(item.get("question") or "")[:120]
+                name = str(item.get("subagent_name") or "sub-agent")
+                lines.append(f"• <code>{name}</code>: {q}")
+        else:
+            lines.append("")
+            lines.append("Pending questions")
+            for item in pending_questions:
+                q = str(item.get("question") or "")[:120]
+                name = str(item.get("subagent_name") or "sub-agent")
+                lines.append(f"  ? {name}: {q}")
+
+    return "\n".join(lines)
+
+
 _PROCESS_SPAWN_FALLBACK_MARKERS = (
     "fds_to_keep",
     "bad file descriptor",
@@ -943,48 +1007,23 @@ class SubAgentManager:
                     break
 
     def format_status_text(self, *, html: bool = False) -> str:
-        """Human-readable list of sub-agents for UI / slash commands."""
-        handles = self.list_all()
-        if not handles:
-            empty = "No sub-agents."
-            return f"<i>{empty}</i>" if html else empty
+        """Human-readable list of sub-agents for UI / slash commands.
 
-        lines: list[str] = []
-        if html:
-            lines.append("<b>Sub-agents</b>")
-        else:
-            lines.append("Sub-agents")
-
-        for h in handles:
-            preview = (h.task_preview or "")[:60]
-            pid = f" pid={h.process_id}" if h.process_id else ""
-            mode = h.config.process_mode.value
-            elapsed = int(h.elapsed_ms)
-            if html:
-                lines.append(f"• <code>{h.name}</code> [{h.status.value}] {mode}{pid} {elapsed}ms")
-                if preview:
-                    lines.append(f"  <i>{preview}</i>")
-            else:
-                lines.append(f"  {h.name} [{h.status.value}] {mode}{pid} {elapsed}ms — {preview}")
-
-        pending = self.interactions.list_pending_questions()
-        if pending:
-            if html:
-                lines.append("")
-                lines.append("<b>Pending questions</b>")
-                for item in pending:
-                    q = (item.get("question") or "")[:120]
-                    name = item.get("subagent_name") or "sub-agent"
-                    lines.append(f"• <code>{name}</code>: {q}")
-            else:
-                lines.append("")
-                lines.append("Pending questions")
-                for item in pending:
-                    q = (item.get("question") or "")[:120]
-                    name = item.get("subagent_name") or "sub-agent"
-                    lines.append(f"  ? {name}: {q}")
-
-        return "\n".join(lines)
+        Profile-scoped: includes jobs from Telegram, Studio, MAX, and other
+        CLI processes on the same Holix profile, not only this process.
+        """
+        summary = self.get_status_summary()
+        pending: list[dict[str, Any]] = []
+        try:
+            pending = list(self.interactions.list_pending_questions() or [])
+        except Exception:
+            pending = []
+        return format_jobs_status_text(
+            list(summary.get("agents") or []),
+            html=html,
+            pending_questions=pending,
+            profile=str(summary.get("profile") or self._profile_name() or ""),
+        )
 
     def get_status_summary(self) -> dict[str, Any]:
         """Get a summary of all sub-agents' status.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **Messenger live sub-agent watch** — `/subagents` in Telegram and MAX lists jobs with buttons. Tapping one shows the last 5 steps, refreshed every 5 seconds, with Stop and Exit. Only one sub-agent can be watched per chat.
+- **Background process pins** — Telegram/MAX pin by script. The same script replaces the previous pin; different scripts stay pinned together. Dead or stopped processes unpin automatically.
+
+### Fixed
+
+- **Honesty empty final** — a ReAct honesty retry (`is_final=False`, no tools) no longer goes to Reflexion and finalize with an empty answer. The graph loops back to `react`.
+- **`holix subagent list`** — lists jobs for the whole profile (Telegram, Studio, CLI), not only the current process. `holix -p PROFILE subagent …` registers the command (lazy CLI load).
+
 ## 1.0.17 — 2026-08-22
 
 ### Added

--- a/integrations/max/bot.py
+++ b/integrations/max/bot.py
@@ -294,6 +294,17 @@ class HelixMaxBot:
                 reply_chat_id=reply_chat_id,
                 chat_type=chat_type or "",
             )
+            try:
+                from integrations.messenger.process_pins import hydrate_session_pins
+
+                hydrate_session_pins(
+                    self._sessions[key],
+                    platform="max",
+                    chat_id=reply_chat_id or user_id,
+                    bot_profile=self.settings.profile,
+                )
+            except Exception:
+                pass
         session = self._sessions[key]
         session.reply_user_id = reply_user_id
         session.reply_chat_id = reply_chat_id
@@ -306,6 +317,65 @@ class HelixMaxBot:
         if session.agent is None:
             await self._switch_session_profile(session, session.profile)
         return session
+
+    def _session_for_pin_chat(self, chat_id: str) -> MaxChatSession | None:
+        for session in self._sessions.values():
+            if session.reply_chat_id is not None and str(session.reply_chat_id) == str(chat_id):
+                return session
+            if str(session.user_id) == str(chat_id):
+                return session
+        return None
+
+    async def _unpin_stored_pin(
+        self,
+        client: MaxClient,
+        chat_id: str,
+        process_id: str,
+        rec: dict[str, Any],
+    ) -> None:
+        session = self._session_for_pin_chat(chat_id)
+        if session is not None:
+            from integrations.max.live_presenter import MaxLivePresenter
+
+            presenter = MaxLivePresenter(client, session)
+            await presenter.unpin_background_process_notice(
+                process_id,
+                label=str(rec.get("label") or process_id),
+                status="stopped",
+            )
+            return
+        from integrations.messenger.process_pins import remove_pin
+
+        mid = rec.get("message_id")
+        try:
+            cid = int(chat_id)
+        except (TypeError, ValueError):
+            cid = None
+        if cid is not None and mid:
+            try:
+                await client.unpin_message(cid, message_id=str(mid))
+            except Exception:
+                pass
+        remove_pin(self.settings.profile, "max", chat_id, process_id)
+
+    async def _unpin_stopped_record(self, client: MaxClient, rec: Any) -> None:
+        process_id = str(getattr(rec, "process_id", "") or "")
+        if not process_id:
+            return
+        chat_id = getattr(rec, "chat_id", None)
+        if chat_id:
+            await self._unpin_stored_pin(
+                client,
+                str(chat_id),
+                process_id,
+                {"label": getattr(rec, "label", "")},
+            )
+            return
+        from integrations.messenger.process_pins import iter_platform_pins
+
+        for cid, pid, pin in iter_platform_pins(self.settings.profile, "max"):
+            if pid == process_id:
+                await self._unpin_stored_pin(client, cid, pid, pin)
 
     def _restore_session_model(self, session: MaxChatSession) -> None:
         from core.session_models import restore_session_model

--- a/integrations/max/client.py
+++ b/integrations/max/client.py
@@ -263,9 +263,10 @@ class MaxClient:
         )
         return result if isinstance(result, dict) else {}
 
-    async def unpin_message(self, chat_id: int) -> dict[str, Any]:
-        """Unpin the current pin in a group chat or channel."""
-        result = await self._request("DELETE", f"/chats/{chat_id}/pin")
+    async def unpin_message(self, chat_id: int, message_id: str | None = None) -> dict[str, Any]:
+        """Unpin a chat pin (optionally a specific message)."""
+        params = {"message_id": message_id} if message_id else None
+        result = await self._request("DELETE", f"/chats/{chat_id}/pin", params=params)
         return result if isinstance(result, dict) else {}
 
     async def edit_message(
@@ -363,7 +364,9 @@ class MaxClient:
                 payload = await resp.json(content_type=None)
             except aiohttp.ContentTypeError:
                 text = await resp.text()
-                raise MaxApiError(f"Upload {resp.status}: {text[:200]}", status=resp.status) from None
+                raise MaxApiError(
+                    f"Upload {resp.status}: {text[:200]}", status=resp.status
+                ) from None
             if resp.status >= 400:
                 detail = payload
                 if isinstance(payload, dict):

--- a/integrations/max/event_handler.py
+++ b/integrations/max/event_handler.py
@@ -150,9 +150,7 @@ class MaxEventHandler:
             elif isinstance(event, FinalResponseEvent):
                 buf.set_thinking(None)
                 recent = self._presenter.session._recent_tool_results
-                last_tool = (
-                    str(recent[-1].get("full_result") or "").strip() if recent else ""
-                )
+                last_tool = str(recent[-1].get("full_result") or "").strip() if recent else ""
                 content = resolve_messenger_final_content(
                     event.content,
                     streamed_answer=buf.answer,
@@ -167,9 +165,7 @@ class MaxEventHandler:
                     )
                     buf.result_posted_separately = True
                     self._presenter.note_final_content(content)
-                    self._presenter.enqueue_outbound(
-                        self._presenter.deliver_final_answer(content)
-                    )
+                    self._presenter.enqueue_outbound(self._presenter.deliver_final_answer(content))
                 buf.set_answer("")
                 buf.mark_done()
                 self._presenter.schedule_edit(force=True)
@@ -182,9 +178,7 @@ class MaxEventHandler:
             elif isinstance(event, ConfirmationRequestEvent):
                 buf.set_thinking(None)
                 self._presenter.schedule_edit(force=True)
-                self._presenter.enqueue_outbound(
-                    self._approvals.on_confirmation_request(event)
-                )
+                self._presenter.enqueue_outbound(self._approvals.on_confirmation_request(event))
 
             elif isinstance(event, SubAgentWaveStartedEvent):
                 buf.set_thinking(None)
@@ -206,19 +200,14 @@ class MaxEventHandler:
                 total = int(getattr(event, "total_waves", 0)) or 1
                 completed = int(getattr(event, "completed", 0))
                 total_jobs = int(getattr(event, "total", 0))
-                buf.add_note(
-                    f"✓ subagents wave {wave}/{total}: {completed}/{total_jobs}"
-                )
+                buf.add_note(f"✓ subagents wave {wave}/{total}: {completed}/{total_jobs}")
                 self._presenter.schedule_edit(force=True)
                 if summary:
-                    self._presenter.enqueue_outbound(
-                        self._presenter.send_notice(summary)
-                    )
+                    self._presenter.enqueue_outbound(self._presenter.send_notice(summary))
                 else:
                     self._presenter.enqueue_outbound(
                         self._presenter.send_notice(
-                            f"✓ Субагенты: волна {wave}/{total} — "
-                            f"{completed}/{total_jobs} готово"
+                            f"✓ Субагенты: волна {wave}/{total} — {completed}/{total_jobs} готово"
                         )
                     )
 
@@ -227,17 +216,12 @@ class MaxEventHandler:
                 added = int(round(float(event.added_timeout_s or 0)))
                 note = (
                     event.message
-                    or (
-                        f"⏱ Таймаут для субагента `{name}` увеличен на {added}s — "
-                        "ещё работает"
-                    )
+                    or (f"⏱ Таймаут для субагента `{name}` увеличен на {added}s — ещё работает")
                 ).strip()
                 buf.add_note(note[:500])
                 self._presenter.schedule_edit()
                 if note:
-                    self._presenter.enqueue_outbound(
-                        self._presenter.send_notice(note)
-                    )
+                    self._presenter.enqueue_outbound(self._presenter.send_notice(note))
 
             elif isinstance(event, SubAgentQuestionEvent):
                 buf.set_thinking(None)
@@ -250,9 +234,7 @@ class MaxEventHandler:
             elif isinstance(event, PlanReviewRequestEvent):
                 buf.set_thinking(None)
                 self._presenter.schedule_edit(force=True)
-                self._presenter.enqueue_outbound(
-                    self._approvals.on_plan_review_request(event)
-                )
+                self._presenter.enqueue_outbound(self._approvals.on_plan_review_request(event))
 
             elif isinstance(event, (PlanStepCompletedEvent, PlanCompletedEvent)):
                 msg = getattr(event, "message", "") or type(event).__name__
@@ -291,6 +273,8 @@ class MaxEventHandler:
                         event.process_id,
                         label,
                         markup=markup,
+                        command=getattr(event, "command", "") or "",
+                        os_pid=int(getattr(event, "pid", 0) or 0),
                     )
                 )
 
@@ -345,10 +329,7 @@ class MaxEventHandler:
     async def _send_subagent_question(self, event: SubAgentQuestionEvent) -> None:
         name = event.subagent_name or "sub-agent"
         question = (event.question or "").strip()
-        text = (
-            f"❓ Sub-agent {name} asks:\n{question}\n\n"
-            f"Reply in chat or /subagent-reply {name} …"
-        )
+        text = f"❓ Sub-agent {name} asks:\n{question}\n\nReply in chat or /subagent-reply {name} …"
         await self._presenter.send_notice(text)
 
     @staticmethod

--- a/integrations/max/interactive.py
+++ b/integrations/max/interactive.py
@@ -132,7 +132,10 @@ class MaxInteractive:
             await run_skills_command(self._host, cmd)
             return True
 
-        if lower.startswith("/subagent") or lower == "/subagents":
+        if lower in ("/subagents", "/subagent-list") or lower == "/subagent list":
+            await self.show_subagent_live_list()
+            return True
+        if lower.startswith("/subagent"):
             from cli.shared.commands.subagent_commands import run_subagents_command
 
             await run_subagents_command(self._host, cmd)
@@ -185,36 +188,14 @@ class MaxInteractive:
                         )
                     except Exception:
                         pass
-            # Update/unpin dedicated process notice
-            mid = self._session.background_process_message_ids.pop(process_id, None)
-            if mid:
-                from core.i18n.locale import LocaleStore
+            from integrations.max.live_presenter import MaxLivePresenter
 
-                from integrations.max.markdown import escape_html
-
-                try:
-                    loc = LocaleStore(self._session.profile).get() or "ru"
-                except Exception:
-                    loc = "ru"
-                # Use module-level ``t`` — a local ``import t`` shadows it for the
-                # whole apply_callback and breaks other actions (sa/rf/…).
-                html = t(
-                    "live.bg_process_stopped",
-                    loc,
-                    label=escape_html(record.label or process_id),
-                    summary="",
-                )
-                client = self._host._client
-                try:
-                    await client.edit_message(mid, html, fmt="html", attachments=None)
-                except Exception:
-                    pass
-                chat_id = self._session.reply_chat_id
-                if chat_id is not None:
-                    try:
-                        await client.unpin_message(int(chat_id))
-                    except Exception:
-                        pass
+            presenter = MaxLivePresenter(self._host._client, self._session)
+            await presenter.unpin_background_process_notice(
+                process_id,
+                label=record.label or process_id,
+                status="stopped",
+            )
             return f"Остановлен: {record.label}"
 
         if action == "m" and value in self._host._execution_modes:
@@ -227,6 +208,19 @@ class MaxInteractive:
             await self.show_stream_picker()
             state = "on" if self._host.streaming_enabled else "off"
             return t("tg.streaming", messenger_host_locale(self._host), state=state)
+
+        if action == "sw":
+            from integrations.messenger.subagent_watch import resolve_job_token
+
+            job_id = resolve_job_token(self._session.subagent_callback_tokens, value)
+            return await self.start_subagent_watch(job_id)
+
+        if action == "ss":
+            return await self.stop_watched_subagent()
+
+        if action == "se":
+            await self.exit_subagent_watch()
+            return t("tg.subagent_watch.closed", messenger_host_locale(self._host))
 
         if action == "sa":
             from integrations.messenger.subagents_settings import set_subagents_enabled_for_host
@@ -414,6 +408,151 @@ class MaxInteractive:
             "_При включении ответ обновляется в одном сообщении по мере генерации._"
         )
         await self._host._send_text_with_keyboard(text, stream_picker_keyboard(on))
+
+    def _cancel_subagent_watch_task(self) -> None:
+        from integrations.messenger.subagent_watch import cancel_session_watch
+
+        cancel_session_watch(self._session)
+
+    async def show_subagent_live_list(self) -> None:
+        from integrations.max.keyboards import subagent_list_keyboard
+        from integrations.messenger.subagent_watch import (
+            format_list_text,
+            list_watchable_jobs,
+            map_job_tokens,
+        )
+
+        lang = messenger_host_locale(self._host)
+        jobs = list_watchable_jobs(self._session.profile, self._host.agent)
+        html = format_list_text(jobs, html=True, locale=lang)
+        ids: list[str] = []
+        labels: dict[str, str] = {}
+        for job in jobs:
+            jid = str(job.get("id") or job.get("name") or "")
+            if not jid:
+                continue
+            ids.append(jid)
+            labels[jid] = f"{job.get('name') or jid} · {job.get('status') or ''}"[:40]
+        tokens = map_job_tokens(self._session.subagent_callback_tokens, ids) if ids else {}
+        kb = subagent_list_keyboard(tokens, labels) if tokens else None
+        if kb is None:
+            await self._host._send_html(html)
+            return
+        try:
+            await self._host._client.send_message(
+                html,
+                fmt="html",
+                attachments=[kb],
+                **self._host._reply_kwargs(),
+            )
+        except Exception:
+            await self._host._send_text_with_keyboard(html, kb)
+
+    async def start_subagent_watch(self, job_id: str) -> str:
+        import asyncio
+
+        from integrations.max.keyboards import subagent_watch_keyboard
+        from integrations.max.models import message_id_from_response
+        from integrations.messenger.subagent_watch import format_watch_text, load_watch_job
+
+        lang = messenger_host_locale(self._host)
+        jid = (job_id or "").strip()
+        job = load_watch_job(self._session.profile, jid, self._host.agent)
+        if not job:
+            return t("tg.subagent_watch.gone", lang)
+        switched = bool(
+            self._session.subagent_watch_job_id and self._session.subagent_watch_job_id != jid
+        )
+        if self._session.subagent_watch_job_id:
+            await self.exit_subagent_watch(silent=True)
+        running = bool(job.get("running"))
+        html = format_watch_text(job, html=True, locale=lang)
+        kb = subagent_watch_keyboard(running=running, locale=lang)
+        payload = await self._host._client.send_message(
+            html,
+            fmt="html",
+            attachments=[kb],
+            **self._host._reply_kwargs(),
+        )
+        mid = message_id_from_response(payload)
+        self._session.subagent_watch_job_id = jid
+        self._session.subagent_watch_message_id = mid
+        if running and mid:
+            self._session.subagent_watch_task = asyncio.create_task(
+                self._subagent_watch_loop(),
+                name=f"max-sa-watch-{jid[:24]}",
+            )
+        if switched:
+            return t("tg.subagent_watch.busy", lang)
+        return str(job.get("name") or jid)
+
+    async def _subagent_watch_loop(self) -> None:
+        import asyncio
+
+        from integrations.messenger.subagent_watch import WATCH_INTERVAL_S
+
+        try:
+            while True:
+                await asyncio.sleep(WATCH_INTERVAL_S)
+                if not self._session.subagent_watch_job_id:
+                    return
+                still = await self._edit_subagent_watch_message()
+                if not still:
+                    return
+        except asyncio.CancelledError:
+            return
+
+    async def _edit_subagent_watch_message(self) -> bool:
+        from integrations.max.keyboards import subagent_watch_keyboard
+        from integrations.messenger.subagent_watch import format_watch_text, load_watch_job
+
+        lang = messenger_host_locale(self._host)
+        jid = self._session.subagent_watch_job_id
+        mid = self._session.subagent_watch_message_id
+        if not jid or not mid:
+            return False
+        job = load_watch_job(self._session.profile, jid, self._host.agent)
+        html = format_watch_text(job, html=True, locale=lang)
+        running = bool(job and job.get("running"))
+        kb = subagent_watch_keyboard(running=running, locale=lang)
+        try:
+            await self._host._client.edit_message(mid, html, fmt="html", attachments=[kb])
+        except Exception:
+            return False
+        return running
+
+    async def stop_watched_subagent(self) -> str:
+        from integrations.messenger.subagent_watch import terminate_watch_job
+
+        lang = messenger_host_locale(self._host)
+        jid = self._session.subagent_watch_job_id
+        if not jid:
+            return t("tg.subagent_watch.gone", lang)
+        await terminate_watch_job(self._host.agent, jid, profile=self._session.profile)
+        await self._edit_subagent_watch_message()
+        return t("tg.subagent_watch.stopped", lang)
+
+    async def exit_subagent_watch(self, *, silent: bool = False) -> None:
+        from integrations.messenger.subagent_watch import format_watch_text, load_watch_job
+
+        lang = messenger_host_locale(self._host)
+        jid = self._session.subagent_watch_job_id
+        mid = self._session.subagent_watch_message_id
+        self._cancel_subagent_watch_task()
+        self._session.subagent_watch_job_id = None
+        self._session.subagent_watch_message_id = None
+        if silent or not mid:
+            return
+        job = load_watch_job(self._session.profile, jid or "", self._host.agent) if jid else None
+        closed = t("tg.subagent_watch.closed", lang)
+        if job:
+            html = format_watch_text(job, html=True, locale=lang) + f"\n\n<i>{closed}</i>"
+        else:
+            html = f"<i>{closed}</i>"
+        try:
+            await self._host._client.edit_message(mid, html, fmt="html", attachments=None)
+        except Exception:
+            pass
 
     async def show_subagents_picker(self) -> None:
         from integrations.messenger.subagents_settings import is_subagents_enabled_for_host

--- a/integrations/max/keyboards.py
+++ b/integrations/max/keyboards.py
@@ -18,6 +18,29 @@ def _cb(action: str, value: str) -> str:
     return f"{PREFIX}:{action}:{value}"
 
 
+def subagent_list_keyboard(
+    job_tokens: dict[str, str], labels: dict[str, str]
+) -> dict[str, Any] | None:
+    rows: list[list[dict[str, str]]] = []
+    for job_id, token in job_tokens.items():
+        text = (labels.get(job_id) or job_id)[:40]
+        rows.append([_callback_btn(text, _cb("sw", token))])
+    if not rows:
+        return None
+    return inline_keyboard(rows)
+
+
+def subagent_watch_keyboard(*, running: bool = True, locale: str | None = None) -> dict[str, Any]:
+    from core.i18n.messages import t
+
+    loc = locale or "ru"
+    buttons: list[dict[str, str]] = []
+    if running:
+        buttons.append(_callback_btn(t("tg.subagent_watch.stop", loc), _cb("ss", "x")))
+    buttons.append(_callback_btn(t("tg.subagent_watch.exit", loc), _cb("se", "x")))
+    return inline_keyboard([buttons])
+
+
 def background_process_stop_keyboard(process_token: str) -> dict[str, Any]:
     return inline_keyboard(
         [
@@ -176,7 +199,12 @@ def sessions_picker_keyboard(
             label = label[:26] + "…"
         global_idx = start + i
         rows.append(
-            [_callback_btn(f"{_mark(cid == current_id)}{global_idx + 1}. {label}", _cb("s", str(global_idx)))]
+            [
+                _callback_btn(
+                    f"{_mark(cid == current_id)}{global_idx + 1}. {label}",
+                    _cb("s", str(global_idx)),
+                )
+            ]
         )
     nav: list[dict[str, str]] = []
     if page > 0:

--- a/integrations/max/live_presenter.py
+++ b/integrations/max/live_presenter.py
@@ -105,9 +105,7 @@ class MaxLivePresenter:
         self._attachments = None
         self._outbound_queue = asyncio.Queue()
         self._outbound_worker = asyncio.create_task(self._outbound_worker_loop())
-        payload = await self._send_outbound(
-            f"⏳ {live_processing_label(self.session.profile)}"
-        )
+        payload = await self._send_outbound(f"⏳ {live_processing_label(self.session.profile)}")
         self._progress_message_id = message_id_from_response(payload)
         self.session.live_message_id = self._progress_message_id
         logger.info(
@@ -244,16 +242,34 @@ class MaxLivePresenter:
         label: str,
         *,
         markup: dict[str, Any] | None = None,
+        command: str = "",
+        os_pid: int = 0,
     ) -> None:
-        """Send a process notice; pin in group chats when API allows."""
+        """Send a process notice; pin in group chats when API allows.
+
+        Same script in this chat replaces the previous pin; other scripts stay.
+        """
         from core.i18n.messages import t
+        from core.runtime.process_script_key import process_script_key
 
         from integrations.max.markdown import escape_html
         from integrations.max.models import message_id_from_response
+        from integrations.messenger.process_pins import same_script_process_ids, save_pin
 
         pid = (process_id or "").strip()
         if not pid:
             return
+        script_key = process_script_key(command)
+        bot_profile = getattr(self.session, "bot_profile", None) or self.session.profile
+        chat_id_raw = self._pin_chat_id() or self.session.reply_chat_id or self.session.user_id
+        for old_pid in same_script_process_ids(
+            bot_profile, "max", chat_id_raw, script_key, exclude=pid
+        ):
+            await self.unpin_background_process_notice(old_pid, label=label, status="stopped")
+        in_session = getattr(self.session, "background_process_script_keys", None) or {}
+        for old_pid, old_key in list(in_session.items()):
+            if old_pid != pid and old_key == script_key:
+                await self.unpin_background_process_notice(old_pid, label=label, status="stopped")
         try:
             from core.i18n.locale import LocaleStore
 
@@ -276,12 +292,26 @@ class MaxLivePresenter:
             mid = message_id_from_response(payload)
             if mid:
                 self.session.background_process_message_ids[pid] = mid
+                keys = getattr(self.session, "background_process_script_keys", None)
+                if keys is not None:
+                    keys[pid] = script_key
+                try:
+                    save_pin(
+                        bot_profile,
+                        "max",
+                        chat_id_raw,
+                        process_id=pid,
+                        message_id=mid,
+                        script_key=script_key,
+                        label=label or pid,
+                        os_pid=os_pid,
+                    )
+                except Exception:
+                    logger.debug("persist MAX process pin failed", exc_info=True)
                 chat_id = self._pin_chat_id()
                 if chat_id is not None:
                     try:
-                        await self._client.pin_message(
-                            chat_id, mid, notify=False
-                        )
+                        await self._client.pin_message(chat_id, mid, notify=False)
                     except Exception as exc:
                         # Dialogs and non-admin group: pin is not available.
                         logger.info(
@@ -307,6 +337,17 @@ class MaxLivePresenter:
 
         pid = (process_id or "").strip()
         mid = self.session.background_process_message_ids.pop(pid, None)
+        keys = getattr(self.session, "background_process_script_keys", None)
+        if keys is not None:
+            keys.pop(pid, None)
+        chat_id_raw = self._pin_chat_id() or self.session.reply_chat_id or self.session.user_id
+        try:
+            from integrations.messenger.process_pins import remove_pin
+
+            bot_profile = getattr(self.session, "bot_profile", None) or self.session.profile
+            remove_pin(bot_profile, "max", chat_id_raw, pid)
+        except Exception:
+            logger.debug("remove MAX process pin failed", exc_info=True)
         if not mid:
             return
         try:
@@ -315,11 +356,7 @@ class MaxLivePresenter:
             loc = LocaleStore(self.session.profile).get() or "ru"
         except Exception:
             loc = "ru"
-        key = (
-            "live.bg_process_error"
-            if status == "error"
-            else "live.bg_process_stopped"
-        )
+        key = "live.bg_process_error" if status == "error" else "live.bg_process_stopped"
         html = t(
             key,
             loc,
@@ -333,13 +370,31 @@ class MaxLivePresenter:
         chat_id = self._pin_chat_id()
         if chat_id is not None:
             try:
-                await self._client.unpin_message(chat_id)
+                await self._client.unpin_message(chat_id, message_id=str(mid))
             except Exception as exc:
                 logger.info(
                     "MAX unpin background process skipped (chat_id=%s): %s",
                     chat_id,
                     exc,
                 )
+            await self._repin_remaining_max()
+
+    async def _repin_remaining_max(self) -> None:
+        chat_id = self._pin_chat_id()
+        if chat_id is None:
+            return
+        remaining = list(self.session.background_process_message_ids.values())
+        if not remaining:
+            return
+        mid = remaining[-1]
+        try:
+            await self._client.pin_message(chat_id, str(mid), notify=False)
+        except Exception as exc:
+            logger.info(
+                "MAX re-pin remaining process skipped (chat_id=%s): %s",
+                chat_id,
+                exc,
+            )
 
     async def send_tool_progress(self, tool_name: str, detail: str = "") -> None:
         label = (tool_name or "tool").strip()

--- a/integrations/max/polling.py
+++ b/integrations/max/polling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from integrations.max.bot import HelixMaxBot
@@ -39,8 +40,6 @@ async def run_polling(settings: MaxSettings | None = None, *, profile: str = "de
             raise
 
         try:
-            import asyncio
-
             from integrations.max.commands import register_bot_commands
             from integrations.messenger.locale import (
                 bootstrap_messenger_locales,
@@ -61,31 +60,63 @@ async def run_polling(settings: MaxSettings | None = None, *, profile: str = "de
             logger.exception("Failed to sync MAX command menu")
 
         logger.info("MAX Long Polling started (profile=%s)", settings.profile)
-        while True:
+        from core.runtime.background_process import (
+            register_process_stop_hook,
+            unregister_process_stop_hook,
+        )
+
+        from integrations.messenger.process_pin_watch import watch_dead_pins
+
+        def _on_stopped(rec: object) -> None:
             try:
-                payload = await poll_client.get_updates(
-                    marker=marker,
-                    limit=100,
-                    timeout=settings.poll_timeout_s,
-                    types=POLL_TYPES,
-                )
-            except MaxApiError as exc:
-                logger.warning("MAX polling error: %s", exc)
-                await asyncio.sleep(2.0)
-                continue
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return
+            loop.create_task(
+                bot._unpin_stopped_record(api_client, rec),
+                name="max-unpin-stopped",
+            )
 
-            next_marker = payload.get("marker")
-            if isinstance(next_marker, int):
-                marker = next_marker
+        register_process_stop_hook(_on_stopped)
+        watch = asyncio.create_task(
+            watch_dead_pins(
+                bot_profile=settings.profile,
+                platform="max",
+                unpin=lambda chat_id, pid, rec: bot._unpin_stored_pin(
+                    api_client, chat_id, pid, rec
+                ),
+            ),
+            name="max-process-pin-watch",
+        )
+        try:
+            while True:
+                try:
+                    payload = await poll_client.get_updates(
+                        marker=marker,
+                        limit=100,
+                        timeout=settings.poll_timeout_s,
+                        types=POLL_TYPES,
+                    )
+                except MaxApiError as exc:
+                    logger.warning("MAX polling error: %s", exc)
+                    await asyncio.sleep(2.0)
+                    continue
 
-            updates = payload.get("updates")
-            if not isinstance(updates, list):
-                continue
-            if updates:
-                logger.info("MAX received %d update(s)", len(updates))
-            for update in updates:
-                if isinstance(update, dict):
-                    try:
-                        await bot.handle_update(api_client, update)
-                    except Exception:
-                        logger.exception("Failed to handle MAX update")
+                next_marker = payload.get("marker")
+                if isinstance(next_marker, int):
+                    marker = next_marker
+
+                updates = payload.get("updates")
+                if not isinstance(updates, list):
+                    continue
+                if updates:
+                    logger.info("MAX received %d update(s)", len(updates))
+                for update in updates:
+                    if isinstance(update, dict):
+                        try:
+                            await bot.handle_update(api_client, update)
+                        except Exception:
+                            logger.exception("Failed to handle MAX update")
+        finally:
+            watch.cancel()
+            unregister_process_stop_hook(_on_stopped)

--- a/integrations/max/session.py
+++ b/integrations/max/session.py
@@ -47,6 +47,11 @@ class MaxChatSession:
     process_callback_tokens: dict[str, str] = field(default_factory=dict)
     # process_id -> MAX message mid of process notice (pinned in groups when possible)
     background_process_message_ids: dict[str, str] = field(default_factory=dict)
+    background_process_script_keys: dict[str, str] = field(default_factory=dict)
+    subagent_callback_tokens: dict[str, str] = field(default_factory=dict)
+    subagent_watch_job_id: str | None = None
+    subagent_watch_message_id: str | None = None
+    subagent_watch_task: Any = None
     pending_admin_broadcast: Any = None
     agent: Any = None
     ui_profiles: list[str] = field(default_factory=list)

--- a/integrations/messenger/process_pin_watch.py
+++ b/integrations/messenger/process_pin_watch.py
@@ -1,0 +1,69 @@
+"""Watch pinned background processes and unpin when the OS process dies."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from core.platform_compat import is_process_alive
+from core.runtime.background_process import get_background_process_registry
+
+from integrations.messenger.process_pins import iter_platform_pins
+
+logger = logging.getLogger(__name__)
+
+UnpinFn = Callable[[str, str, dict[str, Any]], Awaitable[None]]
+
+
+def process_is_alive(process_id: str, rec: dict[str, Any]) -> bool:
+    registry = get_background_process_registry()
+    live = registry.get(process_id)
+    if live is not None:
+        return bool(live.is_running())
+    os_pid = rec.get("os_pid")
+    try:
+        pid = int(os_pid or 0)
+    except (TypeError, ValueError):
+        pid = 0
+    if pid <= 0:
+        return False
+    return bool(is_process_alive(pid))
+
+
+async def reap_dead_pins(
+    *,
+    bot_profile: str,
+    platform: str,
+    unpin: UnpinFn,
+) -> int:
+    """Unpin notices whose OS process is gone. Returns number of reaps."""
+    n = 0
+    for chat_id, process_id, rec in iter_platform_pins(bot_profile, platform):
+        if process_is_alive(process_id, rec):
+            continue
+        try:
+            await unpin(chat_id, process_id, rec)
+            n += 1
+        except Exception:
+            logger.debug("failed to unpin dead %s process %s", platform, process_id, exc_info=True)
+    return n
+
+
+async def watch_dead_pins(
+    *,
+    bot_profile: str,
+    platform: str,
+    unpin: UnpinFn,
+    interval_s: float = 8.0,
+) -> None:
+    delay = max(2.0, float(interval_s))
+    while True:
+        try:
+            await reap_dead_pins(bot_profile=bot_profile, platform=platform, unpin=unpin)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("process pin watch failed", exc_info=True)
+        await asyncio.sleep(delay)

--- a/integrations/messenger/process_pins.py
+++ b/integrations/messenger/process_pins.py
@@ -1,0 +1,174 @@
+"""Persist messenger pins for background processes (Telegram / MAX)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from core.profile.names import profile_dir_for_name, validate_profile_name
+
+logger = logging.getLogger(__name__)
+
+PLATFORMS = ("telegram", "max")
+
+
+def pins_path(bot_profile: str) -> Path:
+    name = validate_profile_name(bot_profile)
+    path = profile_dir_for_name(name) / "data" / "process_pins.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def chat_key(platform: str, chat_id: int | str) -> str:
+    plat = (platform or "").strip().lower() or "telegram"
+    return f"{plat}:{chat_id}"
+
+
+def _load(bot_profile: str) -> dict[str, Any]:
+    path = pins_path(bot_profile)
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save(bot_profile: str, data: dict[str, Any]) -> None:
+    path = pins_path(bot_profile)
+    raw = json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    try:
+        tmp.write_text(raw, encoding="utf-8")
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def list_chat_pins(
+    bot_profile: str, platform: str, chat_id: int | str
+) -> dict[str, dict[str, Any]]:
+    data = _load(bot_profile)
+    raw = data.get(chat_key(platform, chat_id)) or {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for pid, rec in raw.items():
+        if isinstance(rec, dict) and pid:
+            out[str(pid)] = rec
+    return out
+
+
+def save_pin(
+    bot_profile: str,
+    platform: str,
+    chat_id: int | str,
+    *,
+    process_id: str,
+    message_id: int | str,
+    script_key: str,
+    label: str = "",
+    os_pid: int = 0,
+) -> None:
+    pid = (process_id or "").strip()
+    if not pid:
+        return
+    data = _load(bot_profile)
+    key = chat_key(platform, chat_id)
+    bucket = data.get(key)
+    if not isinstance(bucket, dict):
+        bucket = {}
+    bucket[pid] = {
+        "process_id": pid,
+        "message_id": message_id,
+        "script_key": script_key,
+        "label": label,
+        "os_pid": int(os_pid or 0),
+    }
+    data[key] = bucket
+    _save(bot_profile, data)
+
+
+def remove_pin(bot_profile: str, platform: str, chat_id: int | str, process_id: str) -> None:
+    pid = (process_id or "").strip()
+    if not pid:
+        return
+    data = _load(bot_profile)
+    key = chat_key(platform, chat_id)
+    bucket = data.get(key)
+    if not isinstance(bucket, dict):
+        return
+    bucket.pop(pid, None)
+    if bucket:
+        data[key] = bucket
+    else:
+        data.pop(key, None)
+    _save(bot_profile, data)
+
+
+def same_script_process_ids(
+    bot_profile: str,
+    platform: str,
+    chat_id: int | str,
+    script_key: str,
+    *,
+    exclude: str = "",
+) -> list[str]:
+    want = (script_key or "").strip()
+    if not want:
+        return []
+    skip = (exclude or "").strip()
+    out: list[str] = []
+    for pid, rec in list_chat_pins(bot_profile, platform, chat_id).items():
+        if pid == skip:
+            continue
+        if str(rec.get("script_key") or "").strip() == want:
+            out.append(pid)
+    return out
+
+
+def iter_platform_pins(bot_profile: str, platform: str) -> list[tuple[str, str, dict[str, Any]]]:
+    """Yield (chat_id, process_id, record) for one messenger."""
+    prefix = f"{(platform or '').strip().lower()}:"
+    data = _load(bot_profile)
+    out: list[tuple[str, str, dict[str, Any]]] = []
+    for key, bucket in data.items():
+        if not str(key).startswith(prefix) or not isinstance(bucket, dict):
+            continue
+        chat_id = str(key)[len(prefix) :]
+        for pid, rec in bucket.items():
+            if isinstance(rec, dict):
+                out.append((chat_id, str(pid), rec))
+    return out
+
+
+def hydrate_session_pins(
+    session: Any,
+    *,
+    platform: str,
+    chat_id: int | str,
+    bot_profile: str,
+) -> None:
+    """Copy persisted pins into in-memory session maps."""
+    pins = list_chat_pins(bot_profile, platform, chat_id)
+    ids = getattr(session, "background_process_message_ids", None)
+    keys = getattr(session, "background_process_script_keys", None)
+    if ids is None:
+        return
+    for pid, rec in pins.items():
+        mid = rec.get("message_id")
+        if mid is None or mid == "":
+            continue
+        ids[pid] = mid
+        if keys is not None:
+            sk = str(rec.get("script_key") or "")
+            if sk:
+                keys[pid] = sk

--- a/integrations/messenger/subagent_watch.py
+++ b/integrations/messenger/subagent_watch.py
@@ -1,0 +1,205 @@
+"""Live sub-agent watch for Telegram / MAX (one viewer per chat)."""
+
+from __future__ import annotations
+
+import html as html_lib
+import secrets
+from typing import Any
+
+WATCH_INTERVAL_S = 5.0
+WATCH_STEPS = 5
+WATCH_LIST_LIMIT = 8
+
+_KIND_ICON = {
+    "tool": "🔧",
+    "tool_start": "🔧",
+    "tool_result": "✓",
+    "tool_error": "✗",
+    "thinking": "💭",
+    "status": "•",
+    "error": "⚠",
+}
+
+
+def map_job_tokens(mapping: dict[str, str], job_ids: list[str]) -> dict[str, str]:
+    """Replace *mapping* with token→job_id; return job_id→token."""
+    mapping.clear()
+    out: dict[str, str] = {}
+    for jid in job_ids:
+        token = secrets.token_hex(4)
+        mapping[token] = jid
+        out[jid] = token
+    return out
+
+
+def resolve_job_token(mapping: dict[str, str], token: str) -> str:
+    return mapping.get(token, token)
+
+
+def last_activity_steps(
+    job: dict[str, Any] | None, *, limit: int = WATCH_STEPS
+) -> list[dict[str, Any]]:
+    if not job:
+        return []
+    log = job.get("activity_log") or []
+    steps = [e for e in log if isinstance(e, dict)]
+    return steps[-max(1, int(limit)) :]
+
+
+def _step_line(entry: dict[str, Any]) -> str:
+    kind = str(entry.get("kind") or "status").strip().lower()
+    icon = _KIND_ICON.get(kind, "•")
+    msg = " ".join(str(entry.get("message") or "").split())
+    tool = str(entry.get("tool_name") or "").strip()
+    if tool and tool.lower() not in msg.lower():
+        msg = f"{tool}: {msg}" if msg else tool
+    n = entry.get("steps_taken")
+    prefix = f"{n}. " if n not in (None, "", 0) else ""
+    body = msg or kind
+    if len(body) > 160:
+        body = body[:159] + "…"
+    return f"{prefix}{icon} {body}"
+
+
+def format_watch_text(job: dict[str, Any] | None, *, html: bool, locale: str = "ru") -> str:
+    from core.i18n.messages import t
+
+    loc = locale if locale in ("en", "ru") else "ru"
+    if not job:
+        text = t("tg.subagent_watch.gone", loc)
+        return f"<i>{text}</i>" if html else text
+
+    name = str(job.get("name") or job.get("id") or "?").strip()
+    status = str(job.get("status") or "?").strip()
+    steps = int(job.get("steps_taken") or 0)
+    max_steps = int(job.get("max_steps") or 0)
+    preview = " ".join(str(job.get("task_preview") or "").split())[:120]
+    activity = " ".join(str(job.get("current_activity") or "").split())[:160]
+    step_lines = [_step_line(e) for e in last_activity_steps(job)]
+    if not step_lines:
+        step_lines = [t("tg.subagent_watch.no_steps", loc)]
+
+    step_bit = f"{steps}/{max_steps}" if max_steps else str(steps)
+    title = t("tg.subagent_watch.title", loc, name=name, status=status, steps=step_bit)
+    if html:
+        esc = html_lib.escape
+        lines = [f"<b>{esc(title)}</b>"]
+        if preview:
+            lines.append(esc(preview))
+        if activity and activity not in preview:
+            lines.append(f"<i>{esc(activity)}</i>")
+        lines.append("")
+        for line in step_lines:
+            lines.append(esc(line))
+        return "\n".join(lines)
+    lines = [title]
+    if preview:
+        lines.append(preview)
+    if activity and activity not in preview:
+        lines.append(activity)
+    lines.append("")
+    lines.extend(step_lines)
+    return "\n".join(lines)
+
+
+def format_list_text(jobs: list[dict[str, Any]], *, html: bool, locale: str = "ru") -> str:
+    from core.i18n.messages import t
+
+    loc = locale if locale in ("en", "ru") else "ru"
+    if not jobs:
+        text = t("tg.subagent_watch.none", loc)
+        return f"<i>{text}</i>" if html else text
+    title = t("tg.subagent_watch.pick", loc)
+    if html:
+        esc = html_lib.escape
+        lines = [f"<b>{esc(title)}</b>"]
+        for job in jobs:
+            name = str(job.get("name") or "?")
+            status = str(job.get("status") or "?")
+            preview = " ".join(str(job.get("task_preview") or "").split())[:80]
+            line = f"• {name} [{status}]"
+            if preview:
+                line += f" — {preview}"
+            lines.append(esc(line))
+        return "\n".join(lines)
+    lines = [title]
+    for job in jobs:
+        name = str(job.get("name") or "?")
+        status = str(job.get("status") or "?")
+        preview = " ".join(str(job.get("task_preview") or "").split())[:80]
+        line = f"• {name} [{status}]"
+        if preview:
+            line += f" — {preview}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def list_watchable_jobs(profile: str, agent: Any | None = None) -> list[dict[str, Any]]:
+    jobs: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    if agent is not None and hasattr(agent, "subagents"):
+        try:
+            summary = agent.subagents.get_status_summary()
+            for row in summary.get("agents") or []:
+                if not isinstance(row, dict):
+                    continue
+                jid = str(row.get("id") or row.get("name") or "")
+                if not jid or jid in seen:
+                    continue
+                seen.add(jid)
+                jobs.append(row)
+        except Exception:
+            pass
+    if not jobs:
+        from core.subagents.runtime_registry import list_jobs
+
+        for row in list_jobs(profile, include_done=True, include_activity=False):
+            jid = str(row.get("id") or row.get("name") or "")
+            if not jid or jid in seen:
+                continue
+            seen.add(jid)
+            jobs.append(row)
+    jobs.sort(key=lambda j: (0 if j.get("running") else 1, str(j.get("name") or "")))
+    return jobs[:WATCH_LIST_LIMIT]
+
+
+def load_watch_job(profile: str, job_id: str, agent: Any | None = None) -> dict[str, Any] | None:
+    jid = (job_id or "").strip()
+    if not jid:
+        return None
+    if agent is not None and hasattr(agent, "subagents"):
+        try:
+            handle = agent.subagents.get_handle(jid)
+            if handle is not None:
+                row = handle.to_status_dict(include_activity=True, include_result=False)
+                row["id"] = jid
+                row.setdefault("name", handle.name)
+                return row
+        except Exception:
+            pass
+    from core.subagents.runtime_registry import get_job
+
+    return get_job(profile, jid, include_activity=True, include_result=False)
+
+
+async def terminate_watch_job(agent: Any | None, job_id: str, *, profile: str) -> bool:
+    if agent is not None and hasattr(agent, "subagents"):
+        try:
+            return bool(await agent.subagents.terminate(job_id))
+        except Exception:
+            pass
+    from core.subagents.runtime_registry import request_cancel
+
+    return bool(request_cancel(profile, job_id))
+
+
+def cancel_session_watch(session: Any) -> None:
+    task = getattr(session, "subagent_watch_task", None)
+    if task is not None:
+        try:
+            if not task.done():
+                task.cancel()
+        except Exception:
+            pass
+    session.subagent_watch_task = None
+    session.subagent_watch_job_id = None

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -305,6 +305,17 @@ class HolixTelegramBot:
                     conversation_id=f"tg_{profile}_{chat_id}",
                     bot_profile=self.settings.profile,
                 )
+                try:
+                    from integrations.messenger.process_pins import hydrate_session_pins
+
+                    hydrate_session_pins(
+                        self._sessions[chat_id],
+                        platform="telegram",
+                        chat_id=chat_id,
+                        bot_profile=self.settings.profile,
+                    )
+                except Exception:
+                    pass
             session = self._sessions[chat_id]
             if not session.profile_manual_override:
                 target = self._default_profile_for_user(user_id)
@@ -986,6 +997,57 @@ class HolixTelegramBot:
         self._dp = dp
         return bot, dp
 
+    async def _unpin_stored_pin(
+        self,
+        bot: Any,
+        chat_id: str,
+        process_id: str,
+        rec: dict[str, Any],
+    ) -> None:
+        session = None
+        try:
+            session = self._sessions.get(int(chat_id))
+        except (TypeError, ValueError):
+            session = None
+        if session is not None:
+            from integrations.telegram.live_presenter import TelegramLivePresenter
+
+            presenter = TelegramLivePresenter(bot, session)
+            await presenter.unpin_background_process_notice(
+                process_id,
+                label=str(rec.get("label") or process_id),
+                status="stopped",
+            )
+            return
+        mid = rec.get("message_id")
+        if mid:
+            try:
+                await bot.unpin_chat_message(chat_id=int(chat_id), message_id=int(mid))
+            except Exception:
+                pass
+        from integrations.messenger.process_pins import remove_pin
+
+        remove_pin(self.settings.profile, "telegram", chat_id, process_id)
+
+    async def _unpin_stopped_record(self, bot: Any, rec: Any) -> None:
+        process_id = str(getattr(rec, "process_id", "") or "")
+        if not process_id:
+            return
+        chat_id = getattr(rec, "chat_id", None)
+        if chat_id:
+            await self._unpin_stored_pin(
+                bot,
+                str(chat_id),
+                process_id,
+                {"label": getattr(rec, "label", "")},
+            )
+            return
+        from integrations.messenger.process_pins import iter_platform_pins
+
+        for cid, pid, pin in iter_platform_pins(self.settings.profile, "telegram"):
+            if pid == process_id:
+                await self._unpin_stored_pin(bot, cid, pid, pin)
+
     async def run_polling(self) -> None:
         from config import settings
 
@@ -1006,4 +1068,31 @@ class HolixTelegramBot:
         if not self.settings.bot_token:
             raise RuntimeError("Set TELEGRAM_BOT_TOKEN in environment or .env")
         bot, dp = self.build()
-        await dp.start_polling(bot)
+        from core.runtime.background_process import (
+            register_process_stop_hook,
+            unregister_process_stop_hook,
+        )
+
+        from integrations.messenger.process_pin_watch import watch_dead_pins
+
+        def _on_stopped(rec: Any) -> None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return
+            loop.create_task(self._unpin_stopped_record(bot, rec), name="tg-unpin-stopped")
+
+        register_process_stop_hook(_on_stopped)
+        watch = asyncio.create_task(
+            watch_dead_pins(
+                bot_profile=self.settings.profile,
+                platform="telegram",
+                unpin=lambda chat_id, pid, rec: self._unpin_stored_pin(bot, chat_id, pid, rec),
+            ),
+            name="tg-process-pin-watch",
+        )
+        try:
+            await dp.start_polling(bot)
+        finally:
+            watch.cancel()
+            unregister_process_stop_hook(_on_stopped)

--- a/integrations/telegram/event_handler.py
+++ b/integrations/telegram/event_handler.py
@@ -93,9 +93,7 @@ class TelegramEventHandler:
                 if name == "delegate_to_subagent" and body.strip():
                     notice = format_subagent_tool_notice(name, body)
                     if notice and "already_running" not in body:
-                        self._presenter.enqueue_outbound(
-                            self._presenter.send_notice(notice)
-                        )
+                        self._presenter.enqueue_outbound(self._presenter.send_notice(notice))
                     job_id = extract_delegate_job_id(body)
                     if job_id and "already_running" not in body:
                         agent = getattr(self._presenter.session, "agent", None)
@@ -137,9 +135,7 @@ class TelegramEventHandler:
             elif isinstance(event, FinalResponseEvent):
                 buf.set_thinking(None)
                 recent = self._presenter.session._recent_tool_results
-                last_tool = (
-                    str(recent[-1].get("full_result") or "").strip() if recent else ""
-                )
+                last_tool = str(recent[-1].get("full_result") or "").strip() if recent else ""
                 content = resolve_messenger_final_content(
                     event.content,
                     streamed_answer=buf.answer,
@@ -154,9 +150,7 @@ class TelegramEventHandler:
                     )
                     buf.result_posted_separately = True
                     self._presenter.note_final_content(content)
-                    self._presenter.enqueue_outbound(
-                        self._presenter.deliver_final_answer(content)
-                    )
+                    self._presenter.enqueue_outbound(self._presenter.deliver_final_answer(content))
                 buf.set_answer("")
                 buf.mark_done()
                 self._presenter.schedule_edit(force=True)
@@ -175,17 +169,12 @@ class TelegramEventHandler:
                 added = int(round(float(event.added_timeout_s or 0)))
                 note = (
                     event.message
-                    or (
-                        f"⏱ Таймаут для субагента `{name}` увеличен на {added}s — "
-                        "ещё работает"
-                    )
+                    or (f"⏱ Таймаут для субагента `{name}` увеличен на {added}s — ещё работает")
                 ).strip()
                 buf.add_note(note[:500])
                 self._presenter.schedule_edit()
                 if note:
-                    self._presenter.enqueue_outbound(
-                        self._presenter.send_notice(note)
-                    )
+                    self._presenter.enqueue_outbound(self._presenter.send_notice(note))
 
             elif isinstance(event, SubAgentQuestionEvent):
                 buf.set_thinking(None)
@@ -197,9 +186,7 @@ class TelegramEventHandler:
 
             elif isinstance(event, PlanReviewRequestEvent):
                 buf.set_thinking(None)
-                buf.add_note(
-                    live_plan_review_label(buf.profile, step_count=event.step_count)
-                )
+                buf.add_note(live_plan_review_label(buf.profile, step_count=event.step_count))
                 self._presenter.schedule_edit(force=True)
                 asyncio.create_task(self._approvals.on_plan_review_request(event))
 
@@ -251,6 +238,8 @@ class TelegramEventHandler:
                         event.process_id,
                         label,
                         markup=markup,
+                        command=getattr(event, "command", "") or "",
+                        os_pid=int(getattr(event, "pid", 0) or 0),
                     )
                 )
 

--- a/integrations/telegram/interactive.py
+++ b/integrations/telegram/interactive.py
@@ -167,7 +167,10 @@ class TelegramInteractive:
             await run_skills_command(self._host, cmd)
             return True
 
-        if lower.startswith("/subagent") or lower == "/subagents":
+        if lower in ("/subagents", "/subagent-list") or lower == "/subagent list":
+            await self.show_subagent_live_list()
+            return True
+        if lower.startswith("/subagent"):
             from cli.shared.commands.subagent_commands import run_subagents_command
 
             await run_subagents_command(self._host, cmd)
@@ -441,42 +444,14 @@ class TelegramInteractive:
                     except Exception:
                         pass
             # Update/unpin dedicated process notice (survives after agent run).
-            mid = self._session.background_process_message_ids.pop(process_id, None)
-            if mid is not None:
-                from core.i18n.locale import LocaleStore
+            from integrations.telegram.live_presenter import TelegramLivePresenter
 
-                from integrations.telegram.markdown import escape_html
-
-                try:
-                    loc = LocaleStore(self._session.profile).get() or "ru"
-                except Exception:
-                    loc = "ru"
-                # Use module-level ``t`` — a local ``import t`` shadows it for the
-                # whole apply_callback and breaks other actions (sa/rf/…).
-                html = t(
-                    "live.bg_process_stopped",
-                    loc,
-                    label=escape_html(record.label or process_id),
-                    summary="",
-                )
-                bot = self._host._bot
-                try:
-                    await bot.edit_message_text(
-                        html,
-                        chat_id=self._session.chat_id,
-                        message_id=mid,
-                        parse_mode="HTML",
-                        reply_markup=None,
-                    )
-                except Exception:
-                    pass
-                try:
-                    await bot.unpin_chat_message(
-                        chat_id=self._session.chat_id,
-                        message_id=mid,
-                    )
-                except Exception:
-                    pass
+            presenter = TelegramLivePresenter(self._host._bot, self._session)
+            await presenter.unpin_background_process_notice(
+                process_id,
+                label=record.label or process_id,
+                status="stopped",
+            )
             return f"Остановлен: {record.label}"
 
         if action == "m" and value in self._host._execution_modes:
@@ -491,6 +466,21 @@ class TelegramInteractive:
             lang = messenger_host_locale(self._host)
             state = "on" if self._host.streaming_enabled else "off"
             return t("tg.streaming", lang, state=state)
+
+        if action == "sw":
+            from integrations.messenger.subagent_watch import resolve_job_token
+
+            job_id = resolve_job_token(self._session.subagent_callback_tokens, value)
+            toast = await self.start_subagent_watch(job_id)
+            return toast
+
+        if action == "ss":
+            return await self.stop_watched_subagent()
+
+        if action == "se":
+            await self.exit_subagent_watch()
+            lang = messenger_host_locale(self._host)
+            return t("tg.subagent_watch.closed", lang)
 
         if action == "sa":
             from integrations.messenger.subagents_settings import set_subagents_enabled_for_host
@@ -722,6 +712,166 @@ class TelegramInteractive:
             "<i>При включении ответ обновляется в одном сообщении по мере генерации.</i>"
         )
         await self._host._send_html_with_keyboard(text, stream_picker_keyboard(on))
+
+    def _cancel_subagent_watch_task(self) -> None:
+        from integrations.messenger.subagent_watch import cancel_session_watch
+
+        cancel_session_watch(self._session)
+
+    async def show_subagent_live_list(self) -> None:
+        from integrations.messenger.subagent_watch import (
+            format_list_text,
+            list_watchable_jobs,
+            map_job_tokens,
+        )
+        from integrations.telegram.keyboards import subagent_list_keyboard
+
+        lang = messenger_host_locale(self._host)
+        jobs = list_watchable_jobs(self._session.profile, self._host.agent)
+        html = format_list_text(jobs, html=True, locale=lang)
+        tokens: dict[str, str] = {}
+        labels: dict[str, str] = {}
+        ids: list[str] = []
+        for job in jobs:
+            jid = str(job.get("id") or job.get("name") or "")
+            if not jid:
+                continue
+            ids.append(jid)
+            status = str(job.get("status") or "")
+            name = str(job.get("name") or jid)
+            labels[jid] = f"{name} · {status}"[:40]
+        if ids:
+            tokens = map_job_tokens(self._session.subagent_callback_tokens, ids)
+        kb = subagent_list_keyboard(tokens, labels) if tokens else None
+        if kb is None:
+            await self._host._send_html(html)
+            return
+        await self._host._send_html_with_keyboard(html, kb)
+
+    async def start_subagent_watch(self, job_id: str) -> str:
+        import asyncio
+
+        from integrations.messenger.subagent_watch import format_watch_text, load_watch_job
+        from integrations.telegram.keyboards import subagent_watch_keyboard
+
+        lang = messenger_host_locale(self._host)
+        jid = (job_id or "").strip()
+        job = load_watch_job(self._session.profile, jid, self._host.agent)
+        if not job:
+            return t("tg.subagent_watch.gone", lang)
+
+        switched = bool(
+            self._session.subagent_watch_job_id and self._session.subagent_watch_job_id != jid
+        )
+        if self._session.subagent_watch_job_id:
+            await self.exit_subagent_watch(silent=True)
+
+        running = bool(job.get("running"))
+        html = format_watch_text(job, html=True, locale=lang)
+        kb = subagent_watch_keyboard(running=running, locale=lang)
+        msg = await self._host._bot.send_message(
+            self._session.chat_id,
+            html,
+            parse_mode="HTML",
+            reply_markup=kb,
+        )
+        mid = int(getattr(msg, "message_id", 0) or 0)
+        self._session.subagent_watch_job_id = jid
+        self._session.subagent_watch_message_id = mid or None
+        if running and mid:
+            self._session.subagent_watch_task = asyncio.create_task(
+                self._subagent_watch_loop(),
+                name=f"tg-sa-watch-{jid[:24]}",
+            )
+        if switched:
+            return t("tg.subagent_watch.busy", lang)
+        return str(job.get("name") or jid)
+
+    async def _subagent_watch_loop(self) -> None:
+        import asyncio
+
+        from integrations.messenger.subagent_watch import WATCH_INTERVAL_S
+
+        try:
+            while True:
+                await asyncio.sleep(WATCH_INTERVAL_S)
+                if not self._session.subagent_watch_job_id:
+                    return
+                still = await self._edit_subagent_watch_message()
+                if not still:
+                    return
+        except asyncio.CancelledError:
+            return
+
+    async def _edit_subagent_watch_message(self) -> bool:
+        from integrations.messenger.subagent_watch import format_watch_text, load_watch_job
+        from integrations.telegram.keyboards import subagent_watch_keyboard
+        from integrations.telegram.live_presenter import _is_not_modified
+
+        lang = messenger_host_locale(self._host)
+        jid = self._session.subagent_watch_job_id
+        mid = self._session.subagent_watch_message_id
+        if not jid or not mid:
+            return False
+        job = load_watch_job(self._session.profile, jid, self._host.agent)
+        html = format_watch_text(job, html=True, locale=lang)
+        running = bool(job and job.get("running"))
+        kb = subagent_watch_keyboard(running=running, locale=lang)
+        try:
+            await self._host._bot.edit_message_text(
+                html,
+                chat_id=self._session.chat_id,
+                message_id=mid,
+                parse_mode="HTML",
+                reply_markup=kb,
+            )
+        except Exception as exc:
+            if not _is_not_modified(exc):
+                return False
+        return running
+
+    async def stop_watched_subagent(self) -> str:
+        from integrations.messenger.subagent_watch import terminate_watch_job
+
+        lang = messenger_host_locale(self._host)
+        jid = self._session.subagent_watch_job_id
+        if not jid:
+            return t("tg.subagent_watch.gone", lang)
+        await terminate_watch_job(self._host.agent, jid, profile=self._session.profile)
+        await self._edit_subagent_watch_message()
+        return t("tg.subagent_watch.stopped", lang)
+
+    async def exit_subagent_watch(self, *, silent: bool = False) -> None:
+        from integrations.messenger.subagent_watch import format_watch_text, load_watch_job
+        from integrations.telegram.live_presenter import _is_not_modified
+
+        lang = messenger_host_locale(self._host)
+        jid = self._session.subagent_watch_job_id
+        mid = self._session.subagent_watch_message_id
+        self._cancel_subagent_watch_task()
+        self._session.subagent_watch_job_id = None
+        self._session.subagent_watch_message_id = None
+        if silent or not mid:
+            return
+        job = load_watch_job(self._session.profile, jid or "", self._host.agent) if jid else None
+        closed = t("tg.subagent_watch.closed", lang)
+        if job:
+            html = (
+                format_watch_text(job, html=True, locale=lang) + f"\n\n<i>{escape_html(closed)}</i>"
+            )
+        else:
+            html = f"<i>{escape_html(closed)}</i>"
+        try:
+            await self._host._bot.edit_message_text(
+                html,
+                chat_id=self._session.chat_id,
+                message_id=mid,
+                parse_mode="HTML",
+                reply_markup=None,
+            )
+        except Exception as exc:
+            if not _is_not_modified(exc):
+                pass
 
     async def show_subagents_picker(self) -> None:
         from integrations.messenger.subagents_settings import is_subagents_enabled_for_host

--- a/integrations/telegram/keyboards.py
+++ b/integrations/telegram/keyboards.py
@@ -21,6 +21,41 @@ def _cb(action: str, value: str) -> str:
     return data
 
 
+def subagent_list_keyboard(job_tokens: dict[str, str], labels: dict[str, str]) -> Any:
+    """One button per sub-agent (token -> job). labels keyed by job_id."""
+    from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+    rows: list[list[Any]] = []
+    for job_id, token in job_tokens.items():
+        text = (labels.get(job_id) or job_id)[:40]
+        rows.append([InlineKeyboardButton(text=text, callback_data=_cb("sw", token))])
+    if not rows:
+        return None
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def subagent_watch_keyboard(*, running: bool = True, locale: str | None = None) -> Any:
+    from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+    from core.i18n.messages import t
+
+    loc = locale or "ru"
+    buttons = []
+    if running:
+        buttons.append(
+            InlineKeyboardButton(
+                text=t("tg.subagent_watch.stop", loc),
+                callback_data=_cb("ss", "x"),
+            )
+        )
+    buttons.append(
+        InlineKeyboardButton(
+            text=t("tg.subagent_watch.exit", loc),
+            callback_data=_cb("se", "x"),
+        )
+    )
+    return InlineKeyboardMarkup(inline_keyboard=[buttons])
+
+
 def background_process_stop_keyboard(process_token: str) -> Any:
     from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
@@ -212,18 +247,12 @@ def sessions_picker_keyboard(
         )
     nav: list[Any] = []
     if page > 0:
-        nav.append(
-            InlineKeyboardButton(text="◀", callback_data=_cb("sp", str(page - 1)))
-        )
+        nav.append(InlineKeyboardButton(text="◀", callback_data=_cb("sp", str(page - 1))))
     if start + page_size < len(sessions):
-        nav.append(
-            InlineKeyboardButton(text="▶", callback_data=_cb("sp", str(page + 1)))
-        )
+        nav.append(InlineKeyboardButton(text="▶", callback_data=_cb("sp", str(page + 1))))
     if nav:
         rows.append(nav)
-    rows.append(
-        [InlineKeyboardButton(text="＋ Новая сессия", callback_data=_cb("sn", "1"))]
-    )
+    rows.append([InlineKeyboardButton(text="＋ Новая сессия", callback_data=_cb("sn", "1"))])
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
@@ -259,18 +288,12 @@ def skills_picker_keyboard(
 
     nav: list[Any] = []
     if page > 0:
-        nav.append(
-            InlineKeyboardButton(text="◀", callback_data=_cb("skp", str(page - 1)))
-        )
+        nav.append(InlineKeyboardButton(text="◀", callback_data=_cb("skp", str(page - 1))))
     if start + page_size < len(skills):
-        nav.append(
-            InlineKeyboardButton(text="▶", callback_data=_cb("skp", str(page + 1)))
-        )
+        nav.append(InlineKeyboardButton(text="▶", callback_data=_cb("skp", str(page + 1))))
     if nav:
         rows.append(nav)
-    rows.append(
-        [InlineKeyboardButton(text="↻ Обновить", callback_data=_cb("skp", str(page)))]
-    )
+    rows.append([InlineKeyboardButton(text="↻ Обновить", callback_data=_cb("skp", str(page)))])
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
@@ -398,9 +421,13 @@ def models_provider_keyboard(
 
     nav: list[Any] = []
     if page > 0:
-        nav.append(InlineKeyboardButton(text="◀", callback_data=_cb("mv", f"{provider_idx}:{page - 1}")))
+        nav.append(
+            InlineKeyboardButton(text="◀", callback_data=_cb("mv", f"{provider_idx}:{page - 1}"))
+        )
     if start + page_size < len(models):
-        nav.append(InlineKeyboardButton(text="▶", callback_data=_cb("mv", f"{provider_idx}:{page + 1}")))
+        nav.append(
+            InlineKeyboardButton(text="▶", callback_data=_cb("mv", f"{provider_idx}:{page + 1}"))
+        )
     if nav:
         rows.append(nav)
 
@@ -432,20 +459,34 @@ def status_menu_keyboard(locale: str | None = None, *, is_admin: bool = True) ->
     rows.extend(
         [
             [
-                InlineKeyboardButton(text=t("tg.menu.sessions", loc), callback_data=_cb("r", "sessions")),
-                InlineKeyboardButton(text=t("tg.menu.streaming", loc), callback_data=_cb("r", "stream")),
+                InlineKeyboardButton(
+                    text=t("tg.menu.sessions", loc), callback_data=_cb("r", "sessions")
+                ),
+                InlineKeyboardButton(
+                    text=t("tg.menu.streaming", loc), callback_data=_cb("r", "stream")
+                ),
             ],
             [
-                InlineKeyboardButton(text=t("tg.menu.models", loc), callback_data=_cb("r", "models")),
+                InlineKeyboardButton(
+                    text=t("tg.menu.models", loc), callback_data=_cb("r", "models")
+                ),
                 InlineKeyboardButton(text="Tools", callback_data=_cb("r", "tools")),
             ],
             [
-                InlineKeyboardButton(text=t("tg.menu.subagents", loc), callback_data=_cb("r", "subagents")),
-                InlineKeyboardButton(text=t("tg.menu.reflexion", loc), callback_data=_cb("r", "reflexion")),
+                InlineKeyboardButton(
+                    text=t("tg.menu.subagents", loc), callback_data=_cb("r", "subagents")
+                ),
+                InlineKeyboardButton(
+                    text=t("tg.menu.reflexion", loc), callback_data=_cb("r", "reflexion")
+                ),
             ],
             [
-                InlineKeyboardButton(text=t("tg.menu.pipeline", loc), callback_data=_cb("r", "pipeline")),
-                InlineKeyboardButton(text=t("tg.menu.compress", loc), callback_data=_cb("r", "compress")),
+                InlineKeyboardButton(
+                    text=t("tg.menu.pipeline", loc), callback_data=_cb("r", "pipeline")
+                ),
+                InlineKeyboardButton(
+                    text=t("tg.menu.compress", loc), callback_data=_cb("r", "compress")
+                ),
             ],
         ]
     )

--- a/integrations/telegram/live_presenter.py
+++ b/integrations/telegram/live_presenter.py
@@ -175,13 +175,36 @@ class TelegramLivePresenter:
         label: str,
         *,
         markup: Any = None,
+        command: str = "",
+        os_pid: int = 0,
     ) -> None:
-        """Send a process notice and pin it for the user (best-effort)."""
+        """Send a process notice and pin it for the user (best-effort).
+
+        The same script in this chat replaces the previous pin; different
+        scripts stay pinned together.
+        """
         from core.i18n.messages import t
+        from core.runtime.process_script_key import process_script_key
+
+        from integrations.messenger.process_pins import (
+            same_script_process_ids,
+            save_pin,
+        )
 
         pid = (process_id or "").strip()
         if not pid:
             return
+        script_key = process_script_key(command)
+        bot_profile = getattr(self.session, "bot_profile", None) or self.session.profile
+        chat_id = self.session.chat_id
+        for old_pid in same_script_process_ids(
+            bot_profile, "telegram", chat_id, script_key, exclude=pid
+        ):
+            await self.unpin_background_process_notice(old_pid, label=label, status="stopped")
+        in_session = getattr(self.session, "background_process_script_keys", None) or {}
+        for old_pid, old_key in list(in_session.items()):
+            if old_pid != pid and old_key == script_key:
+                await self.unpin_background_process_notice(old_pid, label=label, status="stopped")
         try:
             from core.i18n.locale import LocaleStore
 
@@ -203,6 +226,22 @@ class TelegramLivePresenter:
             mid = int(getattr(msg, "message_id", 0) or 0)
             if mid:
                 self.session.background_process_message_ids[pid] = mid
+                keys = getattr(self.session, "background_process_script_keys", None)
+                if keys is not None:
+                    keys[pid] = script_key
+                try:
+                    save_pin(
+                        bot_profile,
+                        "telegram",
+                        chat_id,
+                        process_id=pid,
+                        message_id=mid,
+                        script_key=script_key,
+                        label=label or pid,
+                        os_pid=os_pid,
+                    )
+                except Exception:
+                    logger.debug("persist telegram process pin failed", exc_info=True)
                 try:
                     await self._bot.pin_chat_message(
                         self.session.chat_id,
@@ -231,6 +270,16 @@ class TelegramLivePresenter:
 
         pid = (process_id or "").strip()
         mid = self.session.background_process_message_ids.pop(pid, None)
+        keys = getattr(self.session, "background_process_script_keys", None)
+        if keys is not None:
+            keys.pop(pid, None)
+        try:
+            from integrations.messenger.process_pins import remove_pin
+
+            bot_profile = getattr(self.session, "bot_profile", None) or self.session.profile
+            remove_pin(bot_profile, "telegram", self.session.chat_id, pid)
+        except Exception:
+            logger.debug("remove telegram process pin failed", exc_info=True)
         if not mid:
             return
         try:

--- a/integrations/telegram/session.py
+++ b/integrations/telegram/session.py
@@ -45,6 +45,12 @@ class ChatSession:
     process_callback_tokens: dict[str, str] = field(default_factory=dict)
     # process_id -> Telegram message_id of pinned process notice
     background_process_message_ids: dict[str, int] = field(default_factory=dict)
+    # process_id -> script identity (same script replaces the pin)
+    background_process_script_keys: dict[str, str] = field(default_factory=dict)
+    subagent_callback_tokens: dict[str, str] = field(default_factory=dict)
+    subagent_watch_job_id: str | None = None
+    subagent_watch_message_id: int | None = None
+    subagent_watch_task: Any = None
     agent: Any = None
     subagent_owner: Any = None
     profile_manual_override: bool = False

--- a/tests/test_background_process_pin.py
+++ b/tests/test_background_process_pin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from core.agent_events import BackgroundProcessStartedEvent, BackgroundProcessStoppedEvent
@@ -39,14 +39,25 @@ async def test_telegram_pins_background_process_notice() -> None:
     # Drain queue manually after handle
     handler = TelegramEventHandler(presenter, approvals=MagicMock())
 
-    handler.handle(
-        BackgroundProcessStartedEvent(
-            process_id="proc_abc",
-            label="telegram_channel_publisher",
-            pid=12345,
-            conversation_id=session.conversation_id,
+    with (
+        patch(
+            "integrations.telegram.approvals._register_callback_token",
+            return_value="tok",
+        ),
+        patch(
+            "integrations.telegram.keyboards.background_process_stop_keyboard",
+            return_value=None,
+        ),
+    ):
+        handler.handle(
+            BackgroundProcessStartedEvent(
+                process_id="proc_abc",
+                label="telegram_channel_publisher",
+                pid=12345,
+                conversation_id=session.conversation_id,
+                command="python bot.py",
+            )
         )
-    )
     # Run outbound job
     job = presenter._outbound_queue.get_nowait()
     await job
@@ -71,6 +82,73 @@ async def test_telegram_pins_background_process_notice() -> None:
 
 
 @pytest.mark.asyncio
+async def test_telegram_replaces_pin_for_same_script_keeps_other() -> None:
+    session = ChatSession(
+        chat_id=42,
+        user_id=7,
+        profile="admin",
+        conversation_id="tg_admin_1",
+        bot_profile="admin",
+    )
+    from core.presenters.live_buffer import LiveTranscriptBuffer
+
+    session.live_buffer = LiveTranscriptBuffer(profile="admin", mode="react")
+    session.live_buffer.publish_answer_separately = True
+
+    bot = MagicMock()
+    msg_a = MagicMock(message_id=11)
+    msg_b = MagicMock(message_id=12)
+    msg_c = MagicMock(message_id=13)
+    bot.send_message = AsyncMock(side_effect=[msg_a, msg_b, msg_c])
+    bot.pin_chat_message = AsyncMock()
+    bot.unpin_chat_message = AsyncMock()
+    bot.edit_message_text = AsyncMock()
+
+    from integrations.telegram.live_presenter import TelegramLivePresenter
+
+    presenter = TelegramLivePresenter(bot, session)
+    await presenter.pin_background_process_notice(
+        "proc_a", "bot", command="python bot.py", os_pid=101
+    )
+    await presenter.pin_background_process_notice(
+        "proc_b", "bot", command="python bot.py --reload", os_pid=102
+    )
+    assert "proc_a" not in session.background_process_message_ids
+    assert session.background_process_message_ids["proc_b"] == 12
+    bot.unpin_chat_message.assert_awaited()
+
+    await presenter.pin_background_process_notice(
+        "proc_c", "worker", command="python worker.py", os_pid=103
+    )
+    assert set(session.background_process_message_ids) == {"proc_b", "proc_c"}
+
+
+@pytest.mark.asyncio
+async def test_reap_unpins_dead_process() -> None:
+    from integrations.messenger.process_pin_watch import reap_dead_pins
+    from integrations.messenger.process_pins import remove_pin, save_pin
+
+    save_pin(
+        "default",
+        "telegram",
+        42,
+        process_id="proc_dead",
+        message_id=9,
+        script_key="app.py",
+        os_pid=999_999_991,
+    )
+    unpinned: list[str] = []
+
+    async def unpin(chat_id: str, pid: str, rec: dict) -> None:
+        unpinned.append(pid)
+        remove_pin("default", "telegram", chat_id, pid)
+
+    n = await reap_dead_pins(bot_profile="default", platform="telegram", unpin=unpin)
+    assert n >= 1
+    assert "proc_dead" in unpinned
+
+
+@pytest.mark.asyncio
 async def test_max_client_pin_endpoints() -> None:
     from integrations.max.client import MaxClient
 
@@ -81,5 +159,7 @@ async def test_max_client_pin_endpoints() -> None:
     args = client._request.await_args
     assert args.args[0] == "PUT"
     assert "/chats/1001/pin" in args.args[1]
-    await client.unpin_message(1001)
+    await client.unpin_message(1001, message_id="mid-xyz")
     assert client._request.await_args.args[0] == "DELETE"
+    params = client._request.await_args.kwargs.get("params") or {}
+    assert params.get("message_id") == "mid-xyz"

--- a/tests/test_cli_lazy_imports.py
+++ b/tests/test_cli_lazy_imports.py
@@ -19,6 +19,10 @@ def test_bootstrap_argv_skips_heavy_modules() -> None:
     assert _needs_heavy_commands(["run", "hello"])
     assert _needs_heavy_commands(["skills", "list"])
     assert _needs_heavy_commands(["memory", "search", "test"])
+    assert _needs_heavy_commands(["-p", "admin", "subagent", "list"])
+    assert _needs_heavy_commands(["--profile", "admin", "subagent", "list"])
+    assert _needs_heavy_commands(["--verbose", "subagent", "list"])
+    assert not _needs_heavy_commands(["-p", "admin", "gateway", "status"])
 
 
 def test_register_bootstrap_without_chromadb(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_process_script_key.py
+++ b/tests/test_process_script_key.py
@@ -1,0 +1,30 @@
+"""Script identity for replacing messenger process pins."""
+
+from core.runtime.process_script_key import process_script_key
+
+
+def test_same_python_script_same_key() -> None:
+    a = process_script_key("python3 app.py --port 8000")
+    b = process_script_key("python app.py --reload")
+    assert a == b == "app.py"
+
+
+def test_different_scripts_different_keys() -> None:
+    assert process_script_key("python bot.py") != process_script_key("python worker.py")
+
+
+def test_npm_run_scripts() -> None:
+    assert process_script_key("npm run dev") != process_script_key("npm run start")
+    assert process_script_key("npm run dev -- --port 3000") == "npm:dev"
+
+
+def test_python_module_and_uvicorn() -> None:
+    assert process_script_key("python -m http.server 8080") == "py-m:http.server"
+    assert process_script_key("uvicorn app.main:app --reload") == "asgi:app.main:app"
+
+
+def test_cwd_disambiguates() -> None:
+    a = process_script_key("python app.py", cwd="/tmp/one")
+    b = process_script_key("python app.py", cwd="/tmp/two")
+    assert a != b
+    assert a.endswith("::app.py")

--- a/tests/test_reflexion.py
+++ b/tests/test_reflexion.py
@@ -38,6 +38,23 @@ def test_route_after_react_tools_still_preferred() -> None:
     )
 
 
+def test_route_after_react_honesty_retry_returns_to_react() -> None:
+    """Empty-tools honesty retry must not finalize via reflect."""
+    assert (
+        route_after_react(
+            {
+                "is_final": False,
+                "tool_calls": [],
+                "step_count": 1,
+                "max_steps": 90,
+                "honesty_nudge_count": 1,
+                "final_response": "",
+            }
+        )
+        == "react"
+    )
+
+
 def test_route_after_reflect_retry() -> None:
     assert (
         route_after_reflect(

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -16,6 +16,7 @@ def _manager(max_concurrent: int = 4) -> SubAgentManager:
         subagent_max_concurrent=max_concurrent,
         subagent_process_timeout=60.0,
         subagent_default_process_mode="async",
+        profile_name="default",
     )
     return SubAgentManager(parent)
 
@@ -73,3 +74,41 @@ def test_format_status_text_lists_jobs() -> None:
     text = mgr.format_status_text()
     assert "researcher-2" in text
     assert "find docs" in text
+    assert "profile default" in text
+
+
+def test_format_status_text_includes_profile_registry_jobs(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI / /subagents must see jobs published by other hosts on this profile."""
+    from core.subagents import runtime_registry as rr
+    from core.subagents.manager import format_jobs_status_text
+
+    monkeypatch.setenv("HOLIX_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        rr,
+        "profile_dir_for_name",
+        lambda name, default="default": tmp_path / "profiles" / (name or default),
+    )
+    owner = rr.owner_key(source="telegram", pid=999)
+    handle = SubAgentHandle(
+        name="coder",
+        status=SubAgentStatus.RUNNING,
+        task_preview="fix gateway",
+        agent_type="coder",
+        config=SubAgentConfig(name="coder", process_mode=ProcessMode.ASYNC),
+    )
+    rr.publish_handle("admin", handle, owner=owner, source="telegram")
+
+    mgr = _manager()
+    mgr._parent.config.profile_name = "admin"
+    text = mgr.format_status_text()
+    assert "coder" in text
+    assert "fix gateway" in text
+    assert "telegram" in text
+    assert "profile admin" in text
+
+    jobs = rr.list_jobs("admin", include_done=True)
+    cli_text = format_jobs_status_text(jobs, profile="admin")
+    assert "coder" in cli_text
+    assert "telegram" in cli_text

--- a/tests/test_subagent_watch.py
+++ b/tests/test_subagent_watch.py
@@ -1,0 +1,56 @@
+"""Live sub-agent watch text and job listing."""
+
+from __future__ import annotations
+
+from integrations.messenger.subagent_watch import (
+    format_list_text,
+    format_watch_text,
+    last_activity_steps,
+    map_job_tokens,
+    resolve_job_token,
+)
+
+
+def test_last_activity_steps_keeps_five() -> None:
+    job = {
+        "activity_log": [
+            {"kind": "status", "message": f"step {i}", "steps_taken": i} for i in range(1, 9)
+        ]
+    }
+    steps = last_activity_steps(job, limit=5)
+    assert [e["steps_taken"] for e in steps] == [4, 5, 6, 7, 8]
+
+
+def test_format_watch_text_includes_steps_and_name() -> None:
+    job = {
+        "name": "coder",
+        "status": "running",
+        "steps_taken": 4,
+        "max_steps": 10,
+        "task_preview": "fix gateway",
+        "current_activity": "writing files",
+        "activity_log": [
+            {"kind": "tool", "message": "write_file", "tool_name": "write_file", "steps_taken": 3},
+            {"kind": "thinking", "message": "Reasoning step 4", "steps_taken": 4},
+        ],
+    }
+    text = format_watch_text(job, html=False, locale="en")
+    assert "coder" in text
+    assert "write_file" in text
+    assert "Reasoning step 4" in text
+    html = format_watch_text(job, html=True, locale="ru")
+    assert "<b>" in html
+    assert "coder" in html
+
+
+def test_format_list_empty() -> None:
+    assert "No sub-agents" in format_list_text([], html=False, locale="en")
+
+
+def test_map_job_tokens_roundtrip() -> None:
+    mapping: dict[str, str] = {}
+    tokens = map_job_tokens(mapping, ["telegram-1::coder", "studio-2::researcher"])
+    assert len(tokens) == 2
+    assert resolve_job_token(mapping, tokens["telegram-1::coder"]) == "telegram-1::coder"
+    map_job_tokens(mapping, ["only"])
+    assert "telegram-1::coder" not in mapping.values()

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.15"
+version = "1.0.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Telegram/MAX: `/subagents` lists jobs with buttons; watch last 5 steps every 5s; Stop / Exit; one watch per chat.
- Background process pins keyed by script: same script replaces the pin, different scripts stay pinned, dead processes unpin.
- Honesty retry (`is_final=False`, no tools) returns to ReAct instead of an empty messenger final.
- `holix subagent list` is profile-scoped; `holix -p PROFILE subagent` loads the command.

No version bump / no GitHub release / no PyPI.

## Test plan
- [x] unit tests for watch text, pin replace, honesty routing, CLI lazy `-p`
- [ ] CI green