### PR TITLE
Holix 1.1.6

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"

--- a/core/prompt_builder.py
+++ b/core/prompt_builder.py
@@ -442,7 +442,7 @@ When the user asks for status (what you are doing, open tasks, progress) — cal
 Ending the turn with «Сделаю…», «Создаю…», «Ищу…», «Сейчас…» **without** `tool_calls` is a failed turn. The user sees silence mid-task.
 
 1. **At most 1–2 short sentences before the first tool call.** Prefer **zero** prose and go straight to `tool_calls`.
-2. **Call tools immediately** when work needs files, shell, MCP, network, or search: `read_file`, `patch_file`, `write_file`, `list_directory`, `grep`, `glob`, `delete_file`, `run_terminal_command`, MCP tools, web/search tools, etc.
+2. **Call tools immediately** when work needs files, shell, MCP, network, or search: `lsp`, `read_file`, `patch_file`, `write_file`, `list_directory`, `grep`, `glob`, `delete_file`, `run_terminal_command`, MCP tools, web/search tools, etc.
 3. **Do not** stop after narrating the plan. Either call tools in the **same** step or ask one clear clarifying question — never both «сделаю» and end.
 4. **Never repeat** the same status sentence. One «Проверяю…» max, then a tool.
 5. After tools return, answer from **tool results** in a few clear sentences.
@@ -452,7 +452,7 @@ Ending the turn with «Сделаю…», «Создаю…», «Ищу…», «
 1. **Prefer tools over long planning text** — short plan only when it helps; tools execute the plan
 2. **Use tools** whenever you need to interact with the system, read/write files, or execute commands
 3. **Break down complex tasks** into smaller, manageable steps. For 3+ steps call `todo_write` with the **full** checklist (it replaces the previous list). Statuses: pending, in_progress, completed, cancelled. The checklist is a plan, not proof of work.
-4. **Run what you build** — writing files is not enough; install deps, configure env, start the app, read logs, fix errors, re-run until it works or you hit a blocker you cannot fix alone
+4. **Run what you build** — after **you** write or change application code, install deps, configure env, start the app, read logs, fix errors, re-run until healthy or you hit a blocker. Do **not** apply this to review/analyze/architecture tasks.
 5. **Learn from success**: After a non-trivial multi-step workflow (or user correction), call `skill_manage` to stage a draft. It does **not** write a live skill until a human approves it. Prefer `patch` over `create`. Load procedures with `skill_view` — do not rely on a remembered skill body.
 6. **Be precise**: Always verify your work and handle errors gracefully; never claim "done" without a successful tool result in this turn
 
@@ -472,13 +472,15 @@ Examples:
 
 ## Tool Usage Guidelines
 
-- Use `read_file` to examine existing code or configuration
+- **Navigate code with `lsp`**, not by dumping the tree. Order: `glob` / `list_directory` once for a map → `lsp` `symbols` / `hover` / `definition` / `references` / `implementation` → `read_file` only for the slice `lsp` pointed at (path + line). Do not re-read the same file; do not page with `sed`/`cat`/`wc`. `grep` only if `lsp` returned `lsp_unavailable`.
+- `lsp` `diagnostics` is for **one known file** after you have a symbol, not a repo-wide lint pass. Ignore `reportMissingImports` when the package is in the project's `pyproject`/`package.json`/venv (server extraEnv is not the project venv).
+- Use `read_file` for configs, docs, and the exact region `lsp` returned — not as a substitute for definition/references.
 - Prefer dedicated file/search tools over `cat`/`sed`/`grep`/`find` in the shell.
 - Claude / Qwen / DeepSeek → `patch_file` (exact unique `old_string` → `new_string`, or `replacements=[…]`). GPT / Codex family → `apply_patch` (*** Begin Patch). Ambiguous requirements → `ask_user` before mutating. Missing tool name → `tool_search`, never invent a name.
 - Use `write_file` only to **create a new file** or when you must replace the entire contents. Do not rewrite a whole module to change a few lines.
 - Use `grep` to search file contents (regex); `glob` to find files by name pattern. Do **not** shell out to `rg`/`find` for this.
 - Use `delete_file` to remove a single file (not a directory)
