### PR TITLE
Holix 1.1.9

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.1.8"
+__version__ = "1.1.9"

--- a/core/sdd/dispatch.py
+++ b/core/sdd/dispatch.py
@@ -247,6 +247,17 @@ async def dispatch_change_tasks(
             }
             if job["process_mode"] is not None and hasattr(job["process_mode"], "value"):
                 job["process_mode"] = job["process_mode"].value
+            if getattr(h, "followed_process", False) is True:
+                job["followed_process"] = True
+                job["studio_process_id"] = str(getattr(h, "studio_process_id", "") or "")
+                sdd = getattr(h, "studio_sdd", None)
+                if isinstance(sdd, dict) and sdd:
+                    job["sdd"] = sdd
+                job["wait_hint"] = (
+                    "wait_subagent_result(job_id) blocks until the Studio "
+                    "process run finishes — not the first child step. "
+                    "Do not treat this SDD task as done until that wait returns."
+                )
             _record_task_job(
                 store,
                 change_id,
@@ -308,7 +319,10 @@ async def dispatch_change_tasks(
             f"{len(main_tasks)} ready main task(s); "
             f"{len(blocked_tasks)} blocked by dependencies. "
             "Successful jobs auto-mark tasks.md and re-dispatch the next ready wave. "
-            "Main ready tasks still need sdd_check_task.\n"
+            "Main ready tasks still need sdd_check_task. "
+            "Jobs with followed_process=true are Studio processes: "
+            "wait_subagent_result(job_id) until the process finishes; "
+            "do not treat that SDD task as done on the first child step.\n"
             f"{graph_summary}"
         ),
         "plan": plan_result["plan"],

--- a/core/sdd/task_completion.py
+++ b/core/sdd/task_completion.py
@@ -307,6 +307,8 @@ async def cancel_sdd_subagents_after_check(
 
     # Also match live handles by SDD marker (covers missing/stale job index)
     for handle in _running_sdd_handles(parent_agent):
+        if getattr(handle, "followed_process", False) is True:
+            continue
         marker = parse_sdd_task_marker(getattr(handle, "task_preview", None) or "")
         if not marker or marker.get("change_id") != cid:
             continue
@@ -319,7 +321,32 @@ async def cancel_sdd_subagents_after_check(
             want_jobs.add(str(name))
 
     cancelled: list[str] = []
+    skipped_process: list[str] = []
     for job_id in sorted(want_jobs):
+        handle = None
+        get_handle = getattr(mgr, "get_handle", None)
+        if callable(get_handle):
+            try:
+                handle = get_handle(job_id)
+            except Exception:
+                handle = None
+        if handle is None:
+            try:
+                for h in _running_sdd_handles(parent_agent):
+                    if str(getattr(h, "name", "") or "") == job_id:
+                        handle = h
+                        break
+            except Exception:
+                handle = None
+        if handle is not None and getattr(handle, "followed_process", False) is True:
+            skipped_process.append(job_id)
+            logger.info(
+                "SDD: skip cancel of Studio process waiter %s (change=%s task=%s)",
+                job_id,
+                cid,
+                task_id or "*",
+            )
+            continue
         try:
             ok = await mgr.terminate(job_id)
         except Exception as exc:
@@ -341,7 +368,24 @@ async def cancel_sdd_subagents_after_check(
     return {
         "cancelled_jobs": cancelled,
         "cancel_requested": sorted(want_jobs),
+        "skipped_process_jobs": skipped_process,
     }
+
+
+def is_studio_process_step_job(*, job_id: str = "", task_preview: str | None = None) -> bool:
+    """True for a child node of a Studio bound process (not the SDD waiter).
+
+    Those jobs must not auto-check tasks.md — the parent waits until the
+    whole process run finishes.
+    """
+    name = str(job_id or "").strip()
+    bare = name.split("::")[-1] if "::" in name else name
+    if bare.startswith("p-"):
+        return True
+    preview = (task_preview or "").lstrip()
+    return preview.startswith("You are a step in a Studio process") or preview.startswith(
+        "You are a review gate in a Studio process"
+    )
 
 
 def try_complete_sdd_task_for_subagent(
@@ -356,6 +400,8 @@ def try_complete_sdd_task_for_subagent(
     Returns result dict when a task was marked, else None.
     """
     if not success or not job_id:
+        return None
+    if is_studio_process_step_job(job_id=job_id, task_preview=task_preview):
         return None
     ws = Path(workspace).expanduser().resolve() if workspace else None
     if ws is None or not ws.is_dir():

--- a/core/subagents/base.py
+++ b/core/subagents/base.py
@@ -277,6 +277,15 @@ class SubAgentHandle:
             "done": self.is_done,
             "spawn_fallback_reason": self.spawn_fallback_reason or "",
         }
+        if getattr(self, "followed_process", False) is True:
+            payload["followed_process"] = True
+            payload["studio_process_id"] = str(getattr(self, "studio_process_id", "") or "")
+            rid = str(getattr(self, "studio_process_run_id", "") or "")
+            if rid:
+                payload["studio_process_run_id"] = rid
+            sdd = getattr(self, "studio_sdd", None)
+            if isinstance(sdd, dict) and sdd:
+                payload["sdd"] = sdd
         if include_activity:
             payload["activity_log"] = list(self.activity_log or [])
         if include_result and self.result is not None:

--- a/core/subagents/manager.py
+++ b/core/subagents/manager.py
@@ -448,6 +448,8 @@ class SubAgentManager:
             )
         )
         # SDD apply/dispatch: mark tasks.md checkbox when job succeeds
+        # (skipped for Studio process *steps*; the bound-process waiter
+        # handle completes only after the whole graph finishes).
         self._maybe_complete_sdd_task(handle, success=success)
         self._publish_runtime(handle)
 

--- a/core/tools/sdd.py
+++ b/core/tools/sdd.py
@@ -757,8 +757,10 @@ class SddCheckTaskTool(BaseTool):
         self.name = "sdd_check_task"
         self.description = (
             "Mark a tasks.md checkbox done or not done. "
-            "When done=true, cancels any still-running subagent bound to that "
-            "task (and all SDD subagents for the change if every task is done)."
+            "When done=true, cancels any still-running one-shot subagent bound "
+            "to that task (and all SDD subagents for the change if every task "
+            "is done). Studio process waiters (followed_process) are not cancelled "
+            "— the parent still waits until the process run finishes."
         )
         self.risk_level = "no"
         self.parameters = {
@@ -916,11 +918,21 @@ class SddApplyTool(BaseTool):
                 )
                 plan = {**plan, "dispatch": dispatch, "auto_dispatched": True}
                 if dispatch.get("ok"):
-                    plan["message"] = (
-                        (plan.get("message") or "")
-                        + " Auto-dispatched subagents by tasks.md assignee "
+                    spawned = list(dispatch.get("spawned") or [])
+                    proc_n = sum(
+                        1 for j in spawned if isinstance(j, dict) and j.get("followed_process")
+                    )
+                    extra = (
+                        " Auto-dispatched subagents by tasks.md assignee "
                         "(use wait_subagent_result on job_id; do not re-spawn with coder)."
-                    ).strip()
+                    )
+                    if proc_n:
+                        extra += (
+                            f" {proc_n} job(s) follow a Studio process — "
+                            "wait_subagent_result blocks until that process run ends; "
+                            "do not mark the SDD task done on the first child step."
+                        )
+                    plan["message"] = ((plan.get("message") or "") + extra).strip()
             return result_json(plan)
         except Exception as exc:
             return _err(exc)
@@ -1091,7 +1103,8 @@ class SddDispatchTool(BaseTool):
             "same-section order inferred). Uses **exact assignee** from tasks.md. "
             "Blocked tasks wait for the next wave after sdd_check_task / auto-complete. "
             "Prefer sdd_apply (auto-dispatches). "
-            "Mode self returns main_tasks only. Then wait_subagent_result / sdd_check_task."
+            "Mode self returns main_tasks only. Then wait_subagent_result / sdd_check_task. "
+            "If a spawned job has followed_process, wait until the Studio process finishes."
         )
         self.risk_level = "high"
         self.parameters = {

--- a/core/tools/subagents.py
+++ b/core/tools/subagents.py
@@ -133,6 +133,22 @@ class DelegateToSubAgentTool(BaseTool):
                     f"(OS-process spawn was unavailable: {fallback}). "
                     f"Call wait_subagent_result(job_id='{h.name}') when you need the answer."
                 )
+            if getattr(h, "followed_process", False) is True:
+                payload["followed_process"] = True
+                payload["studio_process_id"] = str(getattr(h, "studio_process_id", "") or "")
+                payload["studio_process_run_id"] = str(
+                    getattr(h, "studio_process_run_id", "") or ""
+                )
+                sdd = getattr(h, "studio_sdd", None)
+                if isinstance(sdd, dict) and sdd:
+                    payload["sdd"] = sdd
+                payload["message"] = (
+                    f"Sub-agent '{h.name}' is bound to Studio process "
+                    f"{payload['studio_process_id'] or 'graph'}. "
+                    f"Call wait_subagent_result(job_id='{h.name}') and do **not** "
+                    "mark the SDD task done until that wait returns "
+                    "(followed_process finished)."
+                )
             return json.dumps(payload, ensure_ascii=False)
         except Exception as e:
             return f"Error spawning sub-agent: {e}"
@@ -146,10 +162,12 @@ class WaitSubAgentResultTool(BaseTool):
         self._parent = parent_agent
         self.name = "wait_subagent_result"
         self.description = (
-            "Wait for a sub-agent started via delegate_to_subagent and return its result. "
-            "job_id may be the bare name (e.g. coder-python) from delegate_to_subagent "
-            "or the full id (e.g. studio-123::coder-python) from list_subagents. "
-            "Use list_subagents to see running jobs."
+            "Wait for a sub-agent started via delegate_to_subagent / sdd_apply and "
+            "return its result. If that agent is bound to a Studio process, this "
+            "blocks until the **process** finishes — not the first child step. "
+            "Do not treat an SDD task as done while followed_process is still running. "
+            "job_id may be the bare name (e.g. coder-python) or full id "
+            "(studio-123::coder-python). Use list_subagents to see running jobs."
         )
         self.risk_level = "no"
         self.parameters = {
@@ -183,17 +201,36 @@ class WaitSubAgentResultTool(BaseTool):
                 timeout = 3600.0
             # wait_for resolves owner::name and can poll the profile registry.
             result = await mgr.wait_for(job_id, timeout=timeout)
-            return json.dumps(
-                {
-                    "job_id": job_id,
-                    "success": result.success,
-                    "response": result.response,
-                    "error": result.error,
-                    "duration_ms": result.duration_ms,
-                    "steps_taken": result.steps_taken,
-                },
-                ensure_ascii=False,
-            )
+            payload: dict[str, Any] = {
+                "job_id": job_id,
+                "success": result.success,
+                "response": result.response,
+                "error": result.error,
+                "duration_ms": result.duration_ms,
+                "steps_taken": result.steps_taken,
+            }
+            handle = None
+            get_handle = getattr(mgr, "get_handle", None)
+            if callable(get_handle):
+                try:
+                    handle = get_handle(job_id)
+                except Exception:
+                    handle = None
+            if handle is not None and getattr(handle, "followed_process", False) is True:
+                pid = str(getattr(handle, "studio_process_id", "") or "")
+                rid = str(getattr(handle, "studio_process_run_id", "") or "")
+                sdd = getattr(handle, "studio_sdd", None)
+                payload["followed_process"] = True
+                payload["process_id"] = pid
+                payload["run_id"] = rid
+                if isinstance(sdd, dict) and sdd:
+                    payload["sdd"] = sdd
+                pname = pid or "process"
+                payload["message"] = (
+                    f"Job ran as Studio process ({pname}). "
+                    "The SDD originating task is complete only after this process finished."
+                )
+            return json.dumps(payload, ensure_ascii=False)
         except KeyError:
             try:
                 summary = mgr.get_status_summary()
@@ -231,7 +268,11 @@ class ListSubAgentsTool(BaseTool):
         super().__init__()
         self._parent = parent_agent
         self.name = "list_subagents"
-        self.description = "List sub-agents spawned in this session (status, mode, task preview)."
+        self.description = (
+            "List sub-agents spawned in this session (status, mode, task preview). "
+            "Jobs with followed_process=true are Studio process waiters — the SDD "
+            "task is not done until that job finishes."
+        )
         self.risk_level = "no"
         self.parameters = {"type": "object", "properties": {}, "required": []}
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,11 +2,28 @@
 
 ## Unreleased
 
+## 1.1.9 — 2026-09-03
+
+### Added
+
+- **SDD + Studio processes** — spawn of an assignee bound to a Studio process
+  is a process waiter (`followed_process`). `wait_subagent_result` /
+  `list_subagents` / `sdd_apply` / `sdd_dispatch` expose that the job is a
+  process run; the SDD task is done only after the process finishes, not the
+  first child step. Process-step jobs (`p-*` / «You are a step in a Studio
+  process») do not auto-check `tasks.md`. `sdd_check_task` does not cancel
+  the process waiter.
+
 ### Changed
 
 - **pgvector** — `CREATE EXTENSION vector` is skipped when the extension is
   already present (native Postgres: deploy installs it as superuser; the
   `holix` role is not superuser). Extra `all` includes `psycopg`.
+
+### Tests
+
+- Process-step auto-check skip, `followed_process` on dispatch / status,
+  `sdd_check_task` does not terminate a process waiter.
 
 ## 1.1.8 — 2026-09-03
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.1.8"
+version = "1.1.9"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_sdd_task_completion.py
+++ b/tests/test_sdd_task_completion.py
@@ -54,10 +54,24 @@ def _ready_change(store: SpecStore, change_id: str = "feat-x") -> None:
     )
 
 
-def test_parse_sdd_marker():
-    m = parse_sdd_task_marker(
-        "[SDD change=feat-x task=1.1 project=user_catalog]\nDo stuff"
+def test_handle_status_exposes_followed_process():
+    handle = SubAgentHandle(
+        name="python-coder",
+        config=SubAgentConfig(name="python-coder"),
+        status=SubAgentStatus.RUNNING,
+        task_preview="[SDD change=feat-x task=1.1]",
     )
+    handle.followed_process = True
+    handle.studio_process_id = "proc-dev"
+    handle.studio_sdd = {"change_id": "feat-x", "task_id": "1.1"}
+    row = handle.to_status_dict(include_activity=False, include_result=False)
+    assert row["followed_process"] is True
+    assert row["studio_process_id"] == "proc-dev"
+    assert row["sdd"]["task_id"] == "1.1"
+
+
+def test_parse_sdd_marker():
+    m = parse_sdd_task_marker("[SDD change=feat-x task=1.1 project=user_catalog]\nDo stuff")
     assert m == {
         "change_id": "feat-x",
         "task_id": "1.1",
@@ -102,6 +116,29 @@ def test_auto_complete_via_job_index(tmp_path: Path):
         (tmp_path / "openspec/changes/feat-x/tasks.md").read_text(encoding="utf-8")
     )
     assert any(t.id == "1.1" and t.done for t in tasks)
+
+
+def test_skip_studio_process_step_auto_complete(tmp_path: Path):
+    from core.sdd.task_completion import is_studio_process_step_job
+
+    store = SpecStore(tmp_path)
+    _ready_change(store)
+    write_task_job(tmp_path, "feat-x", "1.1", "python-coder")
+    assert is_studio_process_step_job(
+        job_id="p-proc-102d1-python-coder-ab12",
+        task_preview="",
+    )
+    result = try_complete_sdd_task_for_subagent(
+        job_id="python-coder",
+        task_preview="You are a step in a Studio process. Do the work.",
+        success=True,
+        workspace=tmp_path,
+    )
+    assert result is None
+    tasks = parse_tasks_markdown(
+        (tmp_path / "openspec/changes/feat-x/tasks.md").read_text(encoding="utf-8")
+    )
+    assert any(t.id == "1.1" and not t.done for t in tasks)
 
 
 def test_no_auto_complete_on_failure(tmp_path: Path):
@@ -149,6 +186,38 @@ async def test_dispatch_records_structured_jobs(tmp_path: Path):
     assert "[SDD change=feat-x task=1.1]" in call_task
 
 
+@pytest.mark.asyncio
+async def test_dispatch_followed_process_job_fields(tmp_path: Path):
+    store = SpecStore(tmp_path)
+    _ready_change(store)
+    store.set_apply_mode("feat-x", "subagents")
+
+    handle = MagicMock()
+    handle.name = "python-coder"
+    handle.config.process_mode.value = "async"
+    handle.followed_process = True
+    handle.studio_process_id = "proc-dev"
+    handle.studio_sdd = {"change_id": "feat-x", "task_id": "1.1", "project": ""}
+
+    parent = MagicMock()
+    parent.config = MagicMock()
+    parent.config.workspace_root = str(tmp_path)
+    parent.subagents = MagicMock()
+    from unittest.mock import patch
+
+    parent.subagents.spawn_typed = AsyncMock(return_value=(handle, None))
+
+    with patch("core.config_utils.is_subagents_enabled", return_value=True):
+        result = await dispatch_change_tasks(store, "feat-x", parent_agent=parent)
+
+    spawned = {j["task_id"]: j for j in result["spawned"]}
+    job = spawned["1.1"]
+    assert job["followed_process"] is True
+    assert job["studio_process_id"] == "proc-dev"
+    assert "wait_subagent_result" in job["wait_hint"]
+    assert "followed_process" in result["message"]
+
+
 def test_manager_finish_marks_sdd_task(tmp_path: Path):
     store = SpecStore(tmp_path)
     _ready_change(store)
@@ -165,9 +234,7 @@ def test_manager_finish_marks_sdd_task(tmp_path: Path):
         config=SubAgentConfig(name="coder"),
         status=SubAgentStatus.COMPLETED,
         task_preview="[SDD change=feat-x task=1.1]\nBackend",
-        result=SubAgentResult(
-            name="coder", success=True, response="done", steps_taken=3
-        ),
+        result=SubAgentResult(name="coder", success=True, response="done", steps_taken=3),
     )
     mgr._handles["coder"] = handle
     mgr._emit_finished_once(handle)
@@ -294,3 +361,42 @@ async def test_all_tasks_done_cancels_remaining_sdd_jobs(tmp_path: Path):
     assert set(cancel["cancelled_jobs"]) >= {"coder-1"}
     assert "coder-1" in cancel["cancel_requested"]
     assert "coder-2" in cancel["cancel_requested"]
+
+
+@pytest.mark.asyncio
+async def test_check_task_skips_followed_process_waiter(tmp_path: Path):
+    store = SpecStore(tmp_path)
+    _ready_change(store)
+    write_task_job(tmp_path, "feat-x", "1.1", "python-coder")
+
+    parent = MagicMock()
+    parent.config = MagicMock()
+    parent.config.workspace_root = str(tmp_path)
+
+    waiter = SubAgentHandle(
+        name="python-coder",
+        config=SubAgentConfig(name="python-coder"),
+        status=SubAgentStatus.RUNNING,
+        task_preview="[SDD change=feat-x task=1.1]\nBackend work",
+    )
+    waiter.followed_process = True
+    waiter.studio_process_id = "proc-dev"
+    mgr = MagicMock()
+    mgr.list_active = MagicMock(return_value=[waiter])
+    mgr.get_handle = MagicMock(return_value=waiter)
+    mgr.terminate = AsyncMock(return_value=True)
+    parent.subagents = mgr
+
+    result = store.check_task("feat-x", task_id="1.1", done=True)
+    cancel = await cancel_sdd_subagents_after_check(
+        parent,
+        project_root=tmp_path,
+        change_id="feat-x",
+        task_id="1.1",
+        done=True,
+        tasks_done=result["tasks_done"],
+        tasks_total=result["tasks_total"],
+    )
+    assert "python-coder" not in cancel["cancelled_jobs"]
+    assert "python-coder" in cancel["skipped_process_jobs"]
+    mgr.terminate.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix 1.1.9.

SDD apply that spawns an assignee bound to a Studio process now waits for the **process run**, not the first child step (`followed_process` on `wait_subagent_result` / `sdd_apply` / `sdd_dispatch` / `list_subagents`). Process-step jobs do not auto-check `tasks.md`. `sdd_check_task` does not cancel the process waiter.

Also ships the post-1.1.8 pgvector fix: skip `CREATE EXTENSION vector` when it is already installed.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py
- [x] docs/CHANGELOG.md has section 1.1.9
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.1.9` (creates GitHub Release + PyPI).