### PR TITLE
Holix 1.1.0

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.0.18"
+__version__ = "1.1.0"

--- a/core/acp/config.py
+++ b/core/acp/config.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 import os
 import shlex
 
+from core.platform_compat import IS_WINDOWS
+
 
 def acp_argv(*, command: str | None = None) -> list[str] | None:
     raw = (command or os.environ.get("HOLIX_ACP_COMMAND") or "").strip()
     if not raw:
         return None
-    argv = shlex.split(raw)
+    argv = shlex.split(raw, posix=not IS_WINDOWS)
     extra = (os.environ.get("HOLIX_ACP_ARGS") or "").strip()
     if extra:
-        argv.extend(shlex.split(extra))
+        argv.extend(shlex.split(extra, posix=not IS_WINDOWS))
     return argv or None
 
 

--- a/core/commands/reserved.py
+++ b/core/commands/reserved.py
@@ -27,6 +27,7 @@ RESERVED_SLASH_NAMES: frozenset[str] = frozenset(
         "trace",
         "permission",
         "pty",
+        "change",
         "new",
         "sessions",
         "switch",

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -1745,6 +1745,8 @@ def _build_system_prompt_from_state(state: HolixGraphState, agent=None) -> str:
                 workspace_root=getattr(agent.tools, "_workspace_root", None),
             )
             tools_desc = f"{tools_desc}\n\n{sdk}" if tools_desc else sdk
+    if not isinstance(tools_desc, str):
+        tools_desc = ""
 
     # Compact skill index (bodies load via skill_view)
     skills_formatted = ""
@@ -1761,6 +1763,8 @@ def _build_system_prompt_from_state(state: HolixGraphState, agent=None) -> str:
                 skills_formatted = ""
         if not skills_formatted and relevant_skills:
             skills_formatted = agent.skills.format_skills_for_prompt(relevant_skills)
+    if not isinstance(skills_formatted, str):
+        skills_formatted = ""
 
     # Format memories
     relevant_memories = state.get("relevant_memories", [])
@@ -1840,7 +1844,8 @@ def _build_system_prompt_from_state(state: HolixGraphState, agent=None) -> str:
 
     profile_name = profile_name_from_agent(agent) if agent else "default"
     agent_config = getattr(agent, "config", None) if agent else None
-    sub_prompt = str(getattr(agent, "subagent_system_prompt", "") or "").strip() if agent else ""
+    raw_sub = getattr(agent, "subagent_system_prompt", None) if agent else None
+    sub_prompt = raw_sub.strip() if isinstance(raw_sub, str) else ""
     try:
         from core.runtime.todo_list import format_todo_prompt_block, get_todos
 

