### PR TITLE
Holix 1.1.10

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,3 @@
 """Holix CLI - Professional command-line interface for Holix AI Agent."""
 
-__version__ = "1.1.9"
+__version__ = "1.1.10"

--- a/core/sdd/dispatch.py
+++ b/core/sdd/dispatch.py
@@ -253,6 +253,11 @@ async def dispatch_change_tasks(
                 sdd = getattr(h, "studio_sdd", None)
                 if isinstance(sdd, dict) and sdd:
                     job["sdd"] = sdd
+                wt = str(getattr(h, "studio_worktree", "") or "").strip()
+                if not wt and isinstance(sdd, dict):
+                    wt = str(sdd.get("worktree") or "").strip()
+                if wt:
+                    job["worktree"] = wt
                 job["wait_hint"] = (
                     "wait_subagent_result(job_id) blocks until the Studio "
                     "process run finishes — not the first child step. "

--- a/core/subagents/base.py
+++ b/core/subagents/base.py
@@ -286,6 +286,11 @@ class SubAgentHandle:
             sdd = getattr(self, "studio_sdd", None)
             if isinstance(sdd, dict) and sdd:
                 payload["sdd"] = sdd
+            wt = str(getattr(self, "studio_worktree", "") or "").strip()
+            if not wt and isinstance(sdd, dict):
+                wt = str(sdd.get("worktree") or "").strip()
+            if wt:
+                payload["worktree"] = wt
         if include_activity:
             payload["activity_log"] = list(self.activity_log or [])
         if include_result and self.result is not None:

--- a/core/tools/subagents.py
+++ b/core/tools/subagents.py
@@ -142,6 +142,11 @@ class DelegateToSubAgentTool(BaseTool):
                 sdd = getattr(h, "studio_sdd", None)
                 if isinstance(sdd, dict) and sdd:
                     payload["sdd"] = sdd
+                wt = str(getattr(h, "studio_worktree", "") or "").strip()
+                if not wt and isinstance(sdd, dict):
+                    wt = str(sdd.get("worktree") or "").strip()
+                if wt:
+                    payload["worktree"] = wt
                 payload["message"] = (
                     f"Sub-agent '{h.name}' is bound to Studio process "
                     f"{payload['studio_process_id'] or 'graph'}. "
@@ -225,6 +230,11 @@ class WaitSubAgentResultTool(BaseTool):
                 payload["run_id"] = rid
                 if isinstance(sdd, dict) and sdd:
                     payload["sdd"] = sdd
+                wt = str(getattr(handle, "studio_worktree", "") or "").strip()
+                if not wt and isinstance(sdd, dict):
+                    wt = str(sdd.get("worktree") or "").strip()
+                if wt:
+                    payload["worktree"] = wt
                 pname = pid or "process"
                 payload["message"] = (
                     f"Job ran as Studio process ({pname}). "

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 1.1.10 — 2026-09-04
+
+### Added
+
+- **SDD worktree on process waiters** — `wait_subagent_result`, `delegate_to_subagent`,
+  `list_subagents` (`to_status_dict`), and `sdd_apply` dispatch jobs expose
+  `worktree` when a Studio process waiter is bound to `.holix/worktrees/<change_id>`.
+
+### Tests
+
+- Handle status, dispatch job fields, and `wait_subagent_result` JSON include `worktree`.
+
 ## 1.1.9 — 2026-09-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "Holix"
-version = "1.1.9"
+version = "1.1.10"
 description = "Self-improving AI agent with memory, skills, MCP, CLI, and TUI"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_sdd_task_completion.py
+++ b/tests/test_sdd_task_completion.py
@@ -63,11 +63,17 @@ def test_handle_status_exposes_followed_process():
     )
     handle.followed_process = True
     handle.studio_process_id = "proc-dev"
-    handle.studio_sdd = {"change_id": "feat-x", "task_id": "1.1"}
+    handle.studio_worktree = "/tmp/.holix/worktrees/feat-x"
+    handle.studio_sdd = {
+        "change_id": "feat-x",
+        "task_id": "1.1",
+        "worktree": "/tmp/.holix/worktrees/feat-x",
+    }
     row = handle.to_status_dict(include_activity=False, include_result=False)
     assert row["followed_process"] is True
     assert row["studio_process_id"] == "proc-dev"
     assert row["sdd"]["task_id"] == "1.1"
+    assert row["worktree"] == "/tmp/.holix/worktrees/feat-x"
 
 
 def test_parse_sdd_marker():
@@ -197,7 +203,13 @@ async def test_dispatch_followed_process_job_fields(tmp_path: Path):
     handle.config.process_mode.value = "async"
     handle.followed_process = True
     handle.studio_process_id = "proc-dev"
-    handle.studio_sdd = {"change_id": "feat-x", "task_id": "1.1", "project": ""}
+    handle.studio_worktree = "/tmp/.holix/worktrees/feat-x"
+    handle.studio_sdd = {
+        "change_id": "feat-x",
+        "task_id": "1.1",
+        "project": "",
+        "worktree": "/tmp/.holix/worktrees/feat-x",
+    }
 
     parent = MagicMock()
     parent.config = MagicMock()
@@ -214,8 +226,46 @@ async def test_dispatch_followed_process_job_fields(tmp_path: Path):
     job = spawned["1.1"]
     assert job["followed_process"] is True
     assert job["studio_process_id"] == "proc-dev"
+    assert job["worktree"] == "/tmp/.holix/worktrees/feat-x"
     assert "wait_subagent_result" in job["wait_hint"]
     assert "followed_process" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_wait_subagent_exposes_worktree():
+    import json
+
+    from core.tools.subagents import WaitSubAgentResultTool
+
+    handle = SubAgentHandle(
+        name="python-coder",
+        config=SubAgentConfig(name="python-coder"),
+        status=SubAgentStatus.COMPLETED,
+        result=SubAgentResult(name="python-coder", success=True, response="done"),
+    )
+    handle.followed_process = True
+    handle.studio_process_id = "proc-dev"
+    handle.studio_process_run_id = "run-abc"
+    handle.studio_worktree = "/tmp/.holix/worktrees/feat-x"
+    handle.studio_sdd = {
+        "change_id": "feat-x",
+        "task_id": "1.1",
+        "worktree": "/tmp/.holix/worktrees/feat-x",
+    }
+
+    mgr = MagicMock()
+    mgr.get_handle = MagicMock(return_value=handle)
+    mgr.wait_for = AsyncMock(return_value=handle.result)
+    parent = MagicMock()
+    parent.subagents = mgr
+    parent.config = MagicMock()
+    parent.config.profile_name = "default"
+
+    raw = await WaitSubAgentResultTool(parent).execute(job_id="python-coder")
+    payload = json.loads(raw)
+    assert payload["followed_process"] is True
+    assert payload["worktree"] == "/tmp/.holix/worktrees/feat-x"
+    assert payload["sdd"]["change_id"] == "feat-x"
 
 
 def test_manager_finish_marks_sdd_task(tmp_path: Path):

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "holix"
-version = "1.1.9"
+version = "1.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Release Holix 1.1.10.

`wait_subagent_result` / `delegate_to_subagent` / `list_subagents` / `sdd_apply` dispatch expose `worktree` when a Studio process waiter is bound to `.holix/worktrees/<change_id>`.

## Checklist
- [x] Version matches in pyproject.toml and cli/__init__.py
- [x] docs/CHANGELOG.md has section 1.1.10
- [ ] CI green (ruff + pytest matrix)

After merge: tag `v1.1.10` (creates GitHub Release + PyPI).