### PR TITLE
feat: pause at max_steps with Continue/Abort

### DIFF
--- a/cli/commands/chat.py
+++ b/cli/commands/chat.py
@@ -521,6 +521,7 @@ class ChatSession:
             """Returns an event handler tailored for the interactive chat UX."""
             from core.agent_events import (
                 FinalResponseEvent,
+                StepBudgetChoiceEvent,
                 ThinkingEvent,
                 ToolCallResultEvent,
                 ToolCallStartEvent,
@@ -571,6 +572,13 @@ class ChatSession:
                         print_info(
                             f"Confirmation required{sub}: {event.tool_name} — "
                             "/1 once, /2 session, /3 always, /4 deny"
+                        )
+
+                    elif isinstance(event, StepBudgetChoiceEvent):
+                        extra = int(event.extra_steps or 30)
+                        print_info(
+                            (event.message or "Step limit reached")
+                            + f" — Continue (+{extra}) or Abort in the UI"
                         )
 
                 except Exception:

--- a/cli/shared/agent_stop.py
+++ b/cli/shared/agent_stop.py
@@ -146,6 +146,12 @@ async def terminate_running_subagents(agent: Any | None) -> None:
 async def stop_all_agent_activity(host: Any) -> dict[str, int]:
     """Cancel agent runs and unblock confirmations, plan review, and sub-agents."""
     agent = getattr(host, "agent", None)
+    try:
+        from core.runtime.step_budget_pause import abort_all_pending_step_budget
+
+        abort_all_pending_step_budget()
+    except Exception:
+        pass
 
     stats = {
         "confirmations": deny_all_pending_confirmations(agent),
@@ -161,6 +167,12 @@ async def stop_all_agent_activity(host: Any) -> dict[str, int]:
 def stop_agent_activity_sync(host: Any) -> None:
     """Synchronous portion of /stop — safe from UI thread and slash handlers."""
     agent = getattr(host, "agent", None)
+    try:
+        from core.runtime.step_budget_pause import abort_all_pending_step_budget
+
+        abort_all_pending_step_budget()
+    except Exception:
+        pass
     deny_all_pending_confirmations(agent)
     reject_all_pending_plan_reviews()
     dismiss_host_modals(host)

--- a/cli/tui/code/app.py
+++ b/cli/tui/code/app.py
@@ -742,6 +742,7 @@ class HolixCodeApp(App):
             BackgroundProcessErrorEvent,
             BackgroundProcessStartedEvent,
             BackgroundProcessStoppedEvent,
+            StepBudgetChoiceEvent,
         )
         from core.security.confirmation_events import ConfirmationRequestEvent
         from core.subagents.interaction_events import SubAgentQuestionEvent
@@ -750,6 +751,7 @@ class HolixCodeApp(App):
             event,
             ConfirmationRequestEvent
             | SubAgentQuestionEvent
+            | StepBudgetChoiceEvent
             | BackgroundProcessStartedEvent
             | BackgroundProcessStoppedEvent
             | BackgroundProcessErrorEvent,
@@ -2133,6 +2135,9 @@ class HolixCodeApp(App):
 
     def _handle_confirmation_request(self, event: ConfirmationRequestEvent) -> None:
         self._modals.confirmation.show(event)
+
+    def _handle_step_budget_choice(self, event) -> None:
+        self._modals.step_budget.show(event)
 
     def _resolve_confirmation(self, choice: ConfirmationChoice) -> None:
         self._modals.confirmation.resolve(choice)

--- a/cli/tui/code/handlers/events.py
+++ b/cli/tui/code/handlers/events.py
@@ -16,6 +16,7 @@ from core.agent_events import (
     FinalResponseEvent,
     PlanCompletedEvent,
     PlanStepCompletedEvent,
+    StepBudgetChoiceEvent,
     ThinkingEvent,
     TodoListUpdatedEvent,
     ToolCallErrorEvent,
@@ -97,6 +98,10 @@ class CodeEventHandler:
                 self.app.set_thinking(None)
                 # Modal queue + transcript; also /1–/4 if dialog dismissed
                 self.app._handle_confirmation_request(event)
+
+            elif isinstance(event, StepBudgetChoiceEvent):
+                self.app.set_thinking(None)
+                self.app._handle_step_budget_choice(event)
 
             elif isinstance(event, SubAgentQuestionEvent):
                 self.app.set_thinking(None)

--- a/cli/tui/modals/stack.py
+++ b/cli/tui/modals/stack.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from cli.tui.modals.confirmation_presenter import ConfirmationPresenter
 from cli.tui.modals.plan_review import PlanReviewPresenter
+from cli.tui.modals.step_budget_presenter import StepBudgetPresenter
 from cli.tui.modals.subagent_question_presenter import SubagentQuestionPresenter
 
 
@@ -18,6 +19,7 @@ class ModalStack:
         self.confirmation = ConfirmationPresenter(app, self)
         self.plan_review = PlanReviewPresenter(app, self)
         self.subagent_question = SubagentQuestionPresenter(app, self)
+        self.step_budget = StepBudgetPresenter(app, self)
 
     @property
     def active_kind(self) -> str | None:

--- a/cli/tui/modals/step_budget.py
+++ b/cli/tui/modals/step_budget.py
@@ -1,0 +1,87 @@
+"""Step-budget Continue / Abort modal."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+
+class StepBudgetModal(ModalScreen):
+    """Two-button pause when the main agent hits max_steps."""
+
+    CSS = """
+    StepBudgetModal {
+        align: center middle;
+    }
+
+    #step-budget-dialog {
+        background: $surface;
+        border: thick $warning;
+        padding: 1 2;
+        width: 68;
+        max-width: 90%;
+        height: auto;
+        max-height: 80%;
+    }
+
+    #step-budget-title {
+        text-align: center;
+        padding: 0 1;
+        margin-bottom: 1;
+    }
+
+    #step-budget-body {
+        padding: 0 1;
+        margin-bottom: 1;
+    }
+
+    #step-budget-buttons {
+        align: center middle;
+        height: auto;
+        padding: 1;
+    }
+
+    #step-budget-buttons Button {
+        margin: 0 1;
+        min-width: 16;
+    }
+    """
+
+    def __init__(
+        self,
+        message: str,
+        request_id: str = "",
+        extra_steps: int = 30,
+    ):
+        super().__init__()
+        self.message = message
+        self.request_id = request_id
+        self.extra_steps = extra_steps
+
+    def compose(self) -> ComposeResult:
+        with Container(id="step-budget-dialog"):
+            yield Label("⚠ Step limit reached", id="step-budget-title")
+            yield Static(self.message, id="step-budget-body", markup=False)
+            with Horizontal(id="step-budget-buttons"):
+                yield Button(
+                    f"[1] Continue (+{self.extra_steps})",
+                    variant="success",
+                    id="btn-continue",
+                )
+                yield Button("[2] Abort", variant="error", id="btn-abort")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-continue":
+            self.dismiss("continue")
+            return
+        self.dismiss("abort")
+
+    def on_key(self, event) -> None:
+        if event.key == "1":
+            event.stop()
+            self.dismiss("continue")
+        elif event.key in {"2", "escape"}:
+            event.stop()
+            self.dismiss("abort")

--- a/cli/tui/modals/step_budget_presenter.py
+++ b/cli/tui/modals/step_budget_presenter.py
@@ -1,0 +1,137 @@
+"""Step-budget Continue/Abort modal presenter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from core.agent_events import StepBudgetChoiceEvent
+from core.runtime.step_budget_pause import (
+    ABORT,
+    CONTINUE,
+    pending_ids,
+    resolve_step_budget,
+)
+
+from cli.tui.modals.step_budget import StepBudgetModal
+
+if TYPE_CHECKING:
+    from cli.tui.modals.stack import ModalStack
+
+
+class StepBudgetPresenter:
+    """Shows StepBudgetModal and resolves the pause future."""
+
+    def __init__(self, app: Any, stack: ModalStack) -> None:
+        self.app = app
+        self._stack = stack
+        self._queue: list[StepBudgetChoiceEvent] = []
+        self._active: StepBudgetChoiceEvent | None = None
+        self._modal_open = False
+        self._modal: StepBudgetModal | None = None
+
+    def show(self, event: StepBudgetChoiceEvent) -> None:
+        rid = (getattr(event, "request_id", None) or "").strip()
+        if rid:
+            if self._active and (self._active.request_id or "") == rid:
+                return
+            if any((e.request_id or "") == rid for e in self._queue):
+                return
+            if rid not in pending_ids():
+                return
+        self._queue.append(event)
+        self._pump()
+
+    def _log_request(self, event: StepBudgetChoiceEvent) -> None:
+        write = getattr(self.app, "_append_to_log", None) or getattr(
+            self.app, "transcript_write", None
+        )
+        if write:
+            write(f"\n⚠ [bold yellow]{event.message or 'Step limit reached'}[/bold yellow]")
+
+    def _release_active_ui(self, *, pop_screen: bool) -> None:
+        self._modal_open = False
+        self._active = None
+        if self._stack.active_kind == "step_budget":
+            self._stack.set_active(None)
+        modal = self._modal
+        self._modal = None
+        if pop_screen and modal is not None and hasattr(self.app, "pop_screen"):
+            try:
+                self.app.pop_screen()
+            except Exception:
+                pass
+
+    def _pump(self) -> None:
+        if self._active is not None:
+            rid = (self._active.request_id or "").strip()
+            if rid and rid not in pending_ids():
+                self._release_active_ui(pop_screen=True)
+            else:
+                return
+        if self._modal_open:
+            if self._active is None:
+                self._modal_open = False
+            else:
+                return
+        if not self._queue:
+            return
+        if self._stack.has_active and self._stack.active_kind not in (None, "step_budget"):
+            if hasattr(self.app, "set_timer"):
+                self.app.set_timer(0.35, self._pump)
+            return
+
+        event = self._queue.pop(0)
+        rid = (event.request_id or "").strip()
+        if rid and rid not in pending_ids():
+            self._pump()
+            return
+        self._active = event
+        self.app._pending_step_budget = event
+        self._log_request(event)
+        self._open_modal(event)
+
+    def _open_modal(self, event: StepBudgetChoiceEvent) -> None:
+        self._stack.set_active("step_budget")
+        modal = StepBudgetModal(
+            message=event.message or "Step limit reached",
+            request_id=event.request_id,
+            extra_steps=int(event.extra_steps or 30),
+        )
+        self._modal = modal
+        self._modal_open = True
+
+        def _open() -> None:
+            try:
+                self.app.push_screen(modal, self.on_dismissed)
+            except Exception:
+                self._modal = None
+                self._modal_open = False
+                self._active = None
+                if self._stack.active_kind == "step_budget":
+                    self._stack.set_active(None)
+
+        if hasattr(self.app, "call_later"):
+            self.app.call_later(_open)
+        else:
+            _open()
+
+    def on_dismissed(self, result: str | None) -> None:
+        self._modal_open = False
+        self._modal = None
+        self._stack.set_active(None)
+        event = self._active
+        self._active = None
+        raw = (result if isinstance(result, str) else None) or ABORT
+        choice = CONTINUE if str(raw).strip().lower() == CONTINUE else ABORT
+        rid = getattr(event, "request_id", None) if event else None
+        resolve_step_budget(str(rid or ""), choice)
+        write = getattr(self.app, "_append_to_log", None) or getattr(
+            self.app, "transcript_write", None
+        )
+        if write:
+            if choice == CONTINUE:
+                write("[dim]Step budget: continue[/dim]")
+            else:
+                write("[dim]Step budget: abort[/dim]")
+        self.app._pending_step_budget = None
+        self._pump()