--- a/core/host/command_menu.py
+++ b/core/host/command_menu.py
@@ -28,7 +28,6 @@ _HOST_COMMAND_KEYS: list[tuple[str, str]] = [
     ("todos", "tg.cmd.todos"),
     ("trace", "tg.cmd.trace"),
     ("permission", "tg.cmd.permission"),
-    ("pty", "tg.cmd.pty"),
     ("change", "tg.cmd.change"),
     ("tools", "tg.cmd.tools"),
     ("last", "tg.cmd.last"),

--- a/core/runtime/pty_session.py
+++ b/core/runtime/pty_session.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import fcntl
 import os
 import re
 import secrets
@@ -16,6 +15,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from core.platform_compat import IS_POSIX, IS_WINDOWS
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
 
 _DONE = "__HOLIX_DONE__"
 _READY = "__HOLIX_READY__"
@@ -300,6 +304,8 @@ def _spawn_shell(
     workspace_root: str | None,
     sandbox_mode: str,
 ) -> PtyShell:
+    if fcntl is None:
+        raise PtyUnavailable("PTY requires POSIX fcntl")
     import pty as py_pty
 
     bash = shutil.which("bash") or "/bin/bash"

--- a/core/security/confirmation.py
+++ b/core/security/confirmation.py
@@ -571,6 +571,11 @@ class ConfirmationChoice(StrEnum):
     DENY = "deny"  # Block this tool call
 
 
+# Async sub-agents wait on the parent ActionGuard. If Telegram/MAX drops a
+# parallel confirmation keyboard, timeout=none freezes the job forever.
+SUBAGENT_CONFIRMATION_TIMEOUT_S = 300
+
+
 def normalize_confirmation_timeout(value: int | float | None, *, default: int = 0) -> int:
     """Seconds to wait for user approval. 0 or negative = no timeout."""
     if value is None:
@@ -823,6 +828,8 @@ class ActionGuard:
 
             # Wait for resolution (with configurable timeout)
             timeout = self._confirmation_timeout if self._confirmation_timeout > 0 else None
+            if timeout is None and str(conversation_id or "").startswith("subagent:"):
+                timeout = float(SUBAGENT_CONFIRMATION_TIMEOUT_S)
             logger.info(
                 "ActionGuard: awaiting confirmation (timeout=%s, pending=%d)",
                 f"{timeout}s" if timeout is not None else "none",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.1.0 — 2026-08-27
+
+Code mode, SDD git worktrees, OS sandbox, persistent PTY, ACP, session todos, and Telegram/MAX stability.
+
 ### Added
 
 - **SDD git worktrees** — `sdd_create_change` creates a linked git worktree (`.holix/worktrees/<id>`, branch `change/<id>`) and binds the conversation to it. File tools, terminal, and sub-agents use that tree. `/change` lists, switches, or leaves. `HOLIX_WORKTREE=0` keeps the old in-place scaffold. Main clone stays on its current branch. After `sdd_archive`, if the only uncommitted files are under `openspec/`, Holix commits them (`sdd_archive <id>`) and `git worktree remove`. Extra dirty files keep the tree and return porcelain status. Gateway/Telegram start runs `git worktree prune` and, when over `git_worktrees_max`, drops archived+clean trees.
@@ -19,6 +23,7 @@
 
 ### Fixed
 
+- **Parallel sub-agent confirmations** — Telegram/MAX kept one inline keyboard and cleared callback tokens when the next `run_code` asked for approval. Sibling jobs waited forever (`confirmation_timeout=0`). Each prompt now has its own buttons; unused tokens stay. Sub-agent conversations time out after 300s and continue (deny) instead of hanging.
 - **LangGraph `database is locked`** — each overlapping graph (Telegram, Studio host sessions, sub-agents) opened its own SQLite connection to `checkpoints.db`. WAL still serializes writers; a 30s wait then failed the turn. One shared connection per process now; sub-agent graphs use in-memory checkpoints; writers wait up to 60s; autocommit so LangGraph SELECTs do not hold a read transaction.
 - **Browser launch hang** — Chromium `launch` is capped at 30s and no longer holds the session lock, so a stuck launch cannot block `close()`. Context/browser close has an 8s timeout. `browser_open` maps `networkidle` to `load` (long-polling pages never go idle).
 - **PTY write busy-loop** — non-blocking `os.write` to the persistent shell used `except BlockingIOError: continue` on the asyncio loop. When the slave stopped reading (full output buffer / large command) Telegram spun at 100% CPU, `getUpdates` sockets stuck in `CLOSE_WAIT`, and the bot looked dead. Writes now sleep, drain output, and honor the command timeout.
@@ -40,6 +45,15 @@
 - **TUI live process bar** — the top of the screen lists only OS-alive background processes (all of them). Stopped/crashed jobs are removed; the bar polls every 2s. Click a row for its log.
 - **Docs** — TUI (queue + live process bar), Code mode, Telegram/MAX type manager. One canonical page per topic; site nav grouped; TOC on long pages.
 - **TUI workspace** — tools use the directory where `holix tui` was launched (not `profiles/<name>/workspace`). Telegram/MAX keep the profile workspace. Not written to `config.yaml`.
+
+### Tests
+
+- Git worktree bind/archive/prune; shared SQLite checkpointer and in-memory sub-agent saver.
+- Code mode worker/SDK, ACP client, PTY, todos, trajectory, OS sandbox, permission presets.
+- TUI prompt queue, live process bar, todo list, launch workspace.
+- Telegram/MAX help guide and sub-agent type manager.
+- Parallel messenger confirmation tokens; sub-agent confirmation 300s timeout.
+- Browser launch timeout / `networkidle`→`load`; `skill_view` on-demand bodies; sub-agent fork.
 
 ## 1.0.18 — 2026-08-24
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,6 +54,8 @@ Code mode, SDD git worktrees, OS sandbox, persistent PTY, ACP, session todos, an
 - Telegram/MAX help guide and sub-agent type manager.
 - Parallel messenger confirmation tokens; sub-agent confirmation 300s timeout.
 - Browser launch timeout / `networkidle`→`load`; `skill_view` on-demand bodies; sub-agent fork.
+- PTY module imports on Windows (`fcntl` is POSIX-only). `/change` is reserved; Telegram/MAX menu stays at 32 commands (`/pty` remains TUI/CLI).
+- ReAct system prompt ignores MagicMock `subagent_system_prompt` / skills (unit tests).
 
 ## 1.0.18 — 2026-08-24
 

--- a/integrations/max/approvals.py
+++ b/integrations/max/approvals.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
-import secrets
 from typing import Any
 
 from core.plan_review.review_events import PlanReviewRequestEvent
@@ -15,14 +15,12 @@ from integrations.max.client import MaxClient
 from integrations.max.keyboards import confirmation_keyboard, plan_review_keyboard
 from integrations.max.markdown import plain_to_max_html
 from integrations.max.models import message_id_from_response, reply_kwargs_for_session
-
-
-def _register_callback_token(mapping: dict[str, str], full_id: str) -> str:
-    """Map a short opaque token to the full confirmation/review id."""
-    mapping.clear()
-    token = secrets.token_hex(4)
-    mapping[token] = full_id
-    return token
+from integrations.messenger.callback_tokens import (
+    drop_callback_token,
+)
+from integrations.messenger.callback_tokens import (
+    register_callback_token as _register_callback_token,
+)
 
 
 def _lookup_callback_token(mapping: dict[str, str], token_or_id: str) -> str:
@@ -38,7 +36,6 @@ class MaxApprovals:
         self._pending_review_id: str | None = None
 
     async def on_confirmation_request(self, event: ConfirmationRequestEvent) -> None:
-        await self.dismiss_confirmation_ui()
         self._pending_confirm_id = event.confirmation_id
         token = _register_callback_token(
             self._session.approval_callback_tokens,
@@ -67,7 +64,14 @@ class MaxApprovals:
                 chat_type=self._session.chat_type,
             ),
         )
-        self._session.pending_confirmation_message_id = message_id_from_response(payload)
+        mid = message_id_from_response(payload)
+        self._session.pending_confirmation_message_id = mid
+        ids = getattr(self._session, "pending_confirmation_message_ids", None)
+        if ids is None:
+            self._session.pending_confirmation_message_ids = {}
+            ids = self._session.pending_confirmation_message_ids
+        if mid:
+            ids[event.confirmation_id] = mid
 
     async def on_plan_review_request(self, event: PlanReviewRequestEvent) -> None:
         await self.dismiss_plan_review_ui()
@@ -150,8 +154,7 @@ class MaxApprovals:
             confirmation_id,
         )
         if self._try_resolve_confirmation(full_id, choice):
