### PR TITLE
Holix 1.1.1

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/core/memory/chroma_client.py
+++ b/core/memory/chroma_client.py
@@ -1,0 +1,44 @@
+"""Process-wide Chroma ``PersistentClient`` cache.
+
+Chroma 0.5+/1.x rust bindings (``chromadb_rust_bindings``) segfault when the
+same process opens more than one ``PersistentClient`` on one directory.
+Holix used to construct one client in ``ConversationStore`` and another in
+``VectorMemoryStore`` for the same ``vector_db_path``, then more for extra
+Studio sessions and in-process sub-agents — that kills the Studio process
+(Caddy 502) as soon as SDD apply spawns parallel sub-agents.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+_LOCK = threading.Lock()
+_CLIENTS: dict[str, Any] = {}
+
+
+def chroma_client_key(path: str | Path) -> str:
+    return str(Path(path).expanduser().resolve())
+
+
+def get_persistent_client(path: str | Path, **kwargs: Any) -> Any:
+    """Return the process singleton PersistentClient for ``path``."""
+    import chromadb
+    from chromadb.config import Settings as ChromaSettings
+
+    key = chroma_client_key(path)
+    with _LOCK:
+        client = _CLIENTS.get(key)
+        if client is not None:
+            return client
+        settings = kwargs.pop("settings", None) or ChromaSettings(anonymized_telemetry=False)
+        client = chromadb.PersistentClient(path=key, settings=settings, **kwargs)
+        _CLIENTS[key] = client
+        return client
+
+
+def reset_persistent_clients() -> None:
+    """Drop cached clients (tests). Does not shut down native Chroma runtimes."""
+    with _LOCK:
+        _CLIENTS.clear()

--- a/core/memory/conversation.py
+++ b/core/memory/conversation.py
@@ -8,8 +8,6 @@ from datetime import datetime
 from typing import Any
 
 import aiosqlite
-import chromadb
-from chromadb.config import Settings as ChromaSettings
 
 from core.di.runtime_config import HolixRuntimeConfig
 from core.memory.chroma_embeddings import get_or_create_collection
@@ -68,10 +66,9 @@ class ConversationStore:
         self.db_path = prepare_sqlite_db_file(cfg.memory_db_path)
         self.vector_db_path = prepare_vector_db_dir(cfg.vector_db_path)
 
-        self.chroma_client = chromadb.PersistentClient(
-            path=str(self.vector_db_path),
-            settings=ChromaSettings(anonymized_telemetry=False),
-        )
+        from core.memory.chroma_client import get_persistent_client
+
+        self.chroma_client = get_persistent_client(self.vector_db_path)
         collection_name = cfg.memory_chroma_collection or "memory"
         self.collection = get_or_create_collection(
             self.chroma_client,

--- a/core/memory/vector.py
+++ b/core/memory/vector.py
@@ -13,7 +13,6 @@ import logging
 from typing import Any
 
 import chromadb
-from chromadb.config import Settings as ChromaSettings
 
 from core.memory.chroma_embeddings import get_or_create_collection
 
@@ -31,15 +30,14 @@ class VectorMemoryStore:
     def __init__(self, vector_db_path: str | None = None):
         if vector_db_path is None:
             from core.di.runtime_config import HolixRuntimeConfig
+
             vector_db_path = HolixRuntimeConfig.from_settings().vector_db_path
+        from core.memory.chroma_client import get_persistent_client
         from core.paths import prepare_vector_db_dir
 
         self._vector_db_path = prepare_vector_db_dir(vector_db_path)
 
-        self._chroma_client = chromadb.PersistentClient(
-            path=str(self._vector_db_path),
-            settings=ChromaSettings(anonymized_telemetry=False),
-        )
+        self._chroma_client = get_persistent_client(self._vector_db_path)
 
         # Lazy collection cache — created on first access
         self._collections: dict[str, chromadb.Collection] = {}
@@ -210,11 +208,13 @@ class VectorMemoryStore:
 
             if raw["documents"] and raw["documents"][0]:
                 for i, doc in enumerate(raw["documents"][0]):
-                    items.append({
-                        "content": doc,
-                        "metadata": raw["metadatas"][0][i] if raw["metadatas"] else {},
-                        "distance": raw["distances"][0][i] if raw.get("distances") else None,
-                    })
+                    items.append(
+                        {
+                            "content": doc,
+                            "metadata": raw["metadatas"][0][i] if raw["metadatas"] else {},
+                            "distance": raw["distances"][0][i] if raw.get("distances") else None,
+                        }
+                    )
 
             results[name] = items
 

--- a/core/skills/manager.py
+++ b/core/skills/manager.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import chromadb
 import yaml
 
 from core.di.runtime_config import HolixRuntimeConfig
@@ -78,9 +77,11 @@ class SkillsManager:
         if self._local_skills_dir:
             self._local_skills_dir.mkdir(parents=True, exist_ok=True)
 
-        # Initialize ChromaDB for semantic skill search
-        self.chroma_client = chromadb.PersistentClient(
-            path=str(Path(cfg.vector_db_path).parent / "skills_db"),
+        # Initialize ChromaDB for semantic skill search (process singleton per path)
+        from core.memory.chroma_client import get_persistent_client
+
+        self.chroma_client = get_persistent_client(
+            Path(cfg.vector_db_path).parent / "skills_db",
         )
         self.skills_collection = get_or_create_collection(
             self.chroma_client,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 1.1.1 — 2026-08-29
+
+### Fixed
+
+- **Chroma PersistentClient singleton** — opening two `PersistentClient`s on the same directory segfaults in `chromadb_rust_bindings` (Studio 502 after SDD apply via sub-agents). Conversation memory and LTM now share one client per path; extra Studio sessions and in-process sub-agents reuse it.
+
 ## 1.1.0 — 2026-08-27
 
 Code mode, SDD git worktrees, OS sandbox, persistent PTY, ACP, session todos, and Telegram/MAX stability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.1.0"
+version = "1.1.1"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_chroma_client.py
+++ b/tests/test_chroma_client.py
@@ -1,0 +1,93 @@
+"""Process-wide Chroma PersistentClient singleton."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.di.runtime_config import HolixRuntimeConfig
+from core.memory.chroma_client import (
+    chroma_client_key,
+    get_persistent_client,
+    reset_persistent_clients,
+)
+from core.memory.facade import MemoryFacade
+
+
+class _FakeClient:
+    def __init__(self, path=None, settings=None, **_kwargs):
+        self.path = path
+        self.settings = settings
+
+    def get_collection(self, name, embedding_function=None, **_kwargs):
+        return {"name": name, "embedding_function": embedding_function}
+
+    def create_collection(self, **_kwargs):
+        raise AssertionError("must reuse existing collection")
+
+
+def test_get_persistent_client_reuses_same_path(tmp_path, monkeypatch) -> None:
+    created: list[str] = []
+
+    def _factory(*, path, settings=None, **kwargs):
+        created.append(path)
+        return _FakeClient(path=path, settings=settings)
+
+    monkeypatch.setattr("chromadb.PersistentClient", _factory)
+    reset_persistent_clients()
+    a = get_persistent_client(tmp_path / "vec")
+    b = get_persistent_client(tmp_path / "vec")
+    c = get_persistent_client(tmp_path / "other")
+    assert a is b
+    assert a is not c
+    assert created == [
+        chroma_client_key(tmp_path / "vec"),
+        chroma_client_key(tmp_path / "other"),
+    ]
+    reset_persistent_clients()
+
+
+def test_memory_facade_shares_vector_client(tmp_path, monkeypatch) -> None:
+    created: list[str] = []
+
+    def _factory(*, path, settings=None, **kwargs):
+        created.append(path)
+        return _FakeClient(path=path, settings=settings)
+
+    monkeypatch.setattr("chromadb.PersistentClient", _factory)
+    reset_persistent_clients()
+    cfg = HolixRuntimeConfig.from_settings().with_overrides(
+        memory_db_path=str(tmp_path / "mem.db"),
+        vector_db_path=str(tmp_path / "vector_db"),
+        ltm_db_path=str(tmp_path / "ltm.db"),
+        memory_chroma_collection="test_memory",
+        enable_long_term_memory=True,
+    )
+    facade = MemoryFacade(cfg)
+    assert facade.conversations.chroma_client is facade._ltm._vector_store._chroma_client
+    vec_key = chroma_client_key(tmp_path / "vector_db")
+    assert created.count(vec_key) == 1
+    reset_persistent_clients()
+
+
+def test_second_facade_reuses_client(tmp_path, monkeypatch) -> None:
+    created: list[str] = []
+
+    def _factory(*, path, settings=None, **kwargs):
+        created.append(path)
+        return _FakeClient(path=path, settings=settings)
+
+    monkeypatch.setattr("chromadb.PersistentClient", _factory)
+    reset_persistent_clients()
+    cfg = HolixRuntimeConfig.from_settings().with_overrides(
+        memory_db_path=str(tmp_path / "mem.db"),
+        vector_db_path=str(tmp_path / "vector_db"),
+        ltm_db_path=str(tmp_path / "ltm.db"),
+        memory_chroma_collection="test_memory",
+        enable_long_term_memory=True,
+    )
+    first = MemoryFacade(cfg)
+    second = MemoryFacade(cfg)
+    assert first.conversations.chroma_client is second.conversations.chroma_client
+    vec_key = chroma_client_key(Path(tmp_path / "vector_db"))
+    assert created.count(vec_key) == 1
+    reset_persistent_clients()

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix 1.1.1 — Chroma PersistentClient process singleton.

Opening two `PersistentClient`s on the same directory segfaults in `chromadb_rust_bindings` (Studio 502 after SDD apply via in-process sub-agents). Conversation memory, LTM, and skills now share one client per path.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py
- [x] docs/CHANGELOG.md has section 1.1.1
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.1.1` (creates GitHub Release + PyPI).