--- a/config.py
+++ b/config.py
@@ -51,6 +51,14 @@ class Settings(BaseSettings):
         ),
         description="Max number of automatic step-budget extensions per run",
     )
+    max_steps_user_max_extensions: int = Field(
+        default=10,
+        validation_alias=AliasChoices(
+            "HOLIX_MAX_STEPS_USER_MAX_EXTENSIONS",
+            "MAX_STEPS_USER_MAX_EXTENSIONS",
+        ),
+        description="Max Continue clicks after auto-extend stops (each grants extend_by steps)",
+    )
     max_steps_hard_cap: int = Field(
         default=0,
         validation_alias=AliasChoices("HOLIX_MAX_STEPS_HARD_CAP", "MAX_STEPS_HARD_CAP"),

--- a/core/agent_events.py
+++ b/core/agent_events.py
@@ -36,6 +36,8 @@ class EventType(StrEnum):
     FINAL_RESPONSE = "final_response"
     MAX_STEPS_REACHED = "max_steps_reached"
     MAX_STEPS_EXTENDED = "max_steps_extended"
+    STEP_BUDGET_CHOICE = "step_budget_choice"
+    STEP_BUDGET_RESOLVED = "step_budget_resolved"
 
     # Tool execution
     TOOL_CALL_START = "tool_call_start"
@@ -340,6 +342,56 @@ class MaxStepsExtendedEvent(AgentEvent):
             "extra_steps": self.extra_steps,
             "extensions": self.extensions,
             "reason": self.reason,
+        }
+
+
+@dataclass
+class StepBudgetChoiceEvent(AgentEvent):
+    """Main agent hit max_steps and is waiting for Continue / Abort."""
+
+    request_id: str = ""
+    step_count: int = 0
+    max_steps: int = 90
+    extra_steps: int = 30
+    user_extensions_used: int = 0
+    user_extensions_max: int = 10
+    reason: str = ""
+    message: str = ""
+    choices: list[dict[str, str]] = field(default_factory=list)
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.STEP_BUDGET_CHOICE)
+
+    def _extra_fields(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "step_count": self.step_count,
+            "max_steps": self.max_steps,
+            "extra_steps": self.extra_steps,
+            "user_extensions_used": self.user_extensions_used,
+            "user_extensions_max": self.user_extensions_max,
+            "reason": self.reason,
+            "message": self.message,
+            "choices": self.choices,
+        }
+
+
+@dataclass
+class StepBudgetResolvedEvent(AgentEvent):
+    """User picked Continue or Abort for a step-budget pause."""
+
+    request_id: str = ""
+    choice: str = ""
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "type", EventType.STEP_BUDGET_RESOLVED)
+
+    def _extra_fields(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "choice": self.choice,
         }
 
 