-            self._pending_confirm_id = None
-            self._session.approval_callback_tokens.clear()
+            self._forget_confirmation(full_id)
             return True
 
         agent = self._session.agent
@@ -159,15 +162,31 @@ class MaxApprovals:
             from core.subagents.interaction import resolve_any_confirmation
 
             if resolve_any_confirmation(agent, choice):
-                self._pending_confirm_id = None
-                self._session.approval_callback_tokens.clear()
+                self._forget_confirmation(full_id)
                 return True
 
         if self._confirmation_already_resolved(full_id):
-            self._pending_confirm_id = None
-            self._session.approval_callback_tokens.clear()
+            self._forget_confirmation(full_id)
             return True
         return False
+
+    def _forget_confirmation(self, confirmation_id: str) -> None:
+        drop_callback_token(self._session.approval_callback_tokens, confirmation_id)
+        if self._pending_confirm_id == confirmation_id:
+            self._pending_confirm_id = None
+        ids = getattr(self._session, "pending_confirmation_message_ids", None)
+        mid = None
+        if isinstance(ids, dict):
+            mid = ids.pop(confirmation_id, None)
+        if mid is None:
+            mid = self._session.pending_confirmation_message_id
+            self._session.pending_confirmation_message_id = None
+        if mid:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._delete_message_safe(str(mid)))
+            except RuntimeError:
+                pass
 
     def _try_resolve_confirmation(
         self,

--- a/integrations/max/session.py
+++ b/integrations/max/session.py
@@ -41,6 +41,7 @@ class MaxChatSession:
     pending_plan_review_id: str | None = None
     pending_plan_phase: str = "approval"
     pending_confirmation_message_id: str | None = None
+    pending_confirmation_message_ids: dict[str, str] = field(default_factory=dict)
     pending_plan_message_ids: list[str] = field(default_factory=list)
     approval_callback_tokens: dict[str, str] = field(default_factory=dict)
     plan_callback_tokens: dict[str, str] = field(default_factory=dict)

--- a/integrations/messenger/callback_tokens.py
+++ b/integrations/messenger/callback_tokens.py
@@ -1,0 +1,34 @@
+"""Short opaque tokens for messenger inline buttons (Telegram 64-byte cap)."""
+
+from __future__ import annotations
+
+import secrets
+
+_TOKEN_CAP = 48
+
+
+def register_callback_token(mapping: dict[str, str], full_id: str) -> str:
+    """Map *full_id* to an 8-hex token. Keeps prior entries (parallel sub-agents)."""
+    wanted = (full_id or "").strip()
+    if not wanted:
+        token = secrets.token_hex(4)
+        mapping[token] = wanted
+        return token
+    for tok, cid in mapping.items():
+        if cid == wanted:
+            return tok
+    token = secrets.token_hex(4)
+    while token in mapping:
+        token = secrets.token_hex(4)
+    mapping[token] = wanted
+    while len(mapping) > _TOKEN_CAP:
+        mapping.pop(next(iter(mapping)), None)
+    return token
+
+
+def drop_callback_token(mapping: dict[str, str], full_id: str) -> None:
+    """Remove the token for one confirmation; leave siblings in place."""
+    wanted = (full_id or "").strip()
+    dead = [tok for tok, cid in mapping.items() if cid == wanted]
+    for tok in dead:
+        mapping.pop(tok, None)

--- a/integrations/telegram/approvals.py
+++ b/integrations/telegram/approvals.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import secrets
+import asyncio
 from typing import Any
 
 from core.plan_review.review_events import PlanReviewRequestEvent
@@ -10,18 +10,16 @@ from core.plan_review.review_guard import PlanReviewChoice, get_plan_review_guar
 from core.security.confirmation import ConfirmationChoice, get_action_guard
 from core.security.confirmation_events import ConfirmationRequestEvent
 
+from integrations.messenger.callback_tokens import (
+    drop_callback_token,
+)
+from integrations.messenger.callback_tokens import (
+    register_callback_token as _register_callback_token,
+)
 from integrations.telegram.markdown import escape_html, plain_to_telegram_html
 
 # Telegram Bot API: callback_data must be 1–64 bytes.
 _TELEGRAM_CALLBACK_MAX_BYTES = 64
-
-
-def _register_callback_token(mapping: dict[str, str], full_id: str) -> str:
-    """Map a short opaque token to the full confirmation/review id."""
-    mapping.clear()
-    token = secrets.token_hex(4)
-    mapping[token] = full_id
-    return token
 
 
 def _lookup_callback_token(mapping: dict[str, str], token_or_id: str) -> str:
@@ -44,7 +42,8 @@ class TelegramApprovals:
         self._pending_review_id: str | None = None
 
     async def on_confirmation_request(self, event: ConfirmationRequestEvent) -> None:
-        await self.dismiss_confirmation_ui()
+        # Keep sibling prompts (parallel sub-agents). Dismissing here left
+        # earlier run_code confirmations waiting forever with no keyboard.
         self._pending_confirm_id = event.confirmation_id
         token = _register_callback_token(
             self._session.approval_callback_tokens,
@@ -104,6 +103,11 @@ class TelegramApprovals:
             reply_markup=kb,
         )
         self._session.pending_confirmation_message_id = sent.message_id
+        ids = getattr(self._session, "pending_confirmation_message_ids", None)
+        if ids is None:
+            self._session.pending_confirmation_message_ids = {}
+            ids = self._session.pending_confirmation_message_ids
+        ids[event.confirmation_id] = sent.message_id
 
     async def on_plan_review_request(self, event: PlanReviewRequestEvent) -> None:
         await self.dismiss_plan_review_ui()
@@ -199,8 +203,7 @@ class TelegramApprovals:
             confirmation_id,
         )
         if self._try_resolve_confirmation(full_id, choice):
