### PR TITLE
Holix 1.1.5

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"

--- a/core/agent_events.py
+++ b/core/agent_events.py
@@ -139,6 +139,10 @@ class UserMessageEvent(AgentEvent):
 
     content: str = ""
 
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.USER_MESSAGE)
+
     def _extra_fields(self) -> dict[str, Any]:
         return {"content": self.content}
 
@@ -270,6 +274,10 @@ class ToolCallResultEvent(AgentEvent):
     duration_ms: float | None = None
     truncated: bool = False
 
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.TOOL_CALL_RESULT)
+
     def _extra_fields(self) -> dict[str, Any]:
         return {
             "tool_name": self.tool_name,
@@ -288,6 +296,10 @@ class ToolCallErrorEvent(AgentEvent):
     tool_id: str = ""
     error: str = ""
 
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.TOOL_CALL_ERROR)
+
     def _extra_fields(self) -> dict[str, Any]:
         return {
             "tool_name": self.tool_name,
@@ -301,6 +313,10 @@ class MaxStepsReachedEvent(AgentEvent):
     """Agent reached the configured max_steps limit."""
 
     max_steps: int = 90
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.MAX_STEPS_REACHED)
 
 
 @dataclass

--- a/core/graph/action_honesty.py
+++ b/core/graph/action_honesty.py
@@ -1394,6 +1394,25 @@ def _nudge_for_presentation(nudge: str, tools_presentation: str | None) -> str:
     return nudge.rstrip() + CODE_MODE_NUDGE_TAIL
 
 