@@ -1024,6 +1076,8 @@ def make_event(
         EventType.FINAL_RESPONSE: FinalResponseEvent,
         EventType.ERROR: ErrorEvent,
         EventType.MAX_STEPS_EXTENDED: MaxStepsExtendedEvent,
+        EventType.STEP_BUDGET_CHOICE: StepBudgetChoiceEvent,
+        EventType.STEP_BUDGET_RESOLVED: StepBudgetResolvedEvent,
         EventType.THINKING: ThinkingEvent,
         EventType.SKILL_CREATED: SkillCreatedEvent,
         EventType.SKILL_PROPOSED: SkillProposedEvent,
@@ -1139,6 +1193,8 @@ __all__ = [
     "ToolCallErrorEvent",
     "MaxStepsReachedEvent",
     "MaxStepsExtendedEvent",
+    "StepBudgetChoiceEvent",
+    "StepBudgetResolvedEvent",
     "ErrorEvent",
     "LLMCallStartedEvent",
     "LLMCallCompletedEvent",

--- a/core/agent_execution.py
+++ b/core/agent_execution.py
@@ -139,6 +139,7 @@ async def run_agent_loop(
     max_steps = getattr(agent_config, "max_steps", settings.max_steps)
     base_max_steps = int(max_steps or 0)
     step_budget_extensions = 0
+    step_budget_user_extensions = 0
     model = getattr(agent, "model", settings.model)
     temperature = getattr(agent_config, "temperature", settings.temperature)
     client: AsyncOpenAI = agent.client
@@ -533,14 +534,81 @@ async def run_agent_loop(
             )
             continue
 
-        # Max steps reached (hung / no progress / extension cap)
+        from core.presenters.final_content import step_limit_aborted_message
+        from core.runtime.step_budget import StepBudgetDecision, apply_extension
+        from core.runtime.step_budget_pause import ask_continue_or_abort, can_ask_user
+
+        policy = StepBudgetPolicy.from_config(agent_config)
+        if can_ask_user(
+            agent,
+            conversation_id=conversation_id,
+            user_used=step_budget_user_extensions,
+            policy=policy,
+        ):
+            choice = await ask_continue_or_abort(
+                agent=agent,
+                conversation_id=conversation_id,
+                step_count=step_count,
+                max_steps=max_steps,
+                extra_steps=policy.extend_by,
+                user_used=step_budget_user_extensions,
+                user_max=policy.user_max_extensions,
+                reason=decision.reason,
+            )
+            if choice == "continue":
+                extra = policy.extend_by
+                user_decision = StepBudgetDecision(
+                    extend=True,
+                    reason=(
+                        f"user continue; +{extra} steps "
+                        f"({step_count}/{max_steps} → max {max_steps + extra})"
+                    ),
+                    status="working",
+                    extra_steps=extra,
+                    new_max_steps=max_steps + extra,
+                    extensions_used=step_budget_extensions,
+                    user_extensions_used=step_budget_user_extensions + 1,
+                    from_user=True,
+                )
+                prev_max = max_steps
+                max_steps = user_decision.new_max_steps
+                step_budget_user_extensions = user_decision.user_extensions_used
+                patched = apply_extension(
+                    {"conversation_id": conversation_id, "messages": messages},
+                    {"step_count": step_count, "messages": messages},
+                    user_decision,
+                    agent=None,
+                    previous_max_steps=prev_max,
+                )
+                messages = list(patched.get("messages") or messages)
+                yield MaxStepsExtendedEvent(
+                    max_steps=max_steps,
+                    previous_max_steps=prev_max,
+                    extra_steps=user_decision.extra_steps,
+                    extensions=step_budget_user_extensions,
+                    reason=user_decision.reason,
+                    conversation_id=conversation_id,
+                )
+                yield ThinkingEvent(
+                    message=(
+                        f"Step budget extended by {user_decision.extra_steps} "
+                        f"(now max {max_steps}): still working"
+                    ),
+                    conversation_id=conversation_id,
+                )
+                continue
+
+        timeout_msg = step_limit_aborted_message(max_steps)
+        if decision.reason:
+            timeout_msg = f"{timeout_msg} {decision.reason}"
+        yield FinalResponseEvent(
+            content=timeout_msg,
+            steps_taken=step_count,
+            conversation_id=conversation_id,
+        )
         yield MaxStepsReachedEvent(
             max_steps=max_steps,
             conversation_id=conversation_id,
-        )
-        timeout_msg = (
-            f"Agent reached maximum steps ({max_steps}). "
-            f"{decision.reason or 'Task may be too complex.'}"
         )
         await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
         return

--- a/core/config_utils.py
+++ b/core/config_utils.py
@@ -90,6 +90,7 @@ _LOCAL_SYSTEM_KEYS: frozenset[str] = frozenset(
         "max_steps_extend_enabled",
         "max_steps_extend_by",
         "max_steps_max_extensions",
+        "max_steps_user_max_extensions",
         "max_steps_hard_cap",
         "subagent_supervisor_enabled",
         "subagent_supervisor_poll_s",

--- a/core/di/runtime_config.py
+++ b/core/di/runtime_config.py
@@ -76,6 +76,7 @@ class HolixRuntimeConfig:
     max_steps_extend_enabled: bool
     max_steps_extend_by: int
     max_steps_max_extensions: int
+    max_steps_user_max_extensions: int
     max_steps_hard_cap: int
 
     # Safety / plan review
@@ -209,6 +210,9 @@ class HolixRuntimeConfig:
             max_steps_extend_enabled=bool(getattr(s, "max_steps_extend_enabled", True)),
             max_steps_extend_by=int(getattr(s, "max_steps_extend_by", 30) or 30),
             max_steps_max_extensions=int(getattr(s, "max_steps_max_extensions", 10) or 10),
+            max_steps_user_max_extensions=int(
+                getattr(s, "max_steps_user_max_extensions", 10) or 10
+            ),
             max_steps_hard_cap=int(getattr(s, "max_steps_hard_cap", 0) or 0),
             auto_allow_threshold=s.auto_allow_threshold,
             non_interactive=s.non_interactive,
@@ -329,6 +333,8 @@ class HolixRuntimeConfig:
             overrides["max_steps_extend_by"] = int(profile.max_steps_extend_by)
         if getattr(profile, "max_steps_max_extensions", None) is not None:
             overrides["max_steps_max_extensions"] = int(profile.max_steps_max_extensions)
+        if getattr(profile, "max_steps_user_max_extensions", None) is not None:
+            overrides["max_steps_user_max_extensions"] = int(profile.max_steps_user_max_extensions)
         if getattr(profile, "max_steps_hard_cap", None) is not None:
             overrides["max_steps_hard_cap"] = int(profile.max_steps_hard_cap)
         if getattr(profile, "search", None):

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -67,6 +67,7 @@ def prepare_initial_state(
         "max_steps": max_steps,
         "base_max_steps": max_steps,
         "step_budget_extensions": 0,
+        "step_budget_user_extensions": 0,
         "max_steps_per_plan_step": max_per_step,
         "execution_mode": execution_mode,
         "is_final": False,
@@ -235,7 +236,9 @@ async def run_graph_loop(
         from core.llm.response_text import sanitize_assistant_visible_text
         from core.presenters.final_content import (
             coerce_usable_final_text,
+            is_code_or_diff_dump,
             is_placeholder_final,
+            step_limit_reached_message,
         )
         from core.presenters.subagent_tool_text import (
             graph_tool_results_as_recent,
@@ -245,19 +248,21 @@ async def run_graph_loop(
         final_text = sanitize_assistant_visible_text(final_state.get("final_response") or "")
         if is_placeholder_final(final_text):
             final_text = ""
-        if not (final_text or "").strip():
+        step_count = final_state.get("step_count", 0)
+        max_steps = final_state.get("max_steps", 90)
+        at_cap = bool(step_count >= max_steps)
+        if not (final_text or "").strip() and not at_cap:
             picked = pick_best_tool_final(
                 graph_tool_results_as_recent(final_state.get("tool_results"))
             )
             if picked:
                 final_text = picked
-        step_count = final_state.get("step_count", 0)
-        max_steps = final_state.get("max_steps", 90)
-        hit_cap = bool(step_count >= max_steps and not final_state.get("is_final", False))
         final_text = coerce_usable_final_text(
             final_text,
-            max_steps=max_steps if hit_cap else None,
+            max_steps=max_steps if at_cap else None,
         )
+        if at_cap and is_code_or_diff_dump(final_text):
+            final_text = step_limit_reached_message(max_steps, step_count=step_count)
         if not getattr(agent, "_final_response_emitted", False):
             if agent is not None:
                 agent._final_response_emitted = True
@@ -271,12 +276,14 @@ async def run_graph_loop(
                 conversation_id=conversation_id,
             )
 
-        if step_count >= max_steps and not final_state.get("is_final", False):
+        if at_cap and not final_state.get("is_final", False):
             yield MaxStepsReachedEvent(
                 max_steps=max_steps,
                 conversation_id=conversation_id,
             )
-            timeout_msg = f"Agent reached maximum steps ({max_steps}). Task may be too complex."
+            timeout_msg = (
+                final_text or f"Agent reached maximum steps ({max_steps}). Task may be too complex."
+            )
             await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
 
     except asyncio.CancelledError:

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -276,15 +276,17 @@ async def run_graph_loop(
                 conversation_id=conversation_id,
             )
 
-        if at_cap and not final_state.get("is_final", False):
+        if at_cap:
             yield MaxStepsReachedEvent(
                 max_steps=max_steps,
                 conversation_id=conversation_id,
             )
-            timeout_msg = (
-                final_text or f"Agent reached maximum steps ({max_steps}). Task may be too complex."
-            )
-            await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
+            if not final_state.get("is_final", False):
+                timeout_msg = (
+                    final_text
+                    or f"Agent reached maximum steps ({max_steps}). Task may be too complex."
+                )
+                await agent.memory.save_message(conversation_id, "assistant", timeout_msg)
 
     except asyncio.CancelledError:
         raise

--- a/core/graph/nodes/react_node.py
+++ b/core/graph/nodes/react_node.py
@@ -770,9 +770,9 @@ async def react_node(state: HolixGraphState, config: RunnableConfig) -> dict:
                 max_tokens=max_tokens,
                 tool_choice=tool_choice,
             )
-        from core.runtime.step_budget import maybe_extend_for_graph_result
+        from core.runtime.step_budget import maybe_extend_or_ask
 
-        result = maybe_extend_for_graph_result(
+        result = await maybe_extend_or_ask(
             state,
             result,
             agent=agent,

--- a/core/graph/state.py
+++ b/core/graph/state.py
@@ -21,81 +21,84 @@ class HolixGraphState(TypedDict, total=False):
     """
 
     # Core conversation state
-    messages: list[dict[str, Any]]       # Full conversation history
-    user_input: str                      # Latest user message
-    conversation_id: str                 # Thread identifier
-    system_prompt: str                   # Assembled system prompt
+    messages: list[dict[str, Any]]  # Full conversation history
+    user_input: str  # Latest user message
+    conversation_id: str  # Thread identifier
+    system_prompt: str  # Assembled system prompt
 
     # Tool execution state
-    tool_calls: list[dict[str, Any]]     # Pending tool calls from LLM
-    tool_results: list[dict[str, Any]]   # Completed tool call results
+    tool_calls: list[dict[str, Any]]  # Pending tool calls from LLM
+    tool_results: list[dict[str, Any]]  # Completed tool call results
 
     # Memory state (populated by memory_retrieval_node)
-    relevant_memories: list[dict[str, Any]]   # From LTM episodic + semantic
-    relevant_skills: list[dict[str, Any]]     # From procedural memory
+    relevant_memories: list[dict[str, Any]]  # From LTM episodic + semantic
+    relevant_skills: list[dict[str, Any]]  # From procedural memory
     relevant_strategies: list[dict[str, Any]]  # From strategic memory
 
     # Execution control
     step_count: int
     max_steps: int
-    base_max_steps: int                  # Original max_steps before auto-extensions
-    step_budget_extensions: int          # How many times max_steps was auto-extended
-    max_steps_per_plan_step: int         # Max ReAct iterations per plan step
-    execution_mode: str                  # "react" | "plan_and_execute" | "hybrid"
-    is_final: bool                       # True when final response generated
-    final_response: str                  # The final answer
+    base_max_steps: int  # Original max_steps before auto-extensions
+    step_budget_extensions: int  # How many times max_steps was auto-extended
+    step_budget_user_extensions: int  # Continue clicks after auto-extend stopped
+    max_steps_per_plan_step: int  # Max ReAct iterations per plan step
+    execution_mode: str  # "react" | "plan_and_execute" | "hybrid"
+    is_final: bool  # True when final response generated
+    final_response: str  # The final answer
 
     # Streaming support
-    stream: bool                         # Whether to use LLM streaming
+    stream: bool  # Whether to use LLM streaming
 
     # Meta-agent state (Phase 4)
     meta_decision: dict[str, Any] | None  # Strategy adjustments from meta-agent
-    needs_refinement: bool               # Set by meta-agent for self-refinement
+    needs_refinement: bool  # Set by meta-agent for self-refinement
 
     # Self-refinement / Reflexion state
     refinement_iterations: int
     max_refinement_iterations: int
-    reflection_count: int                    # Reflexion retries this turn
-    reflection_log: list[dict[str, Any]]     # Verbal reflections + quality scores
+    reflection_count: int  # Reflexion retries this turn
+    reflection_log: list[dict[str, Any]]  # Verbal reflections + quality scores
 
     # Sub-agent state (Phase 4b)
-    sub_agent_tasks: list[dict[str, Any]]    # Sub-tasks for sub-agents
-    sub_agent_results: dict[str, Any]        # {agent_name: result}
-    pending_subagent: str | None          # Legacy single job id (use pending_subagents)
-    pending_subagents: list[str]          # Active wave job ids
+    sub_agent_tasks: list[dict[str, Any]]  # Sub-tasks for sub-agents
+    sub_agent_results: dict[str, Any]  # {agent_name: result}
+    pending_subagent: str | None  # Legacy single job id (use pending_subagents)
+    pending_subagents: list[str]  # Active wave job ids
     subagent_orchestration: dict[str, Any] | None  # Serialized OrchestrationPlan
-    current_subagent_wave: int            # Next wave index to run
+    current_subagent_wave: int  # Next wave index to run
     subagent_wave_results: dict[str, Any]  # {wave_id: {job_id: result}}
-    subagent_task_meta: dict[str, Any]     # {job_id: task metadata}
+    subagent_task_meta: dict[str, Any]  # {job_id: task metadata}
     subagent_wave_step_indices: list[int] | None  # Plan indices finished in last wave
-    subagent_awaiting_synthesis: bool     # True after collect, before react synthesis
-    subagent_delegate_next: bool           # Router hint to spawn the next wave
+    subagent_awaiting_synthesis: bool  # True after collect, before react synthesis
+    subagent_delegate_next: bool  # Router hint to spawn the next wave
 
     # Graph-native supervisor (post-wave rework cycle)
-    supervisor_needs_rework: bool          # Router: supervisor → delegate again
+    supervisor_needs_rework: bool  # Router: supervisor → delegate again
     supervisor_rework_tasks: list[dict[str, Any]]  # Tasks with guidance for same types
-    supervisor_rework_round: int           # How many graph rework rounds this turn
-    supervisor_log: list[dict[str, Any]]   # Audit trail of interventions
+    supervisor_rework_round: int  # How many graph rework rounds this turn
+    supervisor_log: list[dict[str, Any]]  # Audit trail of interventions
     supervisor_last_diagnosis: dict[str, Any] | None
 
     # Plan state (for plan_and_execute and hybrid modes)
-    plan_steps: list[dict[str, Any]]         # Ordered list of plan steps
-    current_plan_step: int                    # Index of current step
+    plan_steps: list[dict[str, Any]]  # Ordered list of plan steps
+    current_plan_step: int  # Index of current step
     # Stable id for .holix/plans filenames (must be a graph channel or it is dropped).
     plan_id: str
 
     # Plan review state (for plan_and_execute and hybrid modes)
-    plan_status: str                         # "pending_review" | "confirmed" | "auto_execute" | "refine" | "rejected"
-    plan_review_id: str                       # Correlation ID for review request/response
-    plan_refinement_feedback: str             # User feedback when refining the plan
-    plan_clarification_rounds: int            # How many clarification Q&A rounds occurred
+    plan_status: str  # "pending_review" | "confirmed" | "auto_execute" | "refine" | "rejected"
+    plan_review_id: str  # Correlation ID for review request/response
+    plan_refinement_feedback: str  # User feedback when refining the plan
+    plan_clarification_rounds: int  # How many clarification Q&A rounds occurred
 
     # Plan orchestration state (step execution within plan_and_execute)
-    is_step_complete: bool                   # True when current plan step is finished (react produced no tool_calls)
-    current_step_start_count: int            # step_count at the start of current plan step (for per-step limit)
+    is_step_complete: bool  # True when current plan step is finished (react produced no tool_calls)
+    current_step_start_count: (
+        int  # step_count at the start of current plan step (for per-step limit)
+    )
 
     # Action honesty: block "done" claims without successful tool evidence
-    honesty_nudge_count: int                 # How many false-completion nudges this turn
+    honesty_nudge_count: int  # How many false-completion nudges this turn
 
     # Enriched plan data (from detailed plan_node)
     plan_analysis: dict[str, Any] | None  # Analysis: task_summary, complexity, clarifying_questions

--- a/core/presenters/final_content.py
+++ b/core/presenters/final_content.py
@@ -23,6 +23,10 @@ _ABORTED_FINAL_MARKERS = (
     "no llm model configured",
     "no llm client available",
     "agent reached maximum steps",
+    "step limit reached",
+    "достигнут лимит шагов",
+    "run aborted",
+    "выполнение прервано",
     "превышено время выполнения",
 )
 # "Error: …" as a message — not "TimeoutError:" / "ValueError:" inside source dumps.
@@ -36,6 +40,23 @@ UNUSABLE_TEST_DUMP_RU = (
     "Агент не сформировал текстовый ответ (часто — лимит шагов).\n"
     "Последний вывод tool — лог тестов, это не отчёт.\n"
     "{snippet}"
+)
+
+_CODE_LINE_PREFIXES = (
+    "def ",
+    "class ",
+    "import ",
+    "from ",
+    "async def ",
+    "function ",
+    "const ",
+    "let ",
+    "var ",
+    "export ",
+    "public ",
+    "private ",
+    "package ",
+    "#include",
 )
 
 _UNSUCCESSFUL_FINAL_MARKERS = (
@@ -69,6 +90,84 @@ def is_unusable_final_tool_output(text: str | None) -> bool:
     return is_test_log_dump(text or "")
 
 
+def is_code_or_diff_dump(text: str | None) -> bool:
+    """True when the whole message is a source dump or unified diff, not a report."""
+    raw = (text or "").strip()
+    if not raw:
+        return False
+    if is_unusable_final_tool_output(raw):
+        return True
+    if raw.startswith(("diff --git", "--- a/", "+++ b/")):
+        return True
+    diff_hits = sum(
+        1 for hint in ("\ndiff --git ", "\n@@ ", "\n+++ ", "\n--- a/", "\n--- b/") if hint in raw
+    )
+    if diff_hits >= 2 and len(raw) >= 200:
+        return True
+    if raw.startswith("Content of ") and len(raw) >= 400:
+        return True
+    lines = raw.splitlines()
+    if len(lines) < 15:
+        return False
+    code_lines = 0
+    prose_lines = 0
+    for line in lines[:120]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(_CODE_LINE_PREFIXES) or stripped.endswith("{"):
+            code_lines += 1
+            continue
+        if stripped.startswith(("#", "//", "*", "/*")):
+            continue
+        if len(stripped) > 40 and not any(ch in stripped for ch in ("=", "(", "{", ";")):
+            prose_lines += 1
+    return code_lines >= 10 and code_lines > prose_lines * 2 and len(raw) >= 400
+
+
+def is_usable_user_final(text: str | None) -> bool:
+    """True when *text* is a real assistant answer, not a dump/placeholder/abort."""
+    raw = (text or "").strip()
+    if not raw or is_placeholder_final(raw):
+        return False
+    if is_unusable_final_tool_output(raw) or is_code_or_diff_dump(raw):
+        return False
+    if is_aborted_final_response(raw):
+        return False
+    return True
+
+
+def step_limit_reached_message(
+    max_steps: int,
+    *,
+    step_count: int | None = None,
+    extra_steps: int | None = None,
+    locale: str = "ru",
+) -> str:
+    """User-visible notice when the reasoning-step budget is exhausted."""
+    loc = (locale or "ru").strip().lower()[:2]
+    shown = int(step_count or max_steps or 0)
+    cap = int(max_steps or 0)
+    extra = int(extra_steps or 0)
+    if loc == "ru":
+        msg = f"Достигнут лимит шагов ({shown}/{cap})."
+        if extra > 0:
+            msg += f" Нажмите «Продолжить», чтобы выделить ещё {extra} шагов, или «Прервать»."
+        return msg
+    msg = f"Step limit reached ({shown}/{cap})."
+    if extra > 0:
+        msg += f" Choose Continue for +{extra} steps, or Abort."
+    return msg
+
+
+def step_limit_aborted_message(max_steps: int, *, locale: str = "ru") -> str:
+    loc = (locale or "ru").strip().lower()[:2]
+    cap = int(max_steps or 0)
+    if loc == "ru":
+        return f"Достигнут лимит шагов ({cap}). Выполнение прервано."
+    return f"Step limit reached ({cap}). Run aborted."
+
+
 def format_unusable_final(text: str | None, *, max_steps: int | None = None) -> str:
     from core.runtime.test_run_signals import failure_snippet
 
@@ -84,11 +183,15 @@ def coerce_usable_final_text(
     *,
     max_steps: int | None = None,
 ) -> str:
-    """Drop pytest dumps; optionally annotate a max-steps stop."""
+    """Drop pytest/code dumps; optionally annotate a max-steps stop."""
     raw = (text or "").strip()
+    if max_steps:
+        if not raw or is_unusable_final_tool_output(raw) or is_code_or_diff_dump(raw):
+            if is_unusable_final_tool_output(raw):
+                return format_unusable_final(raw, max_steps=max_steps)
+            return step_limit_reached_message(max_steps)
+        return raw
     if not raw:
-        if max_steps:
-            return f"Достигнут лимит шагов ({max_steps}). Текстового ответа нет."
         return ""
     if is_unusable_final_tool_output(raw):
         return format_unusable_final(raw, max_steps=max_steps)

--- a/core/profile/service.py
+++ b/core/profile/service.py
@@ -103,6 +103,7 @@ class ProfileConfig(BaseModel):
     max_steps_extend_enabled: bool | None = None
     max_steps_extend_by: int | None = None
     max_steps_max_extensions: int | None = None
+    max_steps_user_max_extensions: int | None = None
     max_steps_hard_cap: int | None = None
 
     # Hub: optional background ClawHub version updates

--- a/core/runtime/step_budget.py
+++ b/core/runtime/step_budget.py
@@ -22,21 +22,17 @@ logger = logging.getLogger(__name__)
 # Defaults (overridable via Settings / agent config)
 DEFAULT_EXTEND_BY = 30
 DEFAULT_MAX_EXTENSIONS = 10
+DEFAULT_USER_MAX_EXTENSIONS = 10
 DEFAULT_HARD_CAP = 0  # 0 → derive from base max_steps + extend_by * max_extensions
 DEFAULT_LOOKBACK = 6
 
-_ERROR_MARKERS = (
-    "error",
-    "exception",
-    "traceback",
-    "failed",
-    "timeout",
-    "timed out",
-    "permission denied",
-    "not found",
-    "invalid",
-    "❌",
-    "⛔",
+# Whole-token / line failures — not "TimeoutError:" inside a source dump.
+_ERROR_TOKEN_RE = re.compile(
+    r"(?i)(?:^|[\s])(?:error|exception|failed|failure)\s*:|"
+    r"traceback \(most recent call last\)|"
+    r"permission denied|"
+    r"timed out|"
+    r"❌|⛔"
 )
 
 _WEB_ONLY_TOOLS = frozenset({"fetch_url", "web_fetch", "web_search"})
@@ -63,6 +59,7 @@ class StepBudgetPolicy:
     enabled: bool = True
     extend_by: int = DEFAULT_EXTEND_BY
     max_extensions: int = DEFAULT_MAX_EXTENSIONS
+    user_max_extensions: int = DEFAULT_USER_MAX_EXTENSIONS
     hard_cap: int = DEFAULT_HARD_CAP  # absolute max_steps after extensions
     lookback: int = DEFAULT_LOOKBACK
 
@@ -85,6 +82,13 @@ class StepBudgetPolicy:
                     or DEFAULT_MAX_EXTENSIONS
                 ),
             ),
+            user_max_extensions=max(
+                0,
+                int(
+                    getattr(cfg, "max_steps_user_max_extensions", DEFAULT_USER_MAX_EXTENSIONS)
+                    or DEFAULT_USER_MAX_EXTENSIONS
+                ),
+            ),
             hard_cap=max(0, int(getattr(cfg, "max_steps_hard_cap", DEFAULT_HARD_CAP) or 0)),
             lookback=max(
                 3, int(getattr(cfg, "max_steps_lookback", DEFAULT_LOOKBACK) or DEFAULT_LOOKBACK)
@@ -102,6 +106,8 @@ class StepBudgetDecision:
     extra_steps: int = 0
     new_max_steps: int = 0
     extensions_used: int = 0
+    user_extensions_used: int = 0
+    from_user: bool = False
     signals: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -158,12 +164,12 @@ def _signatures_loop(sigs: list[str]) -> bool:
 
 
 def _looks_like_error(text: str) -> bool:
-    low = (text or "").strip().lower()
-    if not low:
+    raw = (text or "").strip()
+    if not raw:
         return True
-    if low.startswith("❌") or low.startswith("⛔"):
+    if raw.startswith("❌") or raw.startswith("⛔"):
         return True
-    return any(m in low for m in _ERROR_MARKERS)
+    return bool(_ERROR_TOKEN_RE.search(raw))
 
 
 def _looks_like_progress(text: str) -> bool:
@@ -552,6 +558,149 @@ def apply_decision_to_state(
     }
 
 
+def _is_terminal_final(text: str | None) -> bool:
+    from core.presenters.final_content import is_aborted_final_response, is_usable_user_final
+
+    raw = (text or "").strip()
+    if not raw:
+        return False
+    if is_aborted_final_response(raw):
+        return True
+    return is_usable_user_final(raw)
+
+
+def _clear_dump_final(out: dict[str, Any]) -> dict[str, Any]:
+    from core.presenters.final_content import is_usable_user_final
+
+    if is_usable_user_final(str(out.get("final_response") or "")):
+        return out
+    out["is_final"] = False
+    out["final_response"] = ""
+    out["needs_refinement"] = False
+    return out
+
+
+def _append_continue_nudge(
+    out: dict[str, Any],
+    state: dict[str, Any],
+    *,
+    extra: int,
+    new_max: int,
+) -> None:
+    messages = out.get("messages")
+    if not isinstance(messages, list):
+        raw = state.get("messages") or []
+        messages = list(raw) if isinstance(raw, list) else []
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                f"[Holix] Step budget extended by {extra} (now max {new_max}). "
+                "Continue the task. Do not dump source code or diffs as the final answer; "
+                "write a short status instead."
+            ),
+        }
+    )
+    out["messages"] = messages
+
+
+def _emit_extended(
+    agent: Any | None,
+    *,
+    conversation_id: str,
+    max_steps: int,
+    previous_max_steps: int,
+    extra_steps: int,
+    extensions: int,
+    reason: str,
+) -> None:
+    if agent is None or not hasattr(agent, "emit"):
+        return
+    try:
+        from core.agent_events import MaxStepsExtendedEvent, ThinkingEvent
+
+        agent.emit(
+            MaxStepsExtendedEvent(
+                max_steps=max_steps,
+                previous_max_steps=previous_max_steps,
+                extra_steps=extra_steps,
+                extensions=extensions,
+                reason=reason,
+                conversation_id=conversation_id,
+            )
+        )
+        agent.emit(
+            ThinkingEvent(
+                message=(
+                    f"Step budget extended by {extra_steps} (now max {max_steps}): still working"
+                ),
+                conversation_id=conversation_id,
+            )
+        )
+    except Exception:
+        logger.debug("failed to emit step budget events", exc_info=True)
+
+
+def apply_extension(
+    state: dict[str, Any],
+    result: dict[str, Any],
+    decision: StepBudgetDecision,
+    *,
+    agent: Any | None = None,
+    previous_max_steps: int,
+) -> dict[str, Any]:
+    """Apply an auto or user extension to graph/loop state."""
+    out = dict(result)
+    out["max_steps"] = int(decision.new_max_steps)
+    if decision.from_user:
+        out["step_budget_user_extensions"] = int(decision.user_extensions_used)
+    else:
+        out["step_budget_extensions"] = int(decision.extensions_used)
+    base_max = int(state.get("base_max_steps") or state.get("max_steps") or previous_max_steps)
+    if "base_max_steps" not in state and "base_max_steps" not in out:
+        out["base_max_steps"] = base_max
+    from core.presenters.final_content import is_usable_user_final
+
+    raw_final = str(out.get("final_response") or "").strip()
+    dump_final = bool(raw_final) and not is_usable_user_final(raw_final)
+    _clear_dump_final(out)
+    if dump_final or decision.from_user:
+        _append_continue_nudge(
+            out,
+            state,
+            extra=decision.extra_steps,
+            new_max=decision.new_max_steps,
+        )
+    _emit_extended(
+        agent,
+        conversation_id=str(state.get("conversation_id") or result.get("conversation_id") or ""),
+        max_steps=decision.new_max_steps,
+        previous_max_steps=previous_max_steps,
+        extra_steps=decision.extra_steps,
+        extensions=(
+            decision.user_extensions_used if decision.from_user else decision.extensions_used
+        ),
+        reason=decision.reason,
+    )
+    return out
+
+
+def abort_at_step_limit(
+    result: dict[str, Any],
+    *,
+    max_steps: int,
+    locale: str = "ru",
+) -> dict[str, Any]:
+    from core.presenters.final_content import step_limit_aborted_message
+
+    out = dict(result)
+    out["is_final"] = True
+    out["needs_refinement"] = False
+    out["tool_calls"] = []
+    out["final_response"] = step_limit_aborted_message(max_steps, locale=locale)
+    return out
+
+
 def maybe_extend_for_graph_result(
     state: dict[str, Any],
     result: dict[str, Any],
@@ -559,14 +708,14 @@ def maybe_extend_for_graph_result(
     agent: Any | None = None,
     task: str = "",
 ) -> dict[str, Any]:
-    """If result is at max_steps with pending tools, maybe bump max_steps on result."""
+    """If result is at max_steps, maybe bump max_steps when work is still healthy."""
     step_count = int(result.get("step_count", state.get("step_count", 0)) or 0)
     max_steps = int(result.get("max_steps", state.get("max_steps", 0)) or 0)
     if max_steps <= 0:
         max_steps = int(state.get("max_steps", 0) or 0)
     if step_count < max_steps:
         return result
-    if result.get("is_final"):
+    if result.get("is_final") and _is_terminal_final(str(result.get("final_response") or "")):
         return result
 
     pending = result.get("tool_calls") or state.get("tool_calls") or []
@@ -605,35 +754,101 @@ def maybe_extend_for_graph_result(
         decision.extensions_used,
         decision.reason,
     )
-    out = dict(result)
-    out["max_steps"] = decision.new_max_steps
-    out["step_budget_extensions"] = decision.extensions_used
-    if "base_max_steps" not in state and "base_max_steps" not in out:
-        out["base_max_steps"] = base_max
-    # Notify UIs
-    if agent is not None and hasattr(agent, "emit"):
-        try:
-            from core.agent_events import MaxStepsExtendedEvent, ThinkingEvent
+    return apply_extension(
+        state,
+        result,
+        decision,
+        agent=agent,
+        previous_max_steps=max_steps,
+    )
 
-            agent.emit(
-                MaxStepsExtendedEvent(
-                    max_steps=decision.new_max_steps,
-                    previous_max_steps=max_steps,
-                    extra_steps=decision.extra_steps,
-                    extensions=decision.extensions_used,
-                    reason=decision.reason,
-                    conversation_id=str(state.get("conversation_id") or ""),
-                )
-            )
-            agent.emit(
-                ThinkingEvent(
-                    message=(
-                        f"Step budget extended by {decision.extra_steps} "
-                        f"(now max {decision.new_max_steps}): still working"
-                    ),
-                    conversation_id=str(state.get("conversation_id") or ""),
-                )
-            )
-        except Exception:
-            logger.debug("failed to emit step budget events", exc_info=True)
-    return out
+
+async def maybe_extend_or_ask(
+    state: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    agent: Any | None = None,
+    task: str = "",
+) -> dict[str, Any]:
+    """Auto-extend when healthy; otherwise pause the main agent for Continue/Abort."""
+    extended = maybe_extend_for_graph_result(state, result, agent=agent, task=task)
+    prev_max = int(result.get("max_steps", state.get("max_steps", 0)) or 0)
+    new_max = int(extended.get("max_steps", prev_max) or 0)
+    if new_max > prev_max:
+        return extended
+
+    step_count = int(extended.get("step_count", state.get("step_count", 0)) or 0)
+    max_steps = int(extended.get("max_steps", state.get("max_steps", 0)) or 0)
+    if max_steps <= 0 or step_count < max_steps:
+        return extended
+    if extended.get("is_final") and _is_terminal_final(str(extended.get("final_response") or "")):
+        return extended
+
+    from core.runtime.step_budget_pause import ask_continue_or_abort, can_ask_user
+
+    policy = policy_from_agent(agent)
+    user_used = int(
+        extended.get(
+            "step_budget_user_extensions",
+            state.get("step_budget_user_extensions", 0),
+        )
+        or 0
+    )
+    conversation_id = str(extended.get("conversation_id") or state.get("conversation_id") or "")
+    locale = _locale_from_agent(agent)
+    if not can_ask_user(agent, conversation_id=conversation_id, user_used=user_used, policy=policy):
+        return abort_at_step_limit(extended, max_steps=max_steps, locale=locale)
+
+    choice = await ask_continue_or_abort(
+        agent=agent,
+        conversation_id=conversation_id,
+        step_count=step_count,
+        max_steps=max_steps,
+        extra_steps=policy.extend_by,
+        user_used=user_used,
+        user_max=policy.user_max_extensions,
+        reason=str(extended.get("step_budget_stop_reason") or ""),
+        locale=locale,
+    )
+    if choice != "continue":
+        return abort_at_step_limit(extended, max_steps=max_steps, locale=locale)
+
+    extra = policy.extend_by
+    decision = StepBudgetDecision(
+        extend=True,
+        reason=f"user continue; +{extra} steps ({step_count}/{max_steps} → max {max_steps + extra})",
+        status="working",
+        extra_steps=extra,
+        new_max_steps=max_steps + extra,
+        extensions_used=int(
+            extended.get("step_budget_extensions", state.get("step_budget_extensions", 0)) or 0
+        ),
+        user_extensions_used=user_used + 1,
+        from_user=True,
+    )
+    logger.info(
+        "step budget user-continue: %s → %s (user_ext=%s)",
+        max_steps,
+        decision.new_max_steps,
+        decision.user_extensions_used,
+    )
+    return apply_extension(
+        state,
+        extended,
+        decision,
+        agent=agent,
+        previous_max_steps=max_steps,
+    )
+
+
+def _locale_from_agent(agent: Any | None) -> str:
+    cfg = getattr(agent, "config", None) if agent is not None else None
+    profile = getattr(cfg, "profile_name", None) if cfg is not None else None
+    if not profile:
+        return "ru"
+    try:
+        from core.i18n.locale import LocaleStore
+
+        return str(LocaleStore(profile).get() or "ru")
+    except Exception:
+        return "ru"

--- a/core/runtime/step_budget_pause.py
+++ b/core/runtime/step_budget_pause.py
@@ -1,0 +1,242 @@
+"""Interactive Continue/Abort pause when the main-agent step budget is exhausted.
+
+Sub-agents and unattended runs skip this and stop with a step-limit message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CONTINUE = "continue"
+ABORT = "abort"
+
+_pending: dict[str, asyncio.Future[str]] = {}
+_payloads: dict[str, dict[str, Any]] = {}
+
+
+def can_ask_user(
+    agent: Any | None,
+    *,
+    conversation_id: str = "",
+    user_used: int = 0,
+    policy: Any | None = None,
+) -> bool:
+    """True when the main interactive agent can pause for Continue/Abort."""
+    if agent is None:
+        return False
+    if policy is not None:
+        user_max = int(getattr(policy, "user_max_extensions", 0) or 0)
+        if user_max <= 0 or int(user_used) >= user_max:
+            return False
+    cfg = getattr(agent, "config", None)
+    if cfg is not None and bool(getattr(cfg, "non_interactive", False)):
+        return False
+    try:
+        from core.di.runtime_config import unattended_requested
+
+        if unattended_requested():
+            return False
+    except Exception:
+        pass
+    prompt = getattr(agent, "subagent_system_prompt", None)
+    if isinstance(prompt, str) and prompt.strip():
+        return False
+    cid = str(conversation_id or "")
+    if cid.startswith("subagent:"):
+        return False
+    try:
+        from core.tools.execution_context import get_subagent_name
+
+        if get_subagent_name():
+            return False
+    except Exception:
+        pass
+    return True
+
+
+def snapshot_pending() -> list[dict[str, Any]]:
+    """Still-waiting Continue/Abort prompts (Studio WS reconnect)."""
+    out: list[dict[str, Any]] = []
+    for request_id, future in list(_pending.items()):
+        if future.done():
+            continue
+        payload = dict(_payloads.get(request_id) or {})
+        payload.setdefault("request_id", request_id)
+        out.append(payload)
+    return out
+
+
+def pending_ids() -> list[str]:
+    return [rid for rid, fut in _pending.items() if not fut.done()]
+
+
+def resolve_step_budget(request_id: str, choice: str) -> bool:
+    """Resolve a pending Continue/Abort prompt. Returns True if a waiter was woken."""
+    rid = str(request_id or "").strip()
+    if not rid:
+        return resolve_step_budget_latest(choice)
+    future = _pending.get(rid)
+    if future is None or future.done():
+        return False
+    normalized = _normalize_choice(choice)
+    try:
+        future.set_result(normalized)
+    except Exception:
+        return False
+    logger.info("step budget resolved %s → %s", rid, normalized)
+    return True
+
+
+def resolve_step_budget_latest(choice: str) -> bool:
+    if not _pending:
+        return False
+    return resolve_step_budget(list(_pending.keys())[-1], choice)
+
+
+def abort_all_pending_step_budget(*, conversation_id: str | None = None) -> int:
+    """Wake waiters with abort (Stop / session teardown)."""
+    woken = 0
+    cid = str(conversation_id or "").strip()
+    for request_id, payload in list(_payloads.items()):
+        if cid and str(payload.get("conversation_id") or "") not in {cid, ""}:
+            continue
+        if resolve_step_budget(request_id, ABORT):
+            woken += 1
+    return woken
+
+
+def _normalize_choice(raw: str) -> str:
+    text = str(raw or "").strip().lower()
+    if text in {
+        CONTINUE,
+        "c",
+        "1",
+        "yes",
+        "y",
+        "ok",
+        "продолжить",
+        "продолжай",
+        "да",
+    }:
+        return CONTINUE
+    return ABORT
+
+
+async def ask_continue_or_abort(
+    *,
+    agent: Any | None,
+    conversation_id: str,
+    step_count: int,
+    max_steps: int,
+    extra_steps: int,
+    user_used: int,
+    user_max: int,
+    reason: str = "",
+    locale: str = "en",
+) -> str:
+    """Emit StepBudgetChoiceEvent and wait until the user picks Continue or Abort."""
+    from core.agent_events import StepBudgetChoiceEvent, StepBudgetResolvedEvent
+    from core.presenters.final_content import step_limit_reached_message
+
+    request_id = f"sb_{uuid.uuid4().hex[:12]}"
+    loc = (locale or "en").strip().lower()[:2]
+    remaining = max(0, int(user_max) - int(user_used))
+    message = step_limit_reached_message(
+        int(max_steps),
+        step_count=int(step_count),
+        extra_steps=int(extra_steps),
+        locale=loc,
+    )
+    if loc == "ru":
+        continue_label = "Продолжить"
+        abort_label = "Прервать"
+        if remaining:
+            message += f" Осталось продлений: {remaining}/{user_max}."
+    else:
+        continue_label = "Continue"
+        abort_label = "Abort"
+        if remaining:
+            message += f" Continues remaining: {remaining}/{user_max}."
+    if reason:
+        message += f"\n({reason})"
+
+    choices = [
+        {"code": CONTINUE, "label": continue_label},
+        {"code": ABORT, "label": abort_label},
+    ]
+    payload = {
+        "request_id": request_id,
+        "conversation_id": conversation_id,
+        "step_count": int(step_count),
+        "max_steps": int(max_steps),
+        "extra_steps": int(extra_steps),
+        "user_extensions_used": int(user_used),
+        "user_extensions_max": int(user_max),
+        "reason": reason,
+        "message": message,
+        "choices": choices,
+    }
+
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[str] = loop.create_future()
+    _pending[request_id] = future
+    _payloads[request_id] = payload
+
+    if agent is not None and hasattr(agent, "emit"):
+        try:
+            agent.emit(
+                StepBudgetChoiceEvent(
+                    request_id=request_id,
+                    step_count=int(step_count),
+                    max_steps=int(max_steps),
+                    extra_steps=int(extra_steps),
+                    user_extensions_used=int(user_used),
+                    user_extensions_max=int(user_max),
+                    reason=reason,
+                    message=message,
+                    choices=choices,
+                    conversation_id=conversation_id,
+                )
+            )
+        except Exception:
+            logger.debug("failed to emit StepBudgetChoiceEvent", exc_info=True)
+
+    logger.info(
+        "step budget waiting for user choice id=%s steps=%s/%s extra=+%s",
+        request_id,
+        step_count,
+        max_steps,
+        extra_steps,
+    )
+    try:
+        return await future
+    except asyncio.CancelledError:
+        return ABORT
+    finally:
+        _pending.pop(request_id, None)
+        _payloads.pop(request_id, None)
+        if agent is not None and hasattr(agent, "emit"):
+            try:
+                agent.emit(
+                    StepBudgetResolvedEvent(
+                        request_id=request_id,
+                        choice=_choice_if_done(future),
+                        conversation_id=conversation_id,
+                    )
+                )
+            except Exception:
+                logger.debug("failed to emit StepBudgetResolvedEvent", exc_info=True)
+
+
+def _choice_if_done(future: asyncio.Future[str]) -> str:
+    if future.done() and not future.cancelled():
+        try:
+            return str(future.result() or ABORT)
+        except Exception:
+            return ABORT
+    return ABORT

--- a/core/runtime/step_budget_pause.py
+++ b/core/runtime/step_budget_pause.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import uuid
 from typing import Any
 
@@ -28,6 +29,9 @@ def can_ask_user(
 ) -> bool:
     """True when the main interactive agent can pause for Continue/Abort."""
     if agent is None:
+        return False
+    # Pytest has no Continue/Abort UI; waiting forever hangs CI.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
         return False
     if policy is not None:
         user_max = int(getattr(policy, "user_max_extensions", 0) or 0)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Changed
+
+- **Step budget** — auto-extend no longer treats `TimeoutError:` / `error` inside
+  source dumps as a hung tool. When auto-extend cannot continue, the **main**
+  agent pauses with Continue (+`max_steps_extend_by`) / Abort instead of
+  dumping a diff as the final message. User continues are capped by
+  `HOLIX_MAX_STEPS_USER_MAX_EXTENSIONS` (default 10). TUI, Telegram, and MAX
+  show the two-button prompt. Sub-agents still auto-extend, then fail with a
+  step-limit error (no dump).
+
+### Tests
+
+- Error-token health check, dump-as-final auto-extend, Continue/Abort pause.
+
 ## 1.1.10 — 2026-09-04
 
 ### Added

--- a/docs/en/EXECUTION_MODES.md
+++ b/docs/en/EXECUTION_MODES.md
@@ -350,7 +350,10 @@ When the agent hits `max_steps`, Holix does not always stop immediately:
 
 1. **Health check** — recent tools, loops, errors, pending work.
 2. **Working + relevant** → grant extra steps (`max_steps_extend_by`, capped).
-3. **Hung / pure error thrash** → stop (or subagent supervisor guidance).
+3. **Hung / extension cap** — the **main** agent pauses with **Continue / Abort**
+   (TUI modal, Telegram/MAX inline buttons). Continue adds `max_steps_extend_by`
+   steps. Sub-agents do not prompt; they fail with a step-limit message.
+   A source dump or diff is never used as the last assistant message.
 
 Implement/fix tasks do **not** get extra steps for a read-only file walk or a red pytest with no `write_file` / `apply_patch` / `patch_file`. A run whose recent tools are only `fetch_url` / `web_search` is also **not** extended (site crawls must stop). Review/analyze must not pytest-loop unless you asked to run tests. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md#agent-loops).
 
@@ -358,8 +361,9 @@ Implement/fix tasks do **not** get extra steps for a read-only file walk or a re
 |----------|---------|--------|
 | `max_steps` | `90` (runtime; profile may override) | Base ReAct/graph step budget |
 | `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Allow auto-extension |
-| `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Steps added per extension |
-| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `10` | Max extensions per run |
+| `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Steps added per auto-extend or Continue |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `10` | Max automatic extensions per run |
+| `HOLIX_MAX_STEPS_USER_MAX_EXTENSIONS` | `10` | Max Continue clicks after auto-extend stops (`0` = no prompt) |
 | `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Absolute cap (`0` = base + extend×N) |
 
 ---

--- a/docs/ru/EXECUTION_MODES.md
+++ b/docs/ru/EXECUTION_MODES.md
@@ -354,7 +354,10 @@ Holix использует цикл в стиле **Reflexion** (не Tree/Graph
 
 1. Проверка прогресса (tools, loop, ошибки).
 2. **Работает + релевантно** → +шаги (`max_steps_extend_by`).
-3. **Завис / thrash** → стоп (или guidance supervisor у субагентов).
+3. **Завис / лимит продлений** — **основной** агент ставит паузу **Продолжить / Прервать**
+   (модалка TUI, кнопки в Telegram/MAX). «Продолжить» добавляет `max_steps_extend_by`
+   шагов. Субагенты не спрашивают: падают с сообщением о лимите.
+   Diff или дамп исходника не становятся последним ответом.
 
 Задачи implement/fix **не** получают лишние шаги за одно чтение файлов или красный pytest без `write_file` / `apply_patch` / `patch_file`. Если недавние tools только `fetch_url` / `web_search`, бюджет тоже **не** растёт (обход сайта должен остановиться). Review/analyze не должен крутить pytest, пока вы сами не попросили тесты. [TROUBLESHOOTING.md](TROUBLESHOOTING.md#agent-loops).
 
@@ -362,8 +365,9 @@ Holix использует цикл в стиле **Reflexion** (не Tree/Graph
 |------------|--------------|--------|
 | `max_steps` | `90` (runtime; профиль может переопределить) | Базовый бюджет |
 | `HOLIX_MAX_STEPS_EXTEND_ENABLED` | `true` | Авто-расширение |
-| `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Шагов за раз |
-| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `10` | Сколько раз |
+| `HOLIX_MAX_STEPS_EXTEND_BY` | `30` | Шагов за автопродление или «Продолжить» |
+| `HOLIX_MAX_STEPS_MAX_EXTENSIONS` | `10` | Сколько автопродлений за запуск |
+| `HOLIX_MAX_STEPS_USER_MAX_EXTENSIONS` | `10` | Сколько раз «Продолжить» после автопродления (`0` = без меню) |
 | `HOLIX_MAX_STEPS_HARD_CAP` | `0` | Жёсткий потолок (`0` = base+extend×N) |
 
 ---

--- a/integrations/max/approvals.py
+++ b/integrations/max/approvals.py
@@ -6,13 +6,19 @@ import asyncio
 import json
 from typing import Any
 
+from core.agent_events import StepBudgetChoiceEvent
 from core.plan_review.review_events import PlanReviewRequestEvent
 from core.plan_review.review_guard import PlanReviewChoice, get_plan_review_guard
+from core.runtime.step_budget_pause import resolve_step_budget
 from core.security.confirmation import ConfirmationChoice, get_action_guard
 from core.security.confirmation_events import ConfirmationRequestEvent
 
 from integrations.max.client import MaxClient
-from integrations.max.keyboards import confirmation_keyboard, plan_review_keyboard
+from integrations.max.keyboards import (
+    confirmation_keyboard,
+    plan_review_keyboard,
+    step_budget_keyboard,
+)
 from integrations.max.markdown import plain_to_max_html
 from integrations.max.models import message_id_from_response, reply_kwargs_for_session
 from integrations.messenger.callback_tokens import (
@@ -34,6 +40,7 @@ class MaxApprovals:
         self._session = session
         self._pending_confirm_id: str | None = None
         self._pending_review_id: str | None = None
+        self._pending_step_budget_id: str | None = None
 
     async def on_confirmation_request(self, event: ConfirmationRequestEvent) -> None:
         self._pending_confirm_id = event.confirmation_id
@@ -72,6 +79,54 @@ class MaxApprovals:
             ids = self._session.pending_confirmation_message_ids
         if mid:
             ids[event.confirmation_id] = mid
+
+    async def on_step_budget_choice(self, event: StepBudgetChoiceEvent) -> None:
+        self._pending_step_budget_id = event.request_id
+        token = _register_callback_token(
+            self._session.approval_callback_tokens,
+            event.request_id,
+        )
+        text = event.message or "Достигнут лимит шагов."
+        if len(text) > 3500:
+            text = text[:3500] + "…"
+        extra = int(event.extra_steps or 30)
+        payload = await self._client.send_message(
+            plain_to_max_html(text),
+            fmt="html",
+            attachments=[step_budget_keyboard(token, extra)],
+            **reply_kwargs_for_session(
+                user_id=self._session.user_id,
+                reply_user_id=self._session.reply_user_id,
+                reply_chat_id=self._session.reply_chat_id,
+                chat_type=self._session.chat_type,
+            ),
+        )
+        mid = message_id_from_response(payload)
+        ids = getattr(self._session, "pending_step_budget_message_ids", None)
+        if ids is None:
+            self._session.pending_step_budget_message_ids = {}
+            ids = self._session.pending_step_budget_message_ids
+        if mid:
+            ids[event.request_id] = mid
+
+    def resolve_step_budget_callback(self, request_id: str, code: str) -> bool:
+        choice = "continue" if code in {"c", "1", "continue"} else "abort"
+        full_id = _lookup_callback_token(
+            self._session.approval_callback_tokens,
+            request_id,
+        )
+        if resolve_step_budget(full_id, choice):
+            self._forget_step_budget(full_id)
+            return True
+        if resolve_step_budget(request_id, choice):
+            self._forget_step_budget(full_id)
+            return True
+        return False
+
+    def _forget_step_budget(self, request_id: str) -> None:
+        drop_callback_token(self._session.approval_callback_tokens, request_id)
+        if self._pending_step_budget_id == request_id:
+            self._pending_step_budget_id = None
 
     async def on_plan_review_request(self, event: PlanReviewRequestEvent) -> None:
         await self.dismiss_plan_review_ui()

--- a/integrations/max/bot.py
+++ b/integrations/max/bot.py
@@ -825,6 +825,12 @@ class HelixMaxBot:
                 notification = result.get("message") or ("✓" if result.get("ok") else "?")
             else:
                 notification = "?"
+        elif payload.startswith("sb:"):
+            parts = payload.split(":", 2)
+            if len(parts) == 3 and approvals.resolve_step_budget_callback(parts[1], parts[2]):
+                notification = "✓"
+            else:
+                notification = "?"
         elif payload.startswith("cfm:"):
             parts = payload.split(":", 2)
             if len(parts) == 3 and approvals.resolve_confirmation_callback(parts[1], parts[2]):

--- a/integrations/max/event_handler.py
+++ b/integrations/max/event_handler.py
@@ -18,6 +18,7 @@ from core.agent_events import (
     FinalResponseEvent,
     PlanCompletedEvent,
     PlanStepCompletedEvent,
+    StepBudgetChoiceEvent,
     SubAgentTimeoutExtendedEvent,
     SubAgentWaveCompletedEvent,
     SubAgentWaveStartedEvent,
@@ -204,6 +205,14 @@ class MaxEventHandler:
                 buf.set_thinking(None)
                 self._presenter.schedule_edit(force=True)
                 self._presenter.enqueue_outbound(self._approvals.on_confirmation_request(event))
+
+            elif isinstance(event, StepBudgetChoiceEvent):
+                buf.set_thinking(None)
+                notice = (event.message or "").strip()
+                if notice:
+                    buf.set_answer(notice)
+                self._presenter.schedule_edit(force=True)
+                self._presenter.enqueue_outbound(self._approvals.on_step_budget_choice(event))
 
             elif isinstance(event, SubAgentWaveStartedEvent):
                 buf.set_thinking(None)

--- a/integrations/max/interactive.py
+++ b/integrations/max/interactive.py
@@ -1262,6 +1262,8 @@ class MaxInteractive:
 async def dispatch_callback(host: MaxHost, payload: str) -> str:
     if payload.startswith("cfm:"):
         return ""
+    if payload.startswith("sb:"):
+        return ""
     if payload.startswith("plan:"):
         return ""
     parsed = parse_callback(payload)

--- a/integrations/max/keyboards.py
+++ b/integrations/max/keyboards.py
@@ -420,6 +420,19 @@ def status_menu_keyboard(locale: str | None = None, *, is_admin: bool = True) ->
     return inline_keyboard(rows)
 
 
+def step_budget_keyboard(request_id: str, extra_steps: int = 30) -> dict[str, Any]:
+    rid = request_id
+    extra = int(extra_steps or 30)
+    return inline_keyboard(
+        [
+            [
+                _callback_btn(f"Продолжить (+{extra})", f"sb:{rid}:c"),
+                _callback_btn("Прервать", f"sb:{rid}:a"),
+            ],
+        ]
+    )
+
+
 def confirmation_keyboard(confirmation_id: str) -> dict[str, Any]:
     cid = confirmation_id
     return inline_keyboard(

--- a/integrations/telegram/approvals.py
+++ b/integrations/telegram/approvals.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from core.agent_events import StepBudgetChoiceEvent
 from core.plan_review.review_events import PlanReviewRequestEvent
 from core.plan_review.review_guard import PlanReviewChoice, get_plan_review_guard
+from core.runtime.step_budget_pause import resolve_step_budget
 from core.security.confirmation import ConfirmationChoice, get_action_guard
 from core.security.confirmation_events import ConfirmationRequestEvent
 
@@ -40,6 +42,7 @@ class TelegramApprovals:
         self._session = session
         self._pending_confirm_id: str | None = None
         self._pending_review_id: str | None = None
+        self._pending_step_budget_id: str | None = None
 
     async def on_confirmation_request(self, event: ConfirmationRequestEvent) -> None:
         # Keep sibling prompts (parallel sub-agents). Dismissing here left
@@ -108,6 +111,73 @@ class TelegramApprovals:
             self._session.pending_confirmation_message_ids = {}
             ids = self._session.pending_confirmation_message_ids
         ids[event.confirmation_id] = sent.message_id
+
+    async def on_step_budget_choice(self, event: StepBudgetChoiceEvent) -> None:
+        self._pending_step_budget_id = event.request_id
+        token = _register_callback_token(
+            self._session.approval_callback_tokens,
+            event.request_id,
+        )
+        text = event.message or "Достигнут лимит шагов."
+        if len(text) > 3500:
+            text = text[:3500] + "…"
+        from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+        extra = int(event.extra_steps or 30)
+        kb = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text=f"Продолжить (+{extra})",
+                        callback_data=_callback_data("sb", token, "c"),
+                    ),
+                    InlineKeyboardButton(
+                        text="Прервать",
+                        callback_data=_callback_data("sb", token, "a"),
+                    ),
+                ],
+            ]
+        )
+        sent = await self._bot.send_message(
+            self._session.chat_id,
+            escape_html(text),
+            parse_mode="HTML",
+            reply_markup=kb,
+        )
+        ids = getattr(self._session, "pending_step_budget_message_ids", None)
+        if ids is None:
+            self._session.pending_step_budget_message_ids = {}
+            ids = self._session.pending_step_budget_message_ids
+        ids[event.request_id] = sent.message_id
+
+    def resolve_step_budget_callback(self, request_id: str, code: str) -> bool:
+        choice = "continue" if code in {"c", "1", "continue"} else "abort"
+        full_id = _lookup_callback_token(
+            self._session.approval_callback_tokens,
+            request_id,
+        )
+        if resolve_step_budget(full_id, choice):
+            self._forget_step_budget(full_id)
+            return True
+        if resolve_step_budget(request_id, choice):
+            self._forget_step_budget(full_id)
+            return True
+        return False
+
+    def _forget_step_budget(self, request_id: str) -> None:
+        drop_callback_token(self._session.approval_callback_tokens, request_id)
+        if self._pending_step_budget_id == request_id:
+            self._pending_step_budget_id = None
+        ids = getattr(self._session, "pending_step_budget_message_ids", None)
+        mid = None
+        if isinstance(ids, dict):
+            mid = ids.pop(request_id, None)
+        if mid is not None:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._delete_message_safe(int(mid)))
+            except RuntimeError:
+                pass
 
     async def on_plan_review_request(self, event: PlanReviewRequestEvent) -> None:
         await self.dismiss_plan_review_ui()

--- a/integrations/telegram/bot.py
+++ b/integrations/telegram/bot.py
@@ -935,6 +935,28 @@ class HolixTelegramBot:
             )
             await query.answer(result.get("message") or "OK", show_alert=not result.get("ok"))
 
+        @dp.callback_query(F.data.startswith("sb:"))
+        async def on_step_budget_cb(query: CallbackQuery) -> None:
+            if query.from_user is None or not query.data:
+                return
+            if not self._allowed(query.from_user.id):
+                await query.answer("Access pending approval.", show_alert=True)
+                return
+            parts = query.data.split(":")
+            if len(parts) != 3:
+                await query.answer("Invalid.", show_alert=True)
+                return
+            _, rid, code = parts
+            session = await self._get_session(query.message.chat.id, query.from_user.id, bot=bot)
+            approvals = TelegramApprovals(bot, session)
+            if approvals.resolve_step_budget_callback(rid, code):
+                await query.answer("OK")
+            else:
+                await query.answer(
+                    "Could not apply. Tap the latest step-limit message.",
+                    show_alert=True,
+                )
+
         @dp.callback_query(F.data.startswith("cfm:"))
         async def on_confirm_cb(query: CallbackQuery) -> None:
             if query.from_user is None or not query.data:

--- a/integrations/telegram/event_handler.py
+++ b/integrations/telegram/event_handler.py
@@ -19,6 +19,7 @@ from core.agent_events import (
     FinalResponseEvent,
     PlanCompletedEvent,
     PlanStepCompletedEvent,
+    StepBudgetChoiceEvent,
     SubAgentTimeoutExtendedEvent,
     ThinkingEvent,
     TodoListUpdatedEvent,
@@ -188,6 +189,14 @@ class TelegramEventHandler:
                 # inline buttons) is sent via approvals below.
                 self._presenter.schedule_edit(force=True)
                 asyncio.create_task(self._approvals.on_confirmation_request(event))
+
+            elif isinstance(event, StepBudgetChoiceEvent):
+                buf.set_thinking(None)
+                notice = (event.message or "").strip()
+                if notice:
+                    buf.set_answer(notice)
+                self._presenter.schedule_edit(force=True)
+                asyncio.create_task(self._approvals.on_step_budget_choice(event))
 
             elif isinstance(event, SubAgentTimeoutExtendedEvent):
                 name = event.name or "sub-agent"

--- a/tests/live_llm/harness.py
+++ b/tests/live_llm/harness.py
@@ -152,6 +152,7 @@ class LiveHarness:
             self_extensions_enabled=False,
             max_steps=max_steps,
             max_steps_extend_enabled=False,
+            max_steps_user_max_extensions=0,
             llm_step_timeout=600.0,
             workspace_root=str(self.workspace),
             workspace_jail_enabled=True,

--- a/tests/test_step_budget.py
+++ b/tests/test_step_budget.py
@@ -342,7 +342,12 @@ def test_graph_result_extends_max_steps() -> None:
 
 def test_graph_result_no_extend_when_final() -> None:
     state = {"max_steps": 15, "user_input": "hi"}
-    result = {"step_count": 15, "is_final": True, "tool_calls": []}
+    result = {
+        "step_count": 15,
+        "is_final": True,
+        "tool_calls": [],
+        "final_response": "Here is the finished report with the API endpoints.",
+    }
     out = maybe_extend_for_graph_result(state, result, agent=None)
     assert (
         out is result
@@ -351,3 +356,95 @@ def test_graph_result_no_extend_when_final() -> None:
         or out.get("step_count") == 15
     )
     assert out.get("max_steps", 15) == 15 or "step_budget_extensions" not in out
+
+
+def test_timeout_error_in_source_dump_is_not_tool_error() -> None:
+    from core.runtime.step_budget import _looks_like_error
+
+    dump = (
+        "Content of notifications.py:\n"
+        "try:\n"
+        "    await wait()\n"
+        "except TimeoutError:\n"
+        "    raise\n"
+        "except ValueError:\n"
+        "    return None\n"
+    )
+    assert _looks_like_error(dump) is False
+    assert _looks_like_error("Error: permission denied") is True
+    assert _looks_like_error("Traceback (most recent call last):\n  File") is True
+
+
+def test_source_dump_with_timeout_error_still_extends() -> None:
+    log = [
+        {
+            "name": "read_file",
+            "arguments": '{"path": "a.py"}',
+            "result": "except TimeoutError:\n    pass\n" + ("x = 1\n" * 20),
+        },
+        {
+            "name": "write_file",
+            "arguments": '{"path": "a.py"}',
+            "result": "OK: wrote a.py successfully with login handlers",
+        },
+        {
+            "name": "read_file",
+            "arguments": '{"path": "b.py"}',
+            "result": "except TimeoutError:\n    raise\n" + ("y = 2\n" * 20),
+        },
+    ]
+    d = evaluate_step_budget(
+        step_count=90,
+        max_steps=90,
+        pending_tool_calls=[{"id": "x", "function": {"name": "write_file"}}],
+        tool_calls_log=log,
+        task="implement notifications retry",
+        policy=StepBudgetPolicy(extend_by=30, max_extensions=10),
+        base_max_steps=90,
+    )
+    assert d.extend
+    assert d.status == "working"
+
+
+def test_graph_result_extends_dump_final() -> None:
+    state = {
+        "user_input": "Build a REST API",
+        "max_steps": 15,
+        "base_max_steps": 15,
+        "step_budget_extensions": 0,
+        "conversation_id": "t1",
+        "messages": [
+            {"role": "user", "content": "Build a REST API"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "1",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": '{"path":"api.py"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "1",
+                "content": "OK: created api.py with endpoints successfully",
+            },
+        ],
+    }
+    dump = "diff --git a/api.py b/api.py\n--- a/api.py\n+++ b/api.py\n@@ -1 +1 @@\n" + (
+        "+def handler():\n" * 20
+    )
+    result = {
+        "step_count": 15,
+        "tool_calls": [{"id": "2", "function": {"name": "read_file"}}],
+        "is_final": True,
+        "final_response": dump,
+        "messages": state["messages"],
+    }
+    out = maybe_extend_for_graph_result(state, result, agent=None, task="Build a REST API")
+    assert out["max_steps"] > 15
+    assert out.get("is_final") is False
+    assert not str(out.get("final_response") or "").startswith("diff --git")

--- a/tests/test_step_budget_pause.py
+++ b/tests/test_step_budget_pause.py
@@ -1,0 +1,201 @@
+"""Continue/Abort pause when the main-agent step budget is exhausted."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from core.agent_events import StepBudgetChoiceEvent
+from core.presenters.final_content import (
+    coerce_usable_final_text,
+    is_code_or_diff_dump,
+    step_limit_reached_message,
+)
+from core.runtime.step_budget import StepBudgetPolicy, maybe_extend_or_ask
+from core.runtime.step_budget_pause import (
+    ABORT,
+    CONTINUE,
+    ask_continue_or_abort,
+    can_ask_user,
+    resolve_step_budget,
+)
+
+
+class _Bus:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    def emit(self, event: object) -> None:
+        self.events.append(event)
+
+
+class _Agent:
+    def __init__(self, *, non_interactive: bool = False) -> None:
+        self.events = _Bus()
+        self.config = SimpleNamespace(
+            non_interactive=non_interactive,
+            profile_name="default",
+            max_steps_extend_by=30,
+            max_steps_user_max_extensions=10,
+            max_steps_max_extensions=10,
+            max_steps_extend_enabled=True,
+        )
+        self.subagent_system_prompt = None
+
+    def emit(self, event: object) -> None:
+        self.events.emit(event)
+
+
+def test_code_or_diff_dump_detection() -> None:
+    diff = (
+        "diff --git a/foo.py b/foo.py\n"
+        "--- a/foo.py\n"
+        "+++ b/foo.py\n"
+        "@@ -1,3 +1,8 @@\n"
+        "+def run():\n"
+        "+    return 1\n"
+    ) * 8
+    assert is_code_or_diff_dump(diff)
+    assert not is_code_or_diff_dump("Updated foo.py and ran tests. All 8 passed.")
+    assert "Достигнут лимит шагов" in coerce_usable_final_text(diff, max_steps=90)
+    assert "90" in step_limit_reached_message(90, step_count=90, extra_steps=30, locale="en")
+
+
+def test_can_ask_user_skips_subagents_and_unattended() -> None:
+    policy = StepBudgetPolicy(user_max_extensions=10)
+    main = _Agent()
+    assert can_ask_user(main, conversation_id="studio_tab", user_used=0, policy=policy)
+    sub = _Agent()
+    sub.subagent_system_prompt = "You are a coder sub-agent"
+    assert not can_ask_user(sub, conversation_id="subagent:job", user_used=0, policy=policy)
+    quiet = _Agent(non_interactive=True)
+    assert not can_ask_user(quiet, conversation_id="cron", user_used=0, policy=policy)
+    assert not can_ask_user(main, conversation_id="studio_tab", user_used=10, policy=policy)
+
+
+@pytest.mark.asyncio
+async def test_ask_continue_resolves_future() -> None:
+    agent = _Agent()
+
+    async def _resolve() -> None:
+        await asyncio.sleep(0)
+        ev = next(e for e in agent.events.events if isinstance(e, StepBudgetChoiceEvent))
+        assert ev.request_id
+        assert any(c.get("code") == CONTINUE for c in ev.choices)
+        assert resolve_step_budget(ev.request_id, CONTINUE)
+
+    task = asyncio.create_task(_resolve())
+    choice = await ask_continue_or_abort(
+        agent=agent,
+        conversation_id="c1",
+        step_count=90,
+        max_steps=90,
+        extra_steps=30,
+        user_used=0,
+        user_max=10,
+        reason="extension limit reached",
+        locale="en",
+    )
+    await task
+    assert choice == CONTINUE
+
+
+@pytest.mark.asyncio
+async def test_maybe_extend_or_ask_user_continue() -> None:
+    agent = _Agent()
+    state = {
+        "user_input": "Build a REST API",
+        "max_steps": 15,
+        "base_max_steps": 15,
+        "step_budget_extensions": 10,
+        "step_budget_user_extensions": 0,
+        "conversation_id": "t1",
+        "messages": [
+            {"role": "user", "content": "Build a REST API"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "1",
+                        "function": {"name": "write_file", "arguments": '{"path":"api.py"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "1",
+                "content": "OK: created api.py with endpoints successfully",
+            },
+        ],
+    }
+    result = {
+        "step_count": 15,
+        "max_steps": 15,
+        "is_final": True,
+        "final_response": "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n" + ("+x\n" * 20),
+        "tool_calls": [],
+        "messages": state["messages"],
+        "step_budget_extensions": 10,
+    }
+
+    async def _resolve() -> None:
+        for _ in range(50):
+            await asyncio.sleep(0)
+            ev = next(
+                (e for e in agent.events.events if isinstance(e, StepBudgetChoiceEvent)),
+                None,
+            )
+            if ev is not None:
+                resolve_step_budget(ev.request_id, CONTINUE)
+                return
+        raise AssertionError("no StepBudgetChoiceEvent")
+
+    task = asyncio.create_task(_resolve())
+    out = await maybe_extend_or_ask(state, result, agent=agent, task="Build a REST API")
+    await task
+    assert out["max_steps"] == 45
+    assert out.get("is_final") is False
+    assert out.get("step_budget_user_extensions") == 1
+
+
+@pytest.mark.asyncio
+async def test_maybe_extend_or_ask_abort() -> None:
+    agent = _Agent()
+    state = {
+        "max_steps": 15,
+        "step_budget_extensions": 10,
+        "conversation_id": "t1",
+        "user_input": "hi",
+        "messages": [],
+    }
+    result = {
+        "step_count": 15,
+        "max_steps": 15,
+        "is_final": False,
+        "final_response": "",
+        "tool_calls": [],
+        "messages": [],
+        "step_budget_extensions": 10,
+    }
+
+    async def _resolve() -> None:
+        for _ in range(50):
+            await asyncio.sleep(0)
+            ev = next(
+                (e for e in agent.events.events if isinstance(e, StepBudgetChoiceEvent)),
+                None,
+            )
+            if ev is not None:
+                resolve_step_budget(ev.request_id, ABORT)
+                return
+        raise AssertionError("no StepBudgetChoiceEvent")
+
+    task = asyncio.create_task(_resolve())
+    out = await maybe_extend_or_ask(state, result, agent=agent, task="hi")
+    await task
+    assert out.get("is_final") is True
+    text = str(out.get("final_response") or "").lower()
+    assert "15" in text
+    assert "limit" in text or "лимит" in text
+    assert out.get("max_steps") == 15

--- a/tests/test_step_budget_pause.py
+++ b/tests/test_step_budget_pause.py
@@ -62,7 +62,8 @@ def test_code_or_diff_dump_detection() -> None:
     assert "90" in step_limit_reached_message(90, step_count=90, extra_steps=30, locale="en")
 
 
-def test_can_ask_user_skips_subagents_and_unattended() -> None:
+def test_can_ask_user_skips_subagents_and_unattended(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     policy = StepBudgetPolicy(user_max_extensions=10)
     main = _Agent()
     assert can_ask_user(main, conversation_id="studio_tab", user_used=0, policy=policy)
@@ -72,6 +73,12 @@ def test_can_ask_user_skips_subagents_and_unattended() -> None:
     quiet = _Agent(non_interactive=True)
     assert not can_ask_user(quiet, conversation_id="cron", user_used=0, policy=policy)
     assert not can_ask_user(main, conversation_id="studio_tab", user_used=10, policy=policy)
+
+
+def test_can_ask_user_skips_pytest() -> None:
+    policy = StepBudgetPolicy(user_max_extensions=10)
+    main = _Agent()
+    assert not can_ask_user(main, conversation_id="studio_tab", user_used=0, policy=policy)
 
 
 @pytest.mark.asyncio
@@ -102,7 +109,8 @@ async def test_ask_continue_resolves_future() -> None:
 
 
 @pytest.mark.asyncio
-async def test_maybe_extend_or_ask_user_continue() -> None:
+async def test_maybe_extend_or_ask_user_continue(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     agent = _Agent()
     state = {
         "user_input": "Build a REST API",
@@ -160,7 +168,8 @@ async def test_maybe_extend_or_ask_user_continue() -> None:
 
 
 @pytest.mark.asyncio
-async def test_maybe_extend_or_ask_abort() -> None:
+async def test_maybe_extend_or_ask_abort(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     agent = _Agent()
     state = {
         "max_steps": 15,

--- a/tests/user_cases/harness.py
+++ b/tests/user_cases/harness.py
@@ -83,6 +83,7 @@ class UserCaseHarness:
             "mcp_enabled": False,
             "self_extensions_enabled": False,
             "max_steps": 12,
+            "max_steps_user_max_extensions": 0,
             "workspace_root": str(self.workspace.root),
             "workspace_jail_enabled": True,
             "profile_name": "default",

--- a/tests/user_cases/test_session_journeys.py
+++ b/tests/user_cases/test_session_journeys.py
@@ -50,6 +50,7 @@ async def test_uc14_max_steps_stops_without_hang(temp_dir, monkeypatch: pytest.M
         config_overrides={
             "max_steps": 2,
             "max_steps_extend_enabled": False,
+            "max_steps_user_max_extensions": 0,
         },
     )
     await h.setup()


### PR DESCRIPTION
## Summary

When the main agent hits `max_steps`, Holix no longer stops with a source dump or diff as the last message.

- Auto-extend still grants extra steps if the run is healthy (supervisor). `TimeoutError:` / `error` inside source dumps no longer count as hung tools.
- If auto-extend cannot continue, the **main** agent pauses with **Continue** (`+max_steps_extend_by`, default +30) or **Abort**.
- Continue clicks are capped by `HOLIX_MAX_STEPS_USER_MAX_EXTENSIONS` (default 10).
- TUI modal, Telegram and MAX inline buttons.
- Sub-agents keep auto-extend, then fail with a step-limit error (no dump).

No version bump and no GitHub release in this PR.

## Tests

- `tests/test_step_budget.py` — dump/`TimeoutError` health check, extend on dump `is_final`
- `tests/test_step_budget_pause.py` — Continue/Abort pause
- `./scripts/lint.sh` green locally