-            self._pending_confirm_id = None
-            self._session.approval_callback_tokens.clear()
+            self._forget_confirmation(full_id)
             return True
 
         # Fallback: match /yes behaviour (latest pending on this agent).
@@ -209,16 +212,32 @@ class TelegramApprovals:
             from core.subagents.interaction import resolve_any_confirmation
 
             if resolve_any_confirmation(agent, choice):
-                self._pending_confirm_id = None
-                self._session.approval_callback_tokens.clear()
+                self._forget_confirmation(full_id)
                 return True
 
         # Idempotent: user double-tapped after the action was already approved.
         if self._confirmation_already_resolved(full_id):
-            self._pending_confirm_id = None
-            self._session.approval_callback_tokens.clear()
+            self._forget_confirmation(full_id)
             return True
         return False
+
+    def _forget_confirmation(self, confirmation_id: str) -> None:
+        drop_callback_token(self._session.approval_callback_tokens, confirmation_id)
+        if self._pending_confirm_id == confirmation_id:
+            self._pending_confirm_id = None
+        ids = getattr(self._session, "pending_confirmation_message_ids", None)
+        mid = None
+        if isinstance(ids, dict):
+            mid = ids.pop(confirmation_id, None)
+        if mid is None and self._session.pending_confirmation_message_id is not None:
+            mid = self._session.pending_confirmation_message_id
+            self._session.pending_confirmation_message_id = None
+        if mid is not None:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._delete_message_safe(int(mid)))
+            except RuntimeError:
+                pass
 
     def _try_resolve_confirmation(
         self,

--- a/integrations/telegram/session.py
+++ b/integrations/telegram/session.py
@@ -38,6 +38,7 @@ class ChatSession:
     pending_plan_review_id: str | None = None
     pending_plan_phase: str = "approval"
     pending_confirmation_message_id: int | None = None
+    pending_confirmation_message_ids: dict[str, int] = field(default_factory=dict)
     pending_plan_message_ids: list[int] = field(default_factory=list)
     # Short tokens for Telegram inline buttons (callback_data max 64 bytes).
     approval_callback_tokens: dict[str, str] = field(default_factory=dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.0.18"
+version = "1.1.0"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_acp_client.py
+++ b/tests/test_acp_client.py
@@ -85,6 +85,19 @@ def test_acp_argv_parses_command_and_args(monkeypatch: pytest.MonkeyPatch) -> No
     assert acp_argv() is None
 
 
+def test_acp_argv_keeps_windows_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.acp import config as acp_config
+
+    monkeypatch.setattr(acp_config, "IS_WINDOWS", True)
+    win = r"D:\a\Holix\.venv\Scripts\python.exe D:\tmp\acp_echo.py"
+    monkeypatch.setenv("HOLIX_ACP_COMMAND", win)
+    monkeypatch.delenv("HOLIX_ACP_ARGS", raising=False)
+    assert acp_argv() == [
+        r"D:\a\Holix\.venv\Scripts\python.exe",
+        r"D:\tmp\acp_echo.py",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_run_acp_prompt_echo(fake_agent: Path) -> None:
     result = await run_acp_prompt(

--- a/tests/test_code_mode.py
+++ b/tests/test_code_mode.py
@@ -176,7 +176,12 @@ async def test_run_code_terminal_pwd_is_workspace(tmp_path) -> None:
         )
     )
     ws = str((tmp_path / "ws").resolve())
-    assert ws in out.replace("/private", "") or ws in out
+    blob = out.replace("/private", "").replace("\\", "/")
+    posix_ws = ws.replace("\\", "/")
+    git_bash_ws = posix_ws
+    if len(posix_ws) >= 2 and posix_ws[1] == ":":
+        git_bash_ws = f"/{posix_ws[0].lower()}{posix_ws[2:]}"
+    assert posix_ws in blob or git_bash_ws in blob or ws in out
 
 
 @pytest.mark.asyncio

--- a/tests/test_confirmation.py
+++ b/tests/test_confirmation.py
@@ -659,6 +659,37 @@ class TestActionGuard:
         result = await asyncio.wait_for(task, timeout=2.0)
         assert result == "late approval ok"
 
+    @pytest.mark.asyncio
+    async def test_subagent_confirmation_times_out(self, monkeypatch: pytest.MonkeyPatch):
+        """Sub-agent conversations must not wait forever when no keyboard is left."""
+        monkeypatch.setattr(
+            "core.security.confirmation.SUBAGENT_CONFIRMATION_TIMEOUT_S",
+            0.05,
+        )
+        guard = ActionGuard(
+            event_bus=None,
+            permission_manager=self.pm,
+            risk_classifier=self.classifier,
+            auto_allow_threshold=RiskLevel.NO,
+            interactive=True,
+            confirmation_timeout=0,
+        )
+
+        async def fake_execute(**kwargs):
+            return "should not run"
+
+        class FakeTool:
+            risk_level = "high"
+
+        result = await guard.check_and_execute(
+            tool_name="run_code",
+            tool_instance=FakeTool(),
+            arguments={"code": "print(1)"},
+            execute_fn=fake_execute,
+            conversation_id="subagent:coder-1",
+        )
+        assert "denied" in result.lower() or "Error" in result
+
 
 class TestPlanExecutionAutoApprove:
     """Tests for auto-approve flag during plan execution."""

--- a/tests/test_telegram_approvals.py
+++ b/tests/test_telegram_approvals.py
@@ -63,6 +63,43 @@ async def test_dismiss_confirmation_ignores_delete_errors(
     assert session.pending_confirmation_message_id is None
 
 
+def test_register_callback_token_keeps_siblings() -> None:
+    mapping: dict[str, str] = {}
+    a = _register_callback_token(mapping, "confirm_a")
+    b = _register_callback_token(mapping, "confirm_b")
+    assert a != b
+    assert mapping[a] == "confirm_a"
+    assert mapping[b] == "confirm_b"
+
+
+def test_resolve_one_confirmation_keeps_sibling_token(
+    approvals: TelegramApprovals, session: ChatSession
+) -> None:
+    agent = MagicMock()
+    agent.tools = MagicMock()
+    agent.subagents = None
+    bus = MagicMock()
+    guard = init_action_guard(event_bus=bus, confirmation_timeout=0)
+    agent.tools._action_guard = guard
+    session.agent = agent
+
+    loop = asyncio.new_event_loop()
+    try:
+        fa = loop.create_future()
+        fb = loop.create_future()
+        guard._pending_confirmations["confirm_a"] = fa
+        guard._pending_confirmations["confirm_b"] = fb
+        ta = _register_callback_token(session.approval_callback_tokens, "confirm_a")
+        tb = _register_callback_token(session.approval_callback_tokens, "confirm_b")
+        assert approvals.resolve_confirmation_callback(ta, "1") is True
+        assert fa.result() == ConfirmationChoice.ALLOW_ONCE
+        assert not fb.done()
+        assert session.approval_callback_tokens[tb] == "confirm_b"
+        assert ta not in session.approval_callback_tokens
+    finally:
+        loop.close()
+
+
 def test_callback_data_stays_within_telegram_limit() -> None:
     token = _register_callback_token({}, "confirm_99_" + "x" * 80)
     assert len(_callback_data("cfm", token, "1").encode("utf-8")) <= 64

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.0.18"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix 1.1.0.

Includes everything on `main` since 1.0.18 (Code mode, SDD git worktrees, OS sandbox, PTY, ACP, session todos, Telegram/MAX help and type manager, checkpoint lock fix, browser/PTY/Telegram stability) plus the uncommitted parallel sub-agent confirmation fix.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py (`1.1.0`)
- [x] docs/CHANGELOG.md has section 1.1.0
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.1.0` (creates GitHub Release + PyPI).