+def should_nudge_introspect_final(
+    *,
+    final_response: str | None,
+    messages: list[dict[str, Any]] | None,
+) -> bool:
+    """True when the model echoed a blocked inspect probe as the answer."""
+    from core.runtime.introspect_signals import is_introspect_refusal
+
+    if is_introspect_refusal(final_response):
+        return True
+    for msg in reversed(messages or []):
+        role = str(msg.get("role") or "")
+        if role == "tool":
+            return is_introspect_refusal(str(msg.get("content") or ""))
+        if role == "user":
+            break
+    return False
+
+
 def honesty_retry_update(
     *,
     messages: list[dict[str, Any]],
@@ -1417,7 +1436,11 @@ def honesty_retry_update(
         if not already:
             updated.append({"role": "assistant", "content": final_response})
     user = (user_input or "").strip() or last_user_text(updated)
-    if is_sdd_fill_request(user) or claims_sdd_artifacts_filled(final_response):
+    if should_nudge_introspect_final(final_response=final_response, messages=updated):
+        from core.runtime.introspect_signals import INTROSPECT_WRITE_NUDGE
+
+        nudge = INTROSPECT_WRITE_NUDGE
+    elif is_sdd_fill_request(user) or claims_sdd_artifacts_filled(final_response):
         nudge = SDD_FILL_HONESTY_NUDGE
     elif denies_visible_workspace(final_response, updated):
         nudge = WORKSPACE_GROUNDING_NUDGE

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -32,6 +32,7 @@ from core.graph.action_honesty import (
     resolve_tool_choice,
     scrub_false_empty_claim_content,
     should_nudge_false_completion,
+    should_nudge_introspect_final,
     should_refuse_false_empty_workspace,
     should_refuse_status_monologue,
     should_refuse_unproven_sdd_fill,
@@ -402,6 +403,25 @@ def _maybe_honesty_retry(
     SDD fill: after max nudges without sdd_write_artifact, replace the lie with
     an honest refusal instead of accepting the claim as final.
     """
+    if should_nudge_introspect_final(final_response=final_response, messages=messages):
+        logger.warning(
+            "Action honesty nudge: blocked echoing library introspection (conversation_id=%s)",
+            state.get("conversation_id", ""),
+        )
+        from core.tools.code_mode.policy import normalize_presentation
+
+        presentation = normalize_presentation(
+            getattr(getattr(agent, "tools", None), "_tools_presentation", None)
+        )
+        return honesty_retry_update(
+            messages=messages,
+            step_count=step_count,
+            final_response=final_response,
+            honesty_nudge_count=int(state.get("honesty_nudge_count") or 0),
+            include_assistant=not assistant_already_appended,
+            user_input=state.get("user_input"),
+            tools_presentation=presentation,
+        )
     if should_nudge_false_completion(
         state,
         final_response=final_response,

--- a/core/memory/tool_content.py
+++ b/core/memory/tool_content.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
+
+_DEBUG_LOG_LINE = re.compile(r"^(?:DEBUG|TRACE)\b")
 
 # SQLite + session reload cap (per tool message).
 DEFAULT_TOOL_MEMORY_MAX_CHARS = 16_384
@@ -53,13 +56,32 @@ def truncate_tool_content_for_graph(
     )
 
 
+def strip_debug_log_lines(content: str) -> str:
+    """Drop logging DEBUG/TRACE lines so pytest dumps stay readable."""
+    text = content or ""
+    if "DEBUG" not in text and "TRACE" not in text:
+        return text
+    kept: list[str] = []
+    dropped = 0
+    for line in text.splitlines():
+        if _DEBUG_LOG_LINE.match(line.lstrip()):
+            dropped += 1
+            continue
+        kept.append(line)
+    if dropped == 0:
+        return text
+    out = "\n".join(kept)
+    note = f"\n… [{dropped} verbose log lines omitted]"
+    return (out + note) if out else note.strip()
+
+
 def truncate_terminal_output(
     content: str,
     *,
     max_chars: int = TERMINAL_OUTPUT_MAX_CHARS,
 ) -> str:
     """Cap raw terminal stdout/stderr (defense in depth before hosts store it)."""
-    text = content or ""
+    text = strip_debug_log_lines(content or "")
     if len(text) <= max_chars:
         return text
     return (

--- a/core/runtime/introspect_signals.py
+++ b/core/runtime/introspect_signals.py
@@ -21,36 +21,34 @@ _INTROSPECT_RE = re.compile(
     # Not ``__name__``: ``type(exc).__name__`` is normal error handling.
     r"|__(?:doc|annotations|defaults|kwdefaults|qualname|module|"
     r"dict|mro|globals|func__)__"
-    r"|python\d*\s+-c\b[^;\n]*\b(?:dir|vars|type|help|getattr|hasattr)\s*\(",
-    re.I,
-)
-
-# Any ``python -c`` that imports a module is a REPL probe, not implementation.
-_PYTHON_C_IMPORT = re.compile(
-    r"\bpython\d*\s+-c\b[\s\S]{0,4000}\b(?:import|from)\s+\w+",
+    r"|python\d*\s+-c\b[^;\n]*\b(?:dir|vars|help|getattr|hasattr)\s*\(",
     re.I,
 )
 
 _TERMINAL = frozenset({"terminal", "run_terminal_command", "code_executor", "execute_python"})
-_WRITE = frozenset({"write_file", "delete_file"})
+_WRITE = frozenset({"write_file", "patch_file", "apply_patch", "delete_file"})
 
 INTROSPECT_REFUSAL = (
     "Error: Library introspection is blocked "
-    "(python -c, inspect.getsource, dir/type/__code__/__doc__). "
+    "(inspect.getsource, dir(), __code__, __doc__). "
     "That is not implementation and will not be executed.\n"
-    "Required next tool: **write_file**. Create the project files now "
-    "(pyproject.toml, package, routers, tests).\n"
-    "DaData: `DadataAsync(token, secret)` / `DadataClient` — "
-    "`suggest(name, query)`, `geolocate`, `iplocate`, `find_by_id`. "
-    "Do not probe the installed package again."
+    "Do not probe installed packages with python -c. "
+    "Next tool must persist code: **write_file** or **patch_file** "
+    "(or apply_patch). Then run tests."
 )
+
+INTROSPECT_WRITE_NUDGE = (
+    "[Action honesty — introspection] python -c / inspect.getsource was blocked. "
+    "Do NOT repeat library probes and do NOT echo that error as the final answer. "
+    "Call write_file or patch_file now with the implementation, then pytest. "
+    "A one-line python -c that only prints a value (no inspect/dir/__code__) is fine."
+)
+
+_REFUSAL_MARK = "library introspection is blocked"
 
 
 def is_introspect_command(command: str) -> bool:
-    text = command or ""
-    if _INTROSPECT_RE.search(text):
-        return True
-    return bool(_PYTHON_C_IMPORT.search(text))
+    return bool(_INTROSPECT_RE.search(command or ""))
 
 
 def is_introspect_code(code: str) -> bool:
@@ -58,11 +56,11 @@ def is_introspect_code(code: str) -> bool:
     text = code or ""
     if _INTROSPECT_RE.search(text):
         return True
-    if re.search(r"\b(?:import|from)\s+inspect\b", text):
-        return True
-    if re.search(r"\b(?:import|from)\s+dadata\b", text, re.I):
-        return True
-    return False
+    return bool(re.search(r"\b(?:import|from)\s+inspect\b", text))
+
+
+def is_introspect_refusal(text: str | None) -> bool:
+    return _REFUSAL_MARK in str(text or "").strip().lower()
 
 
 def is_introspect_trace(trace: dict[str, Any]) -> bool:

--- a/core/runtime/step_budget.py
+++ b/core/runtime/step_budget.py
@@ -361,9 +361,12 @@ def evaluate_step_budget(
 
     green_repeat = tests_already_green_loop(traces)
     inspect_repeat = introspect_loop(traces)
-    from core.runtime.write_signals import noop_write_loop
+    from core.runtime.test_run_signals import tests_failing_without_writes
+    from core.runtime.write_signals import no_write_implementation_loop, noop_write_loop
 
     noop_writes = noop_write_loop(traces)
+    red_tests = tests_failing_without_writes(traces)
+    read_only = no_write_implementation_loop(traces, task)
 
     signals = {
         "pending_tools": len(pending),
@@ -375,6 +378,8 @@ def evaluate_step_budget(
         "tests_green_repeat": green_repeat,
         "inspect_repeat": inspect_repeat,
         "noop_write_repeat": noop_writes,
+        "tests_red_no_write": red_tests,
+        "read_only_impl": read_only,
         "relevance": round(relevance, 3),
         "extensions_used": ext_used,
         "hard_cap": hard,
@@ -415,6 +420,26 @@ def evaluate_step_budget(
         return StepBudgetDecision(
             extend=False,
             reason="hung: write_file with no content changes is not progress",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    if red_tests:
+        return StepBudgetDecision(
+            extend=False,
+            reason="hung: tests keep failing and no file was written",
+            status="hung",
+            extensions_used=ext_used,
+            new_max_steps=ms,
+            signals=signals,
+        )
+
+    if read_only:
+        return StepBudgetDecision(
+            extend=False,
+            reason="hung: implement/fix task only reads or re-runs tests (no write_file)",
             status="hung",
             extensions_used=ext_used,
             new_max_steps=ms,

--- a/core/runtime/test_run_signals.py
+++ b/core/runtime/test_run_signals.py
@@ -36,6 +36,47 @@ def is_test_command(command: str) -> bool:
     return bool(_TEST_CMD_RE.search(command or ""))
 
 
+def is_red_test_output(text: str) -> bool:
+    blob = str(text or "")
+    if _FAILED_RE.search(blob) or _ERROR_RE.search(blob):
+        return True
+    low = blob.lower()
+    if "traceback" in low and "passed" not in low:
+        return True
+    if "failed" in low and "0 failed" not in low:
+        return True
+    return False
+
+
+def is_red_test_trace(trace: dict[str, Any]) -> bool:
+    name = str(trace.get("name") or "").lower()
+    args = extract_command(trace.get("arguments") or "")
+    result = str(trace.get("result") or "")
+    if name not in {"terminal", "run_terminal_command"}:
+        return False
+    if not is_test_command(args):
+        return False
+    return is_red_test_output(result)
+
+
+def tests_failing_without_writes(
+    traces: list[dict[str, Any]] | None,
+    *,
+    min_reds: int = 2,
+) -> bool:
+    """True when pytest/unit tests keep failing and nothing was written since."""
+    rows = list(traces or [])
+    reds = [i for i, t in enumerate(rows) if is_red_test_trace(t)]
+    if len(reds) < min_reds:
+        return False
+    writes = frozenset({"write_file", "patch_file", "apply_patch", "notebook_edit"})
+    last_write = max(
+        (i for i, t in enumerate(rows) if str(t.get("name") or "").lower() in writes),
+        default=-1,
+    )
+    return last_write < reds[0]
+
+
 def is_green_test_output(text: str) -> bool:
     blob = str(text or "")
     low = blob.lower()

--- a/core/runtime/write_signals.py
+++ b/core/runtime/write_signals.py
@@ -2,9 +2,40 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 _WRITE_TOOLS = frozenset({"write_file", "patch_file", "apply_patch", "notebook_edit"})
+_IMPL_TASK = re.compile(
+    r"(?is)\b("
+    r"implement|fix|create|write|add|patch|build|"
+    r"исправ|сделай|создай|напиш|почин|добав|реализуй"
+    r")\b"
+)
+
+
+def no_write_implementation_loop(
+    traces: list[dict[str, Any]] | None,
+    task: str = "",
+    *,
+    lookback: int = 8,
+    min_calls: int = 6,
+) -> bool:
+    """True when an implement/fix task only reads/tests and never writes."""
+    recent = list(traces or [])[-max(lookback, min_calls) :]
+    if len(recent) < min_calls:
+        return False
+    names = [str(t.get("name") or "").strip().lower() for t in recent]
+    if any(n in _WRITE_TOOLS for n in names):
+        return False
+    from core.runtime.test_run_signals import is_red_test_trace
+
+    failed_tests = any(is_red_test_trace(t) for t in recent)
+    impl = bool(_IMPL_TASK.search(task or ""))
+    if not failed_tests and not impl:
+        return False
+    return True
+
 
 NOOP_WRITE_MARK = "no content changes"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- **ReAct read/test loops** — step budget no longer extends when an implement/fix
+  task only reads files or re-runs a failing pytest without `write_file`.
+- **Introspection guard** — block `inspect.getsource` / `dir()` / `__code__`, not
+  every `python -c … import`. Refusal text is generic (no DaData). Echoing that
+  refusal as the final answer is treated as an honesty retry (`write_file`).
+- **Trajectory** — `ToolCallResultEvent` is `tool_call_result`, not generic `error`.
+- Terminal tool output drops `DEBUG`/`TRACE` log lines (pytest + aiosqlite noise).
+
 ## 1.1.4 — 2026-08-31
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.1.5 — 2026-08-31
+
 ### Fixed
 
 - **ReAct read/test loops** — step budget no longer extends when an implement/fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.1.4"
+version = "1.1.5"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_action_honesty.py
+++ b/tests/test_action_honesty.py
@@ -29,6 +29,7 @@ from core.graph.action_honesty import (
     resolve_tool_choice,
     sdd_fill_requires_tools,
     should_nudge_false_completion,
+    should_nudge_introspect_final,
     should_refuse_status_monologue,
     should_refuse_unproven_sdd_fill,
     successful_tools_since_last_user,
@@ -662,6 +663,31 @@ def test_nudge_once_then_stop() -> None:
     assert not should_nudge_false_completion(
         state, final_response="Готово, файл создан.", messages=messages
     )
+
+
+def test_introspect_echo_is_nudged_not_final() -> None:
+    from core.runtime.introspect_signals import INTROSPECT_REFUSAL, INTROSPECT_WRITE_NUDGE
+
+    refusal = INTROSPECT_REFUSAL
+    assert should_nudge_introspect_final(final_response=refusal, messages=[])
+    messages = [
+        {"role": "user", "content": "почини тест оплаты"},
+        {
+            "role": "tool",
+            "content": refusal,
+        },
+    ]
+    assert should_nudge_introspect_final(final_response=refusal, messages=messages)
+    out = honesty_retry_update(
+        messages=messages,
+        step_count=40,
+        final_response=refusal,
+        honesty_nudge_count=0,
+    )
+    assert out["is_final"] is False
+    assert out["final_response"] == ""
+    assert INTROSPECT_WRITE_NUDGE in out["messages"][-1]["content"]
+    assert "dadata" not in out["messages"][-1]["content"].lower()
 
 
 def test_honesty_retry_update_appends_nudge() -> None:

--- a/tests/test_agent_events.py
+++ b/tests/test_agent_events.py
@@ -43,6 +43,14 @@ class TestAgentEvents:
         assert d["tool_name"] == "read_file"
         assert "timestamp" in d
 
+    def test_tool_call_result_is_not_generic_error(self):
+        event = ToolCallResultEvent(
+            tool_name="read_file",
+            result="Content of foo.py:\nprint(1)\n",
+        )
+        assert event.type == EventType.TOOL_CALL_RESULT
+        assert event.to_dict()["type"] == "tool_call_result"
+
     def test_make_event_factory(self):
         """Test the convenience factory."""
         event = make_event(
@@ -98,6 +106,7 @@ class TestAgentEventBus:
         bus.subscribe(async_handler)
 
         event = ToolCallResultEvent(tool_name="test")
+        assert event.type == EventType.TOOL_CALL_RESULT
         bus.emit(event)
 
         # Give the event loop a chance to run the scheduled task

--- a/tests/test_introspect_signals.py
+++ b/tests/test_introspect_signals.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 from core.runtime.introspect_signals import (
+    INTROSPECT_REFUSAL,
     introspect_loop,
     is_introspect_code,
     is_introspect_command,
@@ -27,16 +28,18 @@ def _cmd(method: str) -> str:
 def test_detects_inspect_getsource() -> None:
     assert is_introspect_command('python -c "import inspect; print(inspect.getsource(Foo.bar))"')
     assert is_introspect_command('python -c "print(dir(app))"')
-    assert is_introspect_command('python -c "import dadata; print(dadata.Dadata.__name__)"')
     assert is_introspect_command(
         'python -c "import dadata; print(dadata.Dadata.__init__.__code__.co_flags)"'
     )
+    assert not is_introspect_command('python -c "import dadata; print(dadata.Dadata.__name__)"')
+    assert not is_introspect_command('python -c "import json; print(1)"')
     assert not is_introspect_command("python -m pytest tests")
     assert not is_introspect_command("pip install dadata")
     assert not is_introspect_command('python -c "print(1)"')
     assert not is_introspect_code(
         "try:\n    1/0\nexcept ZeroDivisionError as e:\n    print(type(e).__name__)"
     )
+    assert "dadata" not in INTROSPECT_REFUSAL.lower()
 
 
 def test_introspect_loop_on_rotating_methods() -> None:
@@ -117,8 +120,9 @@ async def test_terminal_refuses_python_c_library_probe() -> None:
     from core.tools.terminal import TerminalTool
 
     out = await TerminalTool().execute(
-        'cd projects/data_address && python -c "import dadata; print(dadata.Dadata.__name__)"',
+        'cd projects/data_address && python -c "import inspect; from dadata.asynchr import DadataClient; print(inspect.getsource(DadataClient.suggest))"',
         timeout=5,
     )
     assert "write_file" in out
     assert "Success" not in out
+    assert "DaDataAsync" not in out

--- a/tests/test_step_budget.py
+++ b/tests/test_step_budget.py
@@ -101,6 +101,88 @@ def test_hung_on_identical_tool_loop() -> None:
     assert "loop" in d.reason.lower()
 
 
+def test_no_extend_when_pytest_keeps_failing_without_writes() -> None:
+    log = [
+        {
+            "name": "read_file",
+            "arguments": '{"path": "payment.py"}',
+            "result": "Content of payment.py:\nasync def successful_payment",
+        },
+        {
+            "name": "run_terminal_command",
+            "arguments": '{"command": "python -m pytest -q src/tests/test_bot_payment.py"}',
+            "result": "Failed: 1 failed, 4 passed\nAssertionError: payload",
+        },
+        {
+            "name": "read_file",
+            "arguments": '{"path": "key_issue.py"}',
+            "result": "Content of key_issue.py:\nclass KeyIssue",
+        },
+        {
+            "name": "run_terminal_command",
+            "arguments": '{"command": "python -m pytest -q src/tests/test_bot_payment.py"}',
+            "result": "Failed: 1 failed, 4 passed\nAssertionError: payload",
+        },
+    ]
+    d = evaluate_step_budget(
+        step_count=90,
+        max_steps=90,
+        tool_calls_log=log,
+        task="исправь падение теста оплаты",
+        policy=StepBudgetPolicy(extend_by=30, max_extensions=3),
+        base_max_steps=90,
+    )
+    assert not d.extend
+    assert d.status == "hung"
+    assert "failing" in d.reason.lower() or "write" in d.reason.lower()
+
+
+def test_no_extend_on_implement_task_that_only_reads() -> None:
+    log = [
+        {
+            "name": "list_directory",
+            "arguments": '{"path": "projects/bot"}',
+            "result": "[dir] src\n[file] pyproject.toml",
+        },
+        {
+            "name": "read_file",
+            "arguments": '{"path": "a.py"}',
+            "result": "Content of a.py:\n" + ("x = 1\n" * 20),
+        },
+        {
+            "name": "read_file",
+            "arguments": '{"path": "b.py"}',
+            "result": "Content of b.py:\n" + ("y = 2\n" * 20),
+        },
+        {
+            "name": "grep",
+            "arguments": '{"pattern": "payment"}',
+            "result": "12 matches",
+        },
+        {
+            "name": "read_file",
+            "arguments": '{"path": "c.py"}',
+            "result": "Content of c.py:\n" + ("z = 3\n" * 20),
+        },
+        {
+            "name": "read_file",
+            "arguments": '{"path": "d.py"}',
+            "result": "Content of d.py:\n" + ("w = 4\n" * 20),
+        },
+    ]
+    d = evaluate_step_budget(
+        step_count=90,
+        max_steps=90,
+        tool_calls_log=log,
+        task="сделай выдачу ключа после successful_payment",
+        policy=StepBudgetPolicy(extend_by=30, max_extensions=3),
+        base_max_steps=90,
+    )
+    assert not d.extend
+    assert d.status == "hung"
+    assert "write_file" in d.reason.lower() or "reads" in d.reason.lower()
+
+
 def test_no_extend_when_same_pytest_already_green() -> None:
     log = [
         {

--- a/tests/test_tool_content.py
+++ b/tests/test_tool_content.py
@@ -1,0 +1,26 @@
+"""Tool output truncation helpers."""
+
+from __future__ import annotations
+
+from core.memory.tool_content import strip_debug_log_lines, truncate_terminal_output
+
+
+def test_strip_debug_log_lines_drops_aiosqlite_noise() -> None:
+    raw = (
+        "Success (exit code 0):\n"
+        "DEBUG    aiosqlite:core.py:62 executing functools.partial(rollback)\n"
+        "DEBUG    aiosqlite:core.py:67 operation completed\n"
+        "FAILED src/tests/test_bot_payment.py::test_successful_payment_handler_issues_key\n"
+        "AssertionError: payload\n"
+    )
+    out = strip_debug_log_lines(raw)
+    assert "aiosqlite" not in out
+    assert "AssertionError: payload" in out
+    assert "omitted" in out
+
+
+def test_truncate_terminal_output_strips_debug_first() -> None:
+    raw = "DEBUG    x\n" * 100 + "1 failed\n"
+    out = truncate_terminal_output(raw, max_chars=2000)
+    assert "1 failed" in out
+    assert "DEBUG    x" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.1.4"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Fixes the Studio prod session failure (read/pytest loop → `python -c` block → DaData error shown as the answer).

- Step budget does not extend when an implement/fix task only reads or re-runs a failing pytest without `write_file`.
- Introspect guard blocks `inspect`/`dir`/`__code__`, not every `python -c import`. Refusal is generic; echoing it as final is an honesty retry.
- `ToolCallResultEvent` logs as `tool_call_result`.
- Terminal output drops DEBUG/TRACE lines.

## Tests
`pytest tests/test_agent_events.py tests/test_introspect_signals.py tests/test_step_budget.py tests/test_action_honesty.py tests/test_tool_content.py` — 81 passed.
