### PR TITLE
Holix 1.1.7

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -233,7 +233,10 @@ async def run_graph_loop(
             final_state = await compiled_graph.ainvoke(initial_state, config)
 
         from core.llm.response_text import sanitize_assistant_visible_text
-        from core.presenters.final_content import is_placeholder_final
+        from core.presenters.final_content import (
+            coerce_usable_final_text,
+            is_placeholder_final,
+        )
         from core.presenters.subagent_tool_text import (
             graph_tool_results_as_recent,
             pick_best_tool_final,
@@ -248,6 +251,13 @@ async def run_graph_loop(
             )
             if picked:
                 final_text = picked
+        step_count = final_state.get("step_count", 0)
+        max_steps = final_state.get("max_steps", 90)
+        hit_cap = bool(step_count >= max_steps and not final_state.get("is_final", False))
+        final_text = coerce_usable_final_text(
+            final_text,
+            max_steps=max_steps if hit_cap else None,
+        )
         if not getattr(agent, "_final_response_emitted", False):
             if agent is not None:
                 agent._final_response_emitted = True
@@ -261,8 +271,6 @@ async def run_graph_loop(
                 conversation_id=conversation_id,
             )
 
-        step_count = final_state.get("step_count", 0)
-        max_steps = final_state.get("max_steps", 90)
         if step_count >= max_steps and not final_state.get("is_final", False):
             yield MaxStepsReachedEvent(
                 max_steps=max_steps,

--- a/core/presenters/final_content.py
+++ b/core/presenters/final_content.py
@@ -30,6 +30,12 @@ MESSENGER_EMPTY_FINAL_RU = (
     "Агент завершил работу без текстового ответа.\nПроверьте модель (/models) или повторите запрос."
 )
 
+UNUSABLE_TEST_DUMP_RU = (
+    "Агент не сформировал текстовый ответ (часто — лимит шагов).\n"
+    "Последний вывод tool — лог тестов, это не отчёт.\n"
+    "{snippet}"
+)
+
 _UNSUCCESSFUL_FINAL_MARKERS = (
     "без текстового ответа",
     "без видимого ответа",
@@ -51,12 +57,47 @@ def is_aborted_final_response(content: str | None) -> bool:
     return any(marker in text for marker in _ABORTED_FINAL_MARKERS)
 
 
+def is_unusable_final_tool_output(text: str | None) -> bool:
+    """True when a tool payload must not be shown as the assistant's answer."""
+    from core.runtime.test_run_signals import is_test_log_dump
+
+    return is_test_log_dump(text or "")
+
+
+def format_unusable_final(text: str | None, *, max_steps: int | None = None) -> str:
+    from core.runtime.test_run_signals import failure_snippet
+
+    snippet = failure_snippet(text or "")
+    body = UNUSABLE_TEST_DUMP_RU.format(snippet=snippet or "(нет краткой строки ошибки)")
+    if max_steps:
+        return f"Достигнут лимит шагов ({max_steps}).\n{body}"
+    return body
+
+
+def coerce_usable_final_text(
+    text: str | None,
+    *,
+    max_steps: int | None = None,
+) -> str:
+    """Drop pytest dumps; optionally annotate a max-steps stop."""
+    raw = (text or "").strip()
+    if not raw:
+        if max_steps:
+            return f"Достигнут лимит шагов ({max_steps}). Текстового ответа нет."
+        return ""
+    if is_unusable_final_tool_output(raw):
+        return format_unusable_final(raw, max_steps=max_steps)
+    return raw
+
+
 def is_meaningful_final_response(content: str | None) -> bool:
     """True when the assistant produced a real answer worth treating as step completion."""
     text = (content or "").strip()
     if not text or is_placeholder_final(text):
         return False
     if is_aborted_final_response(text):
+        return False
+    if is_unusable_final_tool_output(text):
         return False
     lowered = text.lower()
     return not any(marker in lowered for marker in _UNSUCCESSFUL_FINAL_MARKERS)
@@ -86,6 +127,9 @@ def resolve_messenger_final_content(
             tool_text = picked
     if not text and tool_text:
         text = tool_text
+
+    if is_unusable_final_tool_output(text):
+        text = format_unusable_final(text)
 
     if not text:
         return empty_message

--- a/core/presenters/subagent_tool_text.py
+++ b/core/presenters/subagent_tool_text.py
@@ -194,6 +194,8 @@ def pick_best_tool_final(recent_tools: list[dict[str, Any]]) -> str:
     if not recent_tools:
         return ""
 
+    from core.runtime.test_run_signals import is_test_log_dump
+
     errors: list[str] = []
     for entry in reversed(recent_tools):
         if not isinstance(entry, dict):
@@ -203,12 +205,14 @@ def pick_best_tool_final(recent_tools: list[dict[str, Any]]) -> str:
             continue
         if name == "wait_subagent_result":
             text = extract_subagent_tool_text(name, body)
-            if text:
+            if text and not is_test_log_dump(text):
                 return text
         if name == "send_chat_files":
             continue
         formatted = format_tool_body_for_messenger(body, name=name)
         if not formatted:
+            continue
+        if is_test_log_dump(body) or is_test_log_dump(formatted):
             continue
         if _looks_like_tool_error(name, body, formatted):
             errors.append(formatted)
@@ -219,19 +223,15 @@ def pick_best_tool_final(recent_tools: list[dict[str, Any]]) -> str:
         if not isinstance(entry, dict):
             continue
         name, body = _tool_entry_name_body(entry)
-        if not body:
+        if not body or is_test_log_dump(body):
             continue
         text = extract_subagent_tool_text(name, body)
-        if text:
+        if text and not is_test_log_dump(text):
             return text
 
     if errors:
         return errors[0]
-    last = recent_tools[-1]
-    if not isinstance(last, dict):
-        return ""
-    _, body = _tool_entry_name_body(last)
-    return format_tool_body_for_messenger(body) if body else ""
+    return ""
 
 
 def _format_wait_result(raw: str) -> str:

--- a/core/project/init_intent.py
+++ b/core/project/init_intent.py
@@ -1,0 +1,91 @@
+"""Natural-language Holix init → same path as ``/init``."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_INIT_RE = re.compile(
+    r"(?is)("
+    r"инициализац\w*\s+holix"
+    r"|holix\s+init"
+    r"|init(?:ialize|ialise)?\s+holix"
+    r"|/init\b"
+    r"|holix\.md"
+    r"|справ[оа]чник\s+holix"
+    r"|holix\s+handbook"
+    r")"
+)
+
+_ALREADY_INIT_PROMPT = "update_holix_section"
+
+
+def looks_like_holix_init_request(text: str) -> bool:
+    raw = (text or "").strip()
+    if not raw or _ALREADY_INIT_PROMPT in raw:
+        return False
+    return bool(_INIT_RE.search(raw))
+
+
+def expand_user_message_for_holix_init(
+    text: str,
+    *,
+    agent: Any | None = None,
+    locale: str | None = None,
+    profile_name: str | None = None,
+    cwd: str | None = None,
+) -> str:
+    """Prepend the ``/init`` user prompt when the message asks to init Holix.
+
+    Mixed requests keep the original text after the init checklist. Already
+    expanded prompts are left unchanged. ``HOLIX.md`` skeleton is created when
+    missing (same as ``run_project_init``).
+    """
+    raw = (text or "").strip()
+    if not looks_like_holix_init_request(raw):
+        return text
+
+    from core.i18n.locale import LocaleStore, normalize_locale
+    from core.i18n.messages import t
+    from core.project.holix_md import HOLIX_MD_FILENAME
+    from core.project.init_prompt import _holix_md_rel_path, build_init_user_message
+    from core.project.init_scan import scan_project_for_init, write_init_skeleton
+    from core.project.workspace_root import resolve_project_root
+
+    loc = normalize_locale(locale)
+    cfg = getattr(agent, "config", None) if agent is not None else None
+    profile = profile_name or getattr(cfg, "profile_name", None)
+    if profile and locale is None:
+        loc = LocaleStore(str(profile)).get()
+
+    project_root = cwd or resolve_project_root(agent=agent, config=cfg)
+    scan = scan_project_for_init(cwd=project_root)
+    holix_path = _holix_md_rel_path(None)
+    skeleton = scan.scope_root / ".holix" / HOLIX_MD_FILENAME
+    if not skeleton.is_file():
+        template = t("init.holix_template", loc)
+        write_init_skeleton(
+            scan,
+            holix_rel_path=holix_path,
+            template=template,
+            locale=loc,
+        )
+
+    init_prompt = build_init_user_message(
+        locale=loc,
+        profile_name=profile,
+        scan=scan,
+        cwd=project_root,
+    )
+    stripped_lower = raw.lower()
+    if stripped_lower in {"/init", "init", "holix init"} or re.fullmatch(
+        r"(?is)сделай\s+инициализац\w*\s+holix\.?",
+        raw,
+    ):
+        return init_prompt
+    return (
+        f"{init_prompt}\n\n---\n"
+        "The user's original request (do this as well after the handbook "
+        "sections exist):\n"
+        f"{raw}"
+    )

--- a/core/runtime/pty_session.py
+++ b/core/runtime/pty_session.py
@@ -390,6 +390,9 @@ async def run_in_pty(
         await _ensure_ready(shell)
         with _lock:
             _sessions[key] = shell
+    from core.runtime.terminal_result import with_pipefail
+
+    command = with_pipefail(command)
     try:
         result = await shell.run(command, timeout=timeout)
     except TimeoutError:
@@ -400,6 +403,11 @@ async def run_in_pty(
         return "Error: PTY shell exited unexpectedly"
     shell.cwd = result.cwd
     output = truncate_terminal_output(sanitize_paths_in_text(result.output))
-    if result.returncode == 0:
-        return f"Success (exit code 0):\n{output}" if output else "Success (no output)"
-    return f"Error (exit code {result.returncode}):\n{output}"
+    from core.runtime.terminal_result import format_process_result
+
+    return format_process_result(
+        returncode=int(result.returncode or 0),
+        output=output,
+        error="",
+        command=command,
+    )

--- a/core/runtime/session.py
+++ b/core/runtime/session.py
@@ -40,7 +40,15 @@ async def prepare_session(
     messages = await agent.memory.get_conversation(conversation_id, limit=limit)
     messages = inject_soul_into_messages(messages, profile)
 
-    messages.append({"role": "user", "content": user_input})
+    from core.project.init_intent import expand_user_message_for_holix_init
+
+    loop_input = user_input
+    try:
+        loop_input = expand_user_message_for_holix_init(user_input, agent=agent)
+    except Exception:
+        logger.warning("holix init expand failed", exc_info=True)
+        loop_input = user_input
+    messages.append({"role": "user", "content": loop_input})
     await agent.memory.save_message(conversation_id, "user", user_input)
 
     from core.runtime.context_session import compress_session_if_needed

--- a/core/runtime/terminal_result.py
+++ b/core/runtime/terminal_result.py
@@ -5,22 +5,25 @@ from __future__ import annotations
 from core.platform_compat import IS_WINDOWS
 from core.runtime.test_run_signals import is_red_test_output, is_test_command, is_test_log_dump
 
+# dash (Debian/Ubuntu /bin/sh) treats a failed `set` as fatal (special builtin),
+# so we must not invoke `set -o pipefail` unless this is actually bash.
+_PIPEFAIL_PREFIX = '[ -n "${BASH_VERSION:-}" ] && set -o pipefail; '
+
 
 def with_pipefail(command: str) -> str:
-    """Prefix POSIX shells so ``pytest | tail`` keeps pytest's exit code.
+    """Prefix bash so ``pytest | tail`` keeps pytest's exit code.
 
-    Debian/Ubuntu ``/bin/sh`` is dash, which rejects ``set -o pipefail``.
-    ``|| true`` keeps the rest of the command running there; bash still
-    enables pipefail. Red pytest output is also detected by
-    ``format_process_result`` when the pipe hides the exit code.
+    Debian/Ubuntu ``/bin/sh`` is dash and rejects ``pipefail``. Skip ``set``
+    unless ``BASH_VERSION`` is set. Red pytest output is still reported as
+    Error by ``format_process_result`` when a pipe hid the exit code.
     """
     text = str(command or "")
     if not text.strip() or IS_WINDOWS:
         return text
     stripped = text.lstrip()
-    if stripped.startswith("set -o pipefail"):
+    if stripped.startswith('[ -n "${BASH_VERSION:-}" ]') or stripped.startswith("set -o pipefail"):
         return text
-    return "set -o pipefail 2>/dev/null || true; " + text
+    return _PIPEFAIL_PREFIX + text
 
 
 def format_process_result(

--- a/core/runtime/terminal_result.py
+++ b/core/runtime/terminal_result.py
@@ -7,14 +7,20 @@ from core.runtime.test_run_signals import is_red_test_output, is_test_command, i
 
 
 def with_pipefail(command: str) -> str:
-    """Prefix POSIX shells so ``pytest | tail`` keeps pytest's exit code."""
+    """Prefix POSIX shells so ``pytest | tail`` keeps pytest's exit code.
+
+    Debian/Ubuntu ``/bin/sh`` is dash, which rejects ``set -o pipefail``.
+    ``|| true`` keeps the rest of the command running there; bash still
+    enables pipefail. Red pytest output is also detected by
+    ``format_process_result`` when the pipe hides the exit code.
+    """
     text = str(command or "")
     if not text.strip() or IS_WINDOWS:
         return text
     stripped = text.lstrip()
     if stripped.startswith("set -o pipefail"):
         return text
-    return "set -o pipefail; " + text
+    return "set -o pipefail 2>/dev/null || true; " + text
 
 
 def format_process_result(

--- a/core/runtime/terminal_result.py
+++ b/core/runtime/terminal_result.py
@@ -1,0 +1,47 @@
+"""Format shell tool results; honor pytest failures even when a pipe hid rc."""
+
+from __future__ import annotations
+
+from core.platform_compat import IS_WINDOWS
+from core.runtime.test_run_signals import is_red_test_output, is_test_command, is_test_log_dump
+
+
+def with_pipefail(command: str) -> str:
+    """Prefix POSIX shells so ``pytest | tail`` keeps pytest's exit code."""
+    text = str(command or "")
+    if not text.strip() or IS_WINDOWS:
+        return text
+    stripped = text.lstrip()
+    if stripped.startswith("set -o pipefail"):
+        return text
+    return "set -o pipefail; " + text
+
+
+def format_process_result(
+    *,
+    returncode: int,
+    output: str,
+    error: str = "",
+    command: str = "",
+) -> str:
+    """Human-readable terminal tool payload.
+
+    ``pytest … | tail`` often returns 0 because ``tail`` succeeded. If the
+    combined output still looks like a red test run, report Error.
+    """
+    out = output or ""
+    err = error or ""
+    blob = f"{out}\n{err}"
+    rc = int(returncode or 0)
+    tests_lied_ok = (
+        rc == 0
+        and bool(command)
+        and is_test_command(command)
+        and (is_red_test_output(blob) or is_test_log_dump(blob))
+    )
+    if tests_lied_ok:
+        body = out if out.strip() else err
+        return f"Error (exit code 0, tests failed in output):\n{body}"
+    if rc == 0:
+        return f"Success (exit code 0):\n{out}" if out else "Success (no output)"
+    return f"Error (exit code {rc}):\nSTDOUT:\n{out}\nSTDERR:\n{err}"

--- a/core/runtime/test_run_signals.py
+++ b/core/runtime/test_run_signals.py
@@ -48,6 +48,53 @@ def is_red_test_output(text: str) -> bool:
     return False
 
 
+_PYTEST_DUMP_MARKERS = (
+    "short test summary info",
+    "=== errors ===",
+    "=== failures ===",
+    "==== errors ====",
+    "==== failures ====",
+)
+
+
+def is_test_log_dump(text: str) -> bool:
+    """True when ``text`` is a pytest/runner log, not a user-facing answer."""
+    blob = str(text or "")
+    if not blob.strip():
+        return False
+    low = blob.lower()
+    if any(m in low for m in _PYTEST_DUMP_MARKERS):
+        return True
+    if re.search(r"::test_\w+.+(FAILED|ERROR)", blob):
+        return True
+    if low.lstrip().startswith("success (exit code") and is_red_test_output(blob):
+        return True
+    if low.lstrip().startswith("error (exit code") and is_red_test_output(blob):
+        return True
+    return False
+
+
+def failure_snippet(text: str, *, limit: int = 400) -> str:
+    """First useful FAILED / E  line from a pytest dump."""
+    blob = str(text or "")
+    ranked: list[str] = []
+    for line in blob.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("FAILED ") or stripped.startswith("ERROR "):
+            ranked.append(stripped)
+        elif stripped.startswith("E ") or stripped.startswith("E\t"):
+            ranked.append(stripped)
+    if ranked:
+        for line in ranked:
+            if " - " in line:
+                return line[:limit]
+        return ranked[0][:limit]
+    compact = " ".join(blob.split())
+    return compact[:limit]
+
+
 def is_red_test_trace(trace: dict[str, Any]) -> bool:
     name = str(trace.get("name") or "").lower()
     args = extract_command(trace.get("arguments") or "")

--- a/core/sdd/product_change_id.py
+++ b/core/sdd/product_change_id.py
@@ -1,0 +1,219 @@
+"""Studio product projects: allocate ``{task_prefix}-{n}`` instead of free slugs."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_PREFIX_N = re.compile(r"^([a-z0-9][a-z0-9_-]{0,15})-(\d+)$", re.I)
+
+
+def normalize_task_prefix(raw: str, *, project_name: str = "") -> str:
+    pref = re.sub(r"[^A-Za-z0-9_-]+", "", (raw or "").strip())[:16]
+    if not pref:
+        pref = re.sub(r"[^A-Za-z0-9]+", "", (project_name or "").strip())[:16]
+    if not pref:
+        pref = "task"
+    pref = pref.lower()
+    if not re.match(r"^[a-z0-9]", pref):
+        pref = f"t{pref}"[:16]
+    return pref
+
+
+def find_product_project_json(start: Path) -> Path | None:
+    """Walk *start* and parents for Studio ``.holix/project.json``."""
+    cur = Path(start).expanduser().resolve()
+    seen: set[Path] = set()
+    for _ in range(8):
+        if cur in seen:
+            break
+        seen.add(cur)
+        candidate = cur / ".holix" / "project.json"
+        if candidate.is_file():
+            try:
+                data = json.loads(candidate.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                data = None
+            if isinstance(data, dict) and (
+                data.get("id") or data.get("slug") or data.get("tasks") is not None
+            ):
+                return candidate
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    return None
+
+
+def _max_n_for_prefix(data: dict[str, Any], prefix: str, *, project_root: Path) -> int:
+    max_n = 0
+    try:
+        max_n = max(max_n, int((data.get("settings") or {}).get("task_seq") or 0))
+    except (TypeError, ValueError):
+        pass
+    pat = re.compile(rf"^{re.escape(prefix)}-(\d+)$", re.I)
+    for t in data.get("tasks") or []:
+        if not isinstance(t, dict):
+            continue
+        m = pat.match(str(t.get("change_id") or "").strip())
+        if m:
+            try:
+                max_n = max(max_n, int(m.group(1)))
+            except (TypeError, ValueError):
+                pass
+    changes = project_root / "openspec" / "changes"
+    if changes.is_dir():
+        for d in changes.iterdir():
+            if d.is_dir() and not d.name.startswith("."):
+                m = pat.match(d.name)
+                if m:
+                    try:
+                        max_n = max(max_n, int(m.group(1)))
+                    except (TypeError, ValueError):
+                        pass
+            if d.name == "archive" and d.is_dir():
+                for ad in d.iterdir():
+                    if not ad.is_dir():
+                        continue
+                    m = pat.match(ad.name) or re.search(
+                        rf"-{re.escape(prefix)}-(\d+)$", ad.name, re.I
+                    )
+                    if m:
+                        try:
+                            max_n = max(max_n, int(m.group(1)))
+                        except (TypeError, ValueError):
+                            pass
+    wt_root = project_root / ".holix" / "worktrees"
+    if wt_root.is_dir():
+        for d in wt_root.iterdir():
+            if d.is_dir():
+                m = pat.match(d.name)
+                if m:
+                    try:
+                        max_n = max(max_n, int(m.group(1)))
+                    except (TypeError, ValueError):
+                        pass
+    return max_n
+
+
+def allocate_product_change_id(
+    workspace: Path,
+    requested: str = "",
+) -> dict[str, Any] | None:
+    """If *workspace* is a Studio product project, return allocated ``{prefix}-{n}``.
+
+    Returns None when there is no product ``project.json`` (plain Holix SDD).
+    """
+    meta_path = find_product_project_json(Path(workspace))
+    if meta_path is None:
+        return None
+    try:
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    settings = data.get("settings") if isinstance(data.get("settings"), dict) else {}
+    prefix = normalize_task_prefix(
+        str(settings.get("task_prefix") or ""),
+        project_name=str(data.get("name") or data.get("slug") or ""),
+    )
+    project_root = meta_path.parent.parent
+    req = (requested or "").strip().lower()
+    m = _PREFIX_N.match(req)
+    if m and m.group(1).lower() == prefix:
+        cid = f"{prefix}-{int(m.group(2))}"
+        dest = project_root / "openspec" / "changes" / cid
+        if not dest.exists():
+            settings["task_prefix"] = prefix
+            try:
+                settings["task_seq"] = max(int(settings.get("task_seq") or 0), int(m.group(2)))
+            except (TypeError, ValueError):
+                settings["task_seq"] = int(m.group(2))
+            data["settings"] = settings
+            _write_project_json(meta_path, data)
+            return {
+                "change_id": cid,
+                "prefix": prefix,
+                "rewritten_from": requested if requested != cid else None,
+                "project_json": str(meta_path),
+                "data": data,
+                "meta_path": meta_path,
+            }
+    n = _max_n_for_prefix(data, prefix, project_root=project_root) + 1
+    cid = f"{prefix}-{n}"
+    settings["task_prefix"] = prefix
+    settings["task_seq"] = n
+    data["settings"] = settings
+    _write_project_json(meta_path, data)
+    return {
+        "change_id": cid,
+        "prefix": prefix,
+        "rewritten_from": requested if requested and requested != cid else None,
+        "project_json": str(meta_path),
+        "data": data,
+        "meta_path": meta_path,
+    }
+
+
+def ensure_studio_board_task(
+    *,
+    meta_path: Path,
+    data: dict[str, Any],
+    change_id: str,
+    title: str,
+    request: str,
+    worktree_rel: str = "",
+) -> dict[str, Any] | None:
+    """Append a kanban task so analysis UI has a card (idempotent)."""
+    tasks = data.get("tasks")
+    if not isinstance(tasks, list):
+        tasks = []
+        data["tasks"] = tasks
+    cid = (change_id or "").strip()
+    for t in tasks:
+        if isinstance(t, dict) and str(t.get("change_id") or "").strip() == cid:
+            return t
+    repos = data.get("repos") if isinstance(data.get("repos"), list) else []
+    repo = repos[0] if repos and isinstance(repos[0], dict) else {}
+    rel = (
+        str(
+            data.get("workspace_rel")
+            or (f"projects/{data.get('slug')}" if data.get("slug") else "")
+        )
+        .strip()
+        .strip("/")
+    )
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    title_s = (title or request or cid).strip().split("\n", 1)[0][:120] or cid
+    task = {
+        "id": f"task_{uuid.uuid4().hex[:12]}",
+        "title": title_s,
+        "request": (request or title_s).strip(),
+        "kind": "product",
+        "change_id": cid,
+        "repo_id": repo.get("id"),
+        "repo_name": repo.get("name"),
+        "repo_path": str(repo.get("path") or rel),
+        "worktree_path": worktree_rel or "",
+        "column": "draft",
+        "created_by_role": "project_manager",
+        "spec_status": "draft",
+        "comments": [],
+        "analysis": None,
+        "history": [],
+        "created_at": now,
+        "updated_at": now,
+    }
+    tasks.append(task)
+    data["updated_at"] = now
+    _write_project_json(meta_path, data)
+    return task
+
+
+def _write_project_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")

--- a/core/tools/sdd.py
+++ b/core/tools/sdd.py
@@ -223,6 +223,10 @@ class SddCreateChangeTool(BaseTool):
         self.description = (
             "Scaffold a new change under openspec/changes/<id>/ with STUB proposal/"
             "delta specs/tasks only — this does NOT fill the real specification. "
+            "In a Studio product project (.holix/project.json) the id is ALWAYS "
+            "{task_prefix}-{n} (e.g. litellmkeybot-4). Free-form slugs like "
+            "stars-key-for-non-members are rewritten. Prefer "
+            "project_create_task_tool when that MCP tool is available. "
             "You MUST then call sdd_write_artifact for proposal, specs, and tasks. "
             "Main openspec/specs/<domain> updates only after sdd_archive. "
             "Pass request= user request text. If understanding gate is enabled: "
@@ -241,7 +245,11 @@ class SddCreateChangeTool(BaseTool):
                 "project": _PROJECT_PROP,
                 "change_id": {
                     "type": "string",
-                    "description": "Slug id, e.g. oauth-login",
+                    "description": (
+                        "Change id. Studio product projects ignore free-form slugs "
+                        "and allocate {task_prefix}-{n} (e.g. litellmkeybot-4). "
+                        "Outside Studio a slug like oauth-login is kept."
+                    ),
                 },
                 "domain": {
                     "type": "string",
@@ -279,6 +287,14 @@ class SddCreateChangeTool(BaseTool):
 
             prefs = SddPrefsStore(get_profile_name()).get()
             store = _store(project)
+            from core.sdd.product_change_id import (
+                allocate_product_change_id,
+                ensure_studio_board_task,
+            )
+
+            allocated = allocate_product_change_id(store.workspace, requested=change_id)
+            if allocated:
+                change_id = str(allocated["change_id"])
             worktree_note = _attach_change_worktree(store, change_id, project=project)
             result = store.create_change(
                 change_id,
@@ -305,6 +321,41 @@ class SddCreateChangeTool(BaseTool):
                             project=project or "",
                         ),
                     )
+                except Exception:
+                    pass
+            if allocated:
+                result["change_id"] = str(result.get("change_id") or change_id)
+                rewritten = allocated.get("rewritten_from")
+                if rewritten:
+                    result["rewritten_from"] = rewritten
+                    result["note"] = (
+                        f"Studio product project: allocated {result['change_id']} "
+                        f"(ignored slug {rewritten!r}). Use this id for "
+                        "sdd_write_artifact and analysis."
+                    )
+                wt_rel = ""
+                if worktree_note:
+                    try:
+                        wt = Path(str(worktree_note.get("worktree") or "")).resolve()
+                        root = Path(workspace_from_context()).resolve()
+                        wt_rel = str(wt.relative_to(root))
+                    except Exception:
+                        wt_rel = str(worktree_note.get("worktree") or "")
+                try:
+                    board = ensure_studio_board_task(
+                        meta_path=allocated["meta_path"],
+                        data=allocated["data"],
+                        change_id=str(result.get("change_id") or change_id),
+                        title=(request or "").strip().split("\n", 1)[0],
+                        request=request or "",
+                        worktree_rel=wt_rel,
+                    )
+                    if board:
+                        result["task_id"] = board.get("id")
+                        result["board_task"] = {
+                            "id": board.get("id"),
+                            "change_id": board.get("change_id"),
+                        }
                 except Exception:
                     pass
             # When understanding gate is ON, leave clarifying/score=0 so the agent

--- a/core/tools/terminal.py
+++ b/core/tools/terminal.py
@@ -201,13 +201,19 @@ def _format_process_result(
     returncode: int,
     output: str,
     error: str,
+    command: str = "",
 ) -> str:
-    if returncode == 0:
-        return f"Success (exit code 0):\n{output}" if output else "Success (no output)"
     access = _format_access_denial(returncode=returncode, output=output, error=error)
     if access:
         return access
-    return f"Error (exit code {returncode}):\nSTDOUT:\n{output}\nSTDERR:\n{error}"
+    from core.runtime.terminal_result import format_process_result
+
+    return format_process_result(
+        returncode=returncode,
+        output=output,
+        error=error,
+        command=command,
+    )
 
 
 def _spawn_kwargs() -> dict:
@@ -540,6 +546,10 @@ class TerminalTool(BaseTool):
                     pass
 
             use_shell = command_needs_shell(command)
+            if use_shell:
+                from core.runtime.terminal_result import with_pipefail
+
+                command = with_pipefail(command)
             spawn_kw = _spawn_kwargs()
             argv: list[str] | None = None
             if not use_shell:
@@ -623,6 +633,7 @@ class TerminalTool(BaseTool):
                     returncode=process.returncode or 0,
                     output=output,
                     error=error,
+                    command=command,
                 )
 
             except PromoteForegroundService as promo:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Fixed
 
-- **Terminal** — `set -o pipefail` on POSIX shells; `pytest | tail` with FAILED in
-  output is reported as Error even when the pipe's exit code is 0.
+- **Terminal** — bash `pipefail` when the shell supports it (dash `/bin/sh` skips
+  the option); `pytest | tail` with FAILED in output is reported as Error even
+  when the pipe's exit code is 0.
 - **Final answer** — pytest / traceback dumps are not shown as the assistant
   reply when the model hits max steps (short note + first FAILED line instead).
 - **Holix init** — phrases like «инициализацию Holix» / `HOLIX.md` expand to the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## 1.1.7 — 2026-08-31
+
+### Fixed
+
+- **Terminal** — `set -o pipefail` on POSIX shells; `pytest | tail` with FAILED in
+  output is reported as Error even when the pipe's exit code is 0.
+- **Final answer** — pytest / traceback dumps are not shown as the assistant
+  reply when the model hits max steps (short note + first FAILED line instead).
+- **Holix init** — phrases like «инициализацию Holix» / `HOLIX.md` expand to the
+  same `/init` prompt (and seed `.holix/HOLIX.md` when missing).
+- **Studio product SDD** — `sdd_create_change` no longer keeps free-form slugs
+  (`stars-key-for-non-members`); it allocates `{task_prefix}-{n}` from
+  `.holix/project.json` and adds a board task so analysis can run.
+
+### Tests
+
+- Terminal pipefail / red-pytest-as-error, init-intent expansion, product
+  change ids, messenger and `pick_best_tool_final` skip pytest dumps.
+
 ## 1.1.6 — 2026-08-31
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ### Fixed
 
-- **Terminal** — bash `pipefail` when the shell supports it (dash `/bin/sh` skips
-  the option); `pytest | tail` with FAILED in output is reported as Error even
-  when the pipe's exit code is 0.
+- **Terminal** — enable `pipefail` in bash only (dash `/bin/sh` skips it);
+  `pytest | tail` with FAILED in output is reported as Error even when the
+  pipe's exit code is 0.
 - **Final answer** — pytest / traceback dumps are not shown as the assistant
   reply when the model hits max steps (short note + first FAILED line instead).
 - **Holix init** — phrases like «инициализацию Holix» / `HOLIX.md` expand to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.1.6"
+version = "1.1.7"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_init_intent.py
+++ b/tests/test_init_intent.py
@@ -1,0 +1,54 @@
+"""Natural-language Holix init maps onto the /init prompt."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.project.init_intent import (
+    expand_user_message_for_holix_init,
+    looks_like_holix_init_request,
+)
+
+
+def test_detects_ru_and_en_init_phrases() -> None:
+    assert looks_like_holix_init_request(
+        "Проанализируй код используя lsp, проекта litellm-key-bot , "
+        "архитектура поддерживается или нет сделай инициализацию Holix"
+    )
+    assert looks_like_holix_init_request("сделай инициализацию Holix")
+    assert looks_like_holix_init_request("please initialize Holix for this repo")
+    assert looks_like_holix_init_request("write HOLIX.md")
+    assert not looks_like_holix_init_request("проанализируй архитектуру проекта")
+    assert not looks_like_holix_init_request("init git repository")
+
+
+def test_expand_pure_init_is_init_prompt(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "README.md").write_text("# App\n", encoding="utf-8")
+    msg = expand_user_message_for_holix_init(
+        "сделай инициализацию Holix",
+        locale="en",
+        cwd=str(tmp_path),
+    )
+    assert "update_holix_section" in msg
+    assert (tmp_path / ".holix" / "HOLIX.md").is_file()
+    assert "сделай инициализацию" not in msg
+
+
+def test_expand_mixed_keeps_original(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pkg").mkdir()
+    original = (
+        "Проанализируй код используя lsp, проекта foo, "
+        "архитектура поддерживается или нет сделай инициализацию Holix"
+    )
+    msg = expand_user_message_for_holix_init(original, locale="en", cwd=str(tmp_path))
+    assert "update_holix_section" in msg
+    assert original in msg
+    assert "original request" in msg.lower() or "do this as well" in msg.lower()
+
+
+def test_already_expanded_not_rewrapped() -> None:
+    body = "Please fill HOLIX.md via update_holix_section one section at a time."
+    assert looks_like_holix_init_request(body) is False
+    assert expand_user_message_for_holix_init(body, locale="en") == body

--- a/tests/test_messenger_final_content.py
+++ b/tests/test_messenger_final_content.py
@@ -71,6 +71,27 @@ def test_resolve_empty_message() -> None:
     assert resolve_messenger_final_content("") == MESSENGER_EMPTY_FINAL_RU
 
 
+def test_resolve_does_not_ship_pytest_dump() -> None:
+    from core.presenters.final_content import coerce_usable_final_text
+
+    dump = (
+        "Success (exit code 0):\n"
+        "src/x.py::test_admin FAILED\n"
+        "=========================== short test summary info ===========================\n"
+        "FAILED src/x.py::test_admin - NoFactoryError\n"
+    )
+    text = resolve_messenger_final_content(
+        "No response generated",
+        last_tool_result=dump,
+    )
+    assert "NoFactoryError" in text
+    assert "лог тестов" in text
+    assert not text.startswith("Success (exit code")
+    coerced = coerce_usable_final_text(dump, max_steps=90)
+    assert "90" in coerced
+    assert "NoFactoryError" in coerced
+
+
 @pytest.mark.asyncio
 async def test_max_final_placeholder_uses_tool_result() -> None:
     client = MagicMock()
@@ -185,4 +206,3 @@ async def test_max_streaming_delta_not_used_as_final_fallback() -> None:
 
     texts = [call.args[0] for call in client.send_message.await_args_list]
     assert not any("проверю код" in t for t in texts)
-

--- a/tests/test_product_change_id.py
+++ b/tests/test_product_change_id.py
@@ -1,0 +1,88 @@
+"""Studio product change ids: {task_prefix}-{n} not free-form slugs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.sdd.product_change_id import (
+    allocate_product_change_id,
+    ensure_studio_board_task,
+    normalize_task_prefix,
+)
+
+
+def _write_project(
+    tmp: Path, *, prefix: str = "", seq: int = 3, name: str = "LiteLLM Key Bot"
+) -> Path:
+    root = tmp / "projects" / "litellm-key-bot"
+    meta = root / ".holix" / "project.json"
+    meta.parent.mkdir(parents=True)
+    (root / "openspec" / "changes").mkdir(parents=True)
+    (root / "openspec" / "changes" / "litellmkeybot-1").mkdir()
+    data = {
+        "id": "proj_x",
+        "name": name,
+        "slug": "litellm-key-bot",
+        "workspace_rel": "projects/litellm-key-bot",
+        "settings": {"task_prefix": prefix, "task_seq": seq},
+        "repos": [{"id": "r1", "name": "bot", "path": "projects/litellm-key-bot"}],
+        "tasks": [
+            {"id": "task_old", "change_id": "litellmkeybot-1", "title": "old"},
+        ],
+    }
+    meta.write_text(json.dumps(data), encoding="utf-8")
+    return root
+
+
+def test_normalize_prefix_from_name() -> None:
+    assert normalize_task_prefix("", project_name="LiteLLM Key Bot") == "litellmkeybot"
+
+
+def test_allocate_rewrites_slug(tmp_path: Path) -> None:
+    root = _write_project(tmp_path, prefix="", seq=3)
+    out = allocate_product_change_id(root, requested="stars-key-for-non-members")
+    assert out is not None
+    assert out["change_id"] == "litellmkeybot-4"
+    assert out["rewritten_from"] == "stars-key-for-non-members"
+    saved = json.loads((root / ".holix" / "project.json").read_text(encoding="utf-8"))
+    assert saved["settings"]["task_prefix"] == "litellmkeybot"
+    assert saved["settings"]["task_seq"] == 4
+
+
+def test_allocate_keeps_matching_prefix_id(tmp_path: Path) -> None:
+    root = _write_project(tmp_path, prefix="litellmkeybot", seq=3)
+    out = allocate_product_change_id(root, requested="litellmkeybot-4")
+    assert out is not None
+    assert out["change_id"] == "litellmkeybot-4"
+    assert not out.get("rewritten_from")
+
+
+def test_no_product_json_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "openspec").mkdir()
+    assert allocate_product_change_id(tmp_path, requested="oauth-login") is None
+
+
+def test_ensure_board_task_appends(tmp_path: Path) -> None:
+    root = _write_project(tmp_path, prefix="litellmkeybot", seq=4)
+    meta = root / ".holix" / "project.json"
+    data = json.loads(meta.read_text(encoding="utf-8"))
+    task = ensure_studio_board_task(
+        meta_path=meta,
+        data=data,
+        change_id="litellmkeybot-4",
+        title="Stars for non-members",
+        request="buy with stars",
+        worktree_rel="projects/litellm-key-bot/.holix/worktrees/litellmkeybot-4",
+    )
+    assert task is not None
+    assert task["change_id"] == "litellmkeybot-4"
+    again = ensure_studio_board_task(
+        meta_path=meta,
+        data=json.loads(meta.read_text(encoding="utf-8")),
+        change_id="litellmkeybot-4",
+        title="dup",
+        request="dup",
+    )
+    assert again is not None
+    assert again["id"] == task["id"]

--- a/tests/test_subagent_tool_text.py
+++ b/tests/test_subagent_tool_text.py
@@ -75,6 +75,17 @@ def test_resolve_final_uses_wait_subagent_json() -> None:
     assert "Черновик документа готов" in text
 
 
+def test_pick_best_skips_pytest_dump() -> None:
+    dump = (
+        "Success (exit code 0):\n"
+        "src/x.py::test_paid_stars_keys_allow_multiple_active_keys FAILED [100%]\n"
+        "=========================== short test summary info ===========================\n"
+        "FAILED src/x.py::test_paid - IntegrityError\n"
+    )
+    recent = [{"name": "run_terminal_command", "full_result": dump}]
+    assert pick_best_tool_final(recent) == ""
+
+
 def test_pick_best_formats_studio_projects_json() -> None:
     recent = [
         {

--- a/tests/test_terminal_result.py
+++ b/tests/test_terminal_result.py
@@ -10,7 +10,31 @@ def test_with_pipefail_prefixes_once() -> None:
     cmd = "pytest -q | tail -20"
     wrapped = with_pipefail(cmd)
     assert wrapped.startswith("set -o pipefail") or wrapped == cmd
+    assert "|| true" in wrapped or wrapped == cmd
     assert with_pipefail(wrapped) == wrapped
+
+
+def test_pipefail_prefix_is_legal_on_posix_sh() -> None:
+    import shutil
+    import subprocess
+
+    from core.platform_compat import IS_WINDOWS
+
+    if IS_WINDOWS:
+        return
+    sh = shutil.which("sh")
+    if not sh:
+        return
+    wrapped = with_pipefail("echo ok")
+    result = subprocess.run(
+        [sh, "-c", wrapped],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "ok" in result.stdout
+    assert "Illegal option" not in (result.stderr or "")
 
 
 def test_pytest_failed_output_is_error_even_when_rc_zero() -> None:

--- a/tests/test_terminal_result.py
+++ b/tests/test_terminal_result.py
@@ -1,0 +1,58 @@
+"""Terminal result formatting: pipefail and red pytest behind a pipe."""
+
+from __future__ import annotations
+
+from core.runtime.terminal_result import format_process_result, with_pipefail
+from core.runtime.test_run_signals import failure_snippet, is_test_log_dump
+
+
+def test_with_pipefail_prefixes_once() -> None:
+    cmd = "pytest -q | tail -20"
+    wrapped = with_pipefail(cmd)
+    assert wrapped.startswith("set -o pipefail") or wrapped == cmd
+    assert with_pipefail(wrapped) == wrapped
+
+
+def test_pytest_failed_output_is_error_even_when_rc_zero() -> None:
+    out = (
+        "Success (exit code 0):\n"
+        "src/foo.py::test_paid FAILED\n"
+        "=========================== short test summary info ===========================\n"
+        "FAILED src/foo.py::test_paid - IntegrityError\n"
+    )
+    # strip the fake Success header — formatter sees raw stdout
+    raw = (
+        "src/foo.py::test_paid FAILED\n"
+        "=========================== short test summary info ===========================\n"
+        "FAILED src/foo.py::test_paid - IntegrityError\n"
+    )
+    text = format_process_result(
+        returncode=0,
+        output=raw,
+        error="",
+        command="cd backend && pytest -q 2>&1 | tail -60",
+    )
+    assert text.startswith("Error (exit code 0, tests failed")
+    assert "FAILED" in text
+    assert is_test_log_dump(out)
+    assert "IntegrityError" in failure_snippet(raw)
+
+
+def test_green_pytest_still_success() -> None:
+    raw = "........\n8 passed in 0.37s"
+    text = format_process_result(
+        returncode=0,
+        output=raw,
+        command="pytest -q",
+    )
+    assert text.startswith("Success (exit code 0)")
+
+
+def test_non_test_failed_word_not_flipped() -> None:
+    raw = "failed to bind port 8000"
+    text = format_process_result(
+        returncode=0,
+        output=raw,
+        command="curl -s http://127.0.0.1:8000/health",
+    )
+    assert text.startswith("Success (exit code 0)")

--- a/tests/test_terminal_result.py
+++ b/tests/test_terminal_result.py
@@ -9,8 +9,8 @@ from core.runtime.test_run_signals import failure_snippet, is_test_log_dump
 def test_with_pipefail_prefixes_once() -> None:
     cmd = "pytest -q | tail -20"
     wrapped = with_pipefail(cmd)
-    assert wrapped.startswith("set -o pipefail") or wrapped == cmd
-    assert "|| true" in wrapped or wrapped == cmd
+    assert "set -o pipefail" in wrapped or wrapped == cmd
+    assert "BASH_VERSION" in wrapped or wrapped == cmd
     assert with_pipefail(wrapped) == wrapped
 
 
@@ -25,15 +25,16 @@ def test_pipefail_prefix_is_legal_on_posix_sh() -> None:
     sh = shutil.which("sh")
     if not sh:
         return
-    wrapped = with_pipefail("echo ok")
+    wrapped = with_pipefail("echo ok && echo chained")
     result = subprocess.run(
         [sh, "-c", wrapped],
         capture_output=True,
         text=True,
         check=False,
     )
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+    assert "chained" in result.stdout
     assert "Illegal option" not in (result.stderr or "")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix 1.1.7.

- Terminal: `set -o pipefail`; `pytest | tail` with FAILED is Error even when the pipe exits 0.
- Final answer: pytest dumps are not shipped as the assistant reply (max-steps included).
- NL «инициализацию Holix» / HOLIX.md expands to the `/init` prompt.
- Studio product SDD: `sdd_create_change` allocates `{task_prefix}-{n}` and a board task (no free-form slugs).

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py
- [x] docs/CHANGELOG.md has section 1.1.7
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.1.7` (creates GitHub Release + PyPI).