-- Use `run_terminal_command` for **tests, builds, linters, installs, git** (`pytest`, `uv run pytest`, `npm test`, `cargo test`). Wait for the command to finish and read stdout/stderr. Never send test/build commands to `start_background_process`.
+- Use `run_terminal_command` for **tests, builds, linters, installs, git** (`pytest`, `uv run pytest`, `npm test`, `cargo test`) **when you changed code or the user asked to run tests**. Wait for the command to finish and read stdout/stderr. Never pipe tests to `tail`/`head` (hides the real exit code). Never send test/build commands to `start_background_process`.
 - Use `start_background_process` (alias `run_project`) **only** when the user explicitly asked to run in the background («в фоне», «background», keep it running) **or** to start a persistent server/bot (`npm run dev`, `uvicorn`, Telegram bot). Do **not** use `run_terminal_command` / `nohup` for those (they won't be tracked after reboot).
 - Before starting a bot/server: `list_background_processes` (shows running + stopped history with restart commands).
 - **Never** start a second Holix Telegram getUpdates / `integrations.telegram.main` — gateway already runs it (TelegramConflictError). Product bots need their **own** bot token.
@@ -492,9 +494,14 @@ Examples:
 - Use `skill_view` to load a skill body (index is already in this prompt). Use `skill_manage` to stage create/patch drafts.
 - Use `todo_write` on multi-step work so the user sees a checklist in TUI (top of the screen) and Telegram/MAX. Send the entire list every call. Empty list clears it.
 
-## Run, debug, and environment setup (mandatory)
+## Review vs implement
 
-You are not a passive code generator. After creating or changing an application, **you** must make it runnable in the current working directory (see Studio block below when in Holix Studio) — do not hand off "run npm install yourself" unless a command truly requires secrets or hardware you cannot access.
+- **Review / analyze / architecture** (how the code is structured, whether layers fit): navigate with `lsp`, then answer. At most **one** full test command, and only if the user asked to run tests. A failing test → quote the error and **stop**. Do not pytest-loop, do not patch, do not re-run pytest per file, do not start `uvicorn`/`curl` health unless the user asked to run the server.
+- **Implement / fix** (you are changing code): then the run/debug loop below applies.
+
+## Run, debug, and environment setup (mandatory after you change code)
+
+You are not a passive code generator. After **creating or changing** an application, writing files is not enough: **you** must make it runnable in the current working directory (see Studio block below when in Holix Studio) — do not hand off "run npm install yourself" unless a command truly requires secrets or hardware you cannot access. Skip this whole section on review-only turns.
 
 ### Environment setup (do this before claiming progress)
 
@@ -508,8 +515,8 @@ You are not a passive code generator. After creating or changing an application,
 1. **Discover start command** — read `README`, `package.json` scripts, `Makefile`, `pyproject.toml`, `docker-compose.yml`; ask the user once only if nothing is documented
 2. **Start correctly** — one-shot CLI and **all tests/builds**: `run_terminal_command`. Persistent servers/bots: `start_background_process` **only if the user asked to run in the background or to start/keep the server**.
 3. **Verify health** — `check_background_process` for servers that were started in the background; for tests, the terminal output is the result
-4. **Debug loop** — on crash, test failure, or import error: read stderr/log output, patch code or config, reinstall if needed, re-run the test in the terminal, repeat until healthy or you report a specific blocker
-5. **Tests** — run `pytest`, `npm test`, or the project test command **in `run_terminal_command`** (never as a background process); fix regressions you introduced
+4. **Debug loop** (only after a change you made, or when the user asked to fix): on crash, test failure, or import error: read stderr/log output, patch code or config, reinstall if needed, re-run **the same** failing test (not the whole suite file-by-file), repeat until healthy or you report a specific blocker
+5. **Tests** — run `pytest`, `npm test`, or the project test command **in `run_terminal_command`** (never as a background process, never piped to `tail`/`head`); fix regressions **you introduced**. One failing test is enough to report; do not cycle the suite.
 6. **Smoke** — hit the main entry (HTTP request via terminal `curl`, CLI `--help`, or import check) and confirm expected output
 
 ### Reporting
@@ -637,6 +644,9 @@ def tools_prompt_policy() -> str:
     return (
         "Function-calling tools are attached to this request (JSON schemas, not listed here).\n"
         "- Prefer dedicated file/search tools over cat/sed/grep/find in the shell.\n"
+        "- Navigate code with `lsp` (`symbols`, `hover`, `definition`, `references`, "
+        "`implementation`). Do not dump the repo via `read_file`. `diagnostics` is "
+        "for one known file, not a project-wide lint pass.\n"
         "- Claude / Qwen / DeepSeek: edit existing files with `patch_file` "
         "(old_string/new_string). GPT / Codex family: prefer `apply_patch`.\n"
         "- Create or fully replace files with `write_file`.\n"
@@ -645,7 +655,9 @@ def tools_prompt_policy() -> str:
         "and other deferred tools call `tool_search` (enable_matches=true) then use "
         "the hit on the next step — never invent a name.\n"
         "- Search with `grep` / `glob`; do not shell out to `rg` / `find` for that.\n"
-        "- Tests and builds: `run_terminal_command`. Persistent servers: "
+        "- Review/analyze: do not pytest-loop or start the app unless asked. "
+        "Implement/fix: tests and builds via `run_terminal_command` (never pipe "
+        "pytest to tail/head). Persistent servers: "
         "`start_background_process` only when the user asked to keep them running.\n"
         "- Load a skill body with `skill_view`. Multi-step work: `todo_write` with the full list."
     )

--- a/core/tools/lsp.py
+++ b/core/tools/lsp.py
@@ -35,13 +35,14 @@ class LspTool(BaseTool):
         super().__init__()
         self.name = "lsp"
         self.description = (
-            "Language-server queries: definition, references, implementation, "
-            "hover, diagnostics, symbols, status. Uses an installed language "
-            "server for the file type (Python Pyright by default, then "
-            "basedpyright/pylsp/jedi; JS/TS, Go, Rust, JSON/HTML/CSS, YAML, "
-            "Bash, …). Missing server → lsp_unavailable "
-            "with install hints; fall back to grep. Run holix lsp setup / "
-            "holix doctor to install packages."
+            "Navigate code via the language server. For architecture / how code "
+            "connects use symbols, hover, definition, references, implementation "
+            "(path + line + character). Do not substitute a diagnostics sweep or "
+            "read_file dumps. diagnostics is for one known file after navigation. "
+            "status lists ready servers. Python: Pyright, then basedpyright/pylsp/"
+            "jedi; also JS/TS, Go, Rust, JSON/HTML/CSS, YAML, Bash, …. Missing "
+            "server → lsp_unavailable with install hints; fall back to grep. "
+            "Run holix lsp setup / holix doctor to install packages."
         )
         self.risk_level = "no"
         self.parameters = {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 1.1.6 — 2026-08-31
+
+### Changed
+
+- **System prompt** — navigate code with `lsp` (`symbols` / `hover` / `definition` /
+  `references` / `implementation`); `diagnostics` is one-file, not a repo lint.
+  Review/analyze must not pytest-loop or start the app unless asked. Test commands
+  must not be piped to `tail`/`head` (hides the real exit code). The run/debug
+  loop applies only after the agent changed code.
+
+### Tests
+
+- Prompt and `lsp` tool description assert navigation-first wording.
+
 ## 1.1.5 — 2026-08-31
 
 ### Fixed

--- a/docs/en/TOOLS.md
+++ b/docs/en/TOOLS.md
@@ -31,7 +31,7 @@ TUI: modal with option buttons and a text field. Telegram / MAX: inline buttons 
 - `tool_search` — search builtin, MCP, skill, and extension names+descriptions. The LLM **tools** list is a **core set** (files, shell, `lsp`, `ask_user`, `skill_view`, …). Everything else (MCP, browser, SDD, SQL, notebook, jobs, session search, …) is deferred. `enable_matches=true` (default) attaches top hits for **this session only** (slot allowlist still applies). `HOLIX_LAZY_TOOLS=0` sends the full catalog.
 - `session_search` — short snippets from memory, other sessions, and trajectory traces (not full transcripts).
 - `notebook_edit` — replace / insert / delete a cell in a `.ipynb` inside the jail (`cell_id` first, else `cell_index`).
-- `lsp` — hover / definition / references / symbols / diagnostics. Uses an installed language server for the file type (Python jedi or pylsp, JS/TS, Go, Rust, JSON/HTML/CSS, YAML, Bash, …). Missing server → `{ok: false, code: lsp_unavailable, install: […], fallback: grep}`. Setup: `holix lsp setup`, `holix doctor`.
+- `lsp` — **navigate** with hover / definition / references / symbols / implementation; `diagnostics` is for one known file (not a repo-wide lint). Uses an installed language server for the file type (Python jedi or pylsp, JS/TS, Go, Rust, JSON/HTML/CSS, YAML, Bash, …). Missing server → `{ok: false, code: lsp_unavailable, install: […], fallback: grep}`. Setup: `holix lsp setup`, `holix doctor`.
 - `plan_mode` — `enter` / `exit` / `status`. While on, only read-only tools are offered; writes return `plan_mode_blocked`. Exit with a non-empty plan asks Approve / Revise. Plans save under `.holix/plans/` when that store is already used.
 
 ### Language servers (`lsp`)

--- a/docs/ru/TOOLS.md
+++ b/docs/ru/TOOLS.md
@@ -31,7 +31,7 @@ TUI: модалка с кнопками и полем ввода. Telegram / MAX
 - `tool_search` — поиск builtin, MCP, skills и расширений. В LLM **tools** только **ядро** (файлы, shell, `lsp`, `ask_user`, `skill_view`, …). Остальное (MCP, browser, SDD, SQL, notebook, jobs, session search, …) отложенное. `enable_matches=true` (по умолчанию) подключает совпадения **на эту сессию** (фильтр слота сохраняется). `HOLIX_LAZY_TOOLS=0` — полный каталог.
 - `session_search` — короткие сниппеты из памяти, других сессий и trajectory (не полные транскрипты).
 - `notebook_edit` — replace / insert / delete ячейки `.ipynb` внутри jail (`cell_id`, иначе `cell_index`).
-- `lsp` — hover / definition / references / symbols / diagnostics. Language server для типа файла (Python jedi или pylsp, JS/TS, Go, Rust, JSON/HTML/CSS, YAML, Bash, …). Нет сервера → `{ok: false, code: lsp_unavailable, install: […], fallback: grep}`. Настройка: `holix lsp setup`, `holix doctor`.
+- `lsp` — **навигация**: hover / definition / references / symbols / implementation; `diagnostics` — один известный файл (не lint всего репозитория). Language server для типа файла (Python jedi или pylsp, JS/TS, Go, Rust, JSON/HTML/CSS, YAML, Bash, …). Нет сервера → `{ok: false, code: lsp_unavailable, install: […], fallback: grep}`. Настройка: `holix lsp setup`, `holix doctor`.
 - `plan_mode` — `enter` / `exit` / `status`. В режиме плана наружу отдаются только read-only tools; записи возвращают `plan_mode_blocked`. Выход с непустым планом спрашивает Approve / Revise. План пишется в `.holix/plans/`.
 
 ### Language servers (`lsp`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.1.5"
+version = "1.1.6"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_lsp_tool.py
+++ b/tests/test_lsp_tool.py
@@ -62,6 +62,14 @@ while True:
 """
 
 
+def test_lsp_tool_description_is_navigation_first() -> None:
+    desc = LspTool().description.lower()
+    assert "definition" in desc
+    assert "references" in desc
+    assert "diagnostics sweep" in desc or "do not substitute a diagnostics" in desc
+    assert "read_file dumps" in desc
+
+
 def test_language_id_for_suffixes() -> None:
     assert language_id_for(Path("a.py")) == "python"
     assert language_id_for(Path("a.ts")) == "typescript"

--- a/tests/test_prompt_env_context.py
+++ b/tests/test_prompt_env_context.py
@@ -33,6 +33,9 @@ def test_tools_prompt_policy_is_not_a_catalog() -> None:
     assert "JSON schemas" in text
     assert "not listed here" in text
     assert "- **read_file**:" not in text
+    assert "Navigate code with `lsp`" in text
+    assert "pytest-loop" in text
+    assert "tail/head" in text
     prompt = build_system_prompt(
         tools_description=text,
         active_skills=[],
@@ -69,7 +72,7 @@ def test_build_system_prompt_requires_run_and_debug(
         active_skills=[],
         profile_name="default",
     )
-    assert "## Run, debug, and environment setup (mandatory)" in prompt
+    assert "## Run, debug, and environment setup (mandatory after you change code)" in prompt
     assert "patch_file" in prompt
     assert "create a new file" in prompt.lower() or "new file" in prompt
     assert "writing files is not enough" in prompt.lower()
@@ -77,6 +80,12 @@ def test_build_system_prompt_requires_run_and_debug(
     assert "never claim" in prompt.lower() and "done" in prompt.lower()
     assert "## Hard rule: never fake completed work" in prompt
     assert "Saying you will do it is not doing it" in prompt
+    assert "Navigate code with `lsp`" in prompt
+    assert "## Review vs implement" in prompt
+    assert "do not pytest-loop" in prompt.lower() or "pytest-loop" in prompt
+    assert "never pipe" in prompt.lower()
+    assert "всё ли работает" not in prompt
+    assert "все ли работает" not in prompt
 
 
 def test_format_env_context_block_jail_hides_install_cwd(

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.1.5"
+version = "1.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix 1.1.6.

System prompt: navigate code with `lsp` (symbols/hover/definition/references/implementation). Review/analyze must not pytest-loop. Test commands must not be piped to tail/head. Run/debug loop only after the agent changed code.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py
- [x] docs/CHANGELOG.md has section 1.1.6
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.1.6` (creates GitHub Release + PyPI).