### PR TITLE
Holix 1.1.4

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.1.4 — 2026-08-31
+
 ### Changed
 
 - **Claude-style deferred tools** — the LLM `tools` list is a core set

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.1.3"
+version = "1.1.4"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix 1.1.4 — Claude-style deferred tool schemas (`tool_search` + core set) and live tests 69–71.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py (`1.1.4`)
- [x] docs/CHANGELOG.md has section 1.1.4
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.1.4` (creates GitHub Release + PyPI).