### PR TITLE
fix: archive SDD specs that use ### F-1 headings

### DIFF
--- a/core/sdd/merge.py
+++ b/core/sdd/merge.py
@@ -13,6 +13,8 @@ _SECTION_RE = re.compile(
     r"^##\s+(ADDED|MODIFIED|REMOVED)\s+Requirements?\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
+# Full-domain specs (often RU fill): ``### F-1. Title`` instead of ``### Requirement:``.
+_H3_RE = re.compile(r"^###\s+(?P<title>\S.*?)\s*$", re.MULTILINE)
 
 
 @dataclass
@@ -36,6 +38,43 @@ def _split_requirements(content: str) -> list[_Requirement]:
     return reqs
 
 
+def _split_h3_as_requirements(content: str) -> list[_Requirement]:
+    """Treat ``### Title`` blocks as requirements when OpenSpec headings are missing.
+
+    Agents often write a full domain spec (``## Требования`` / ``### F-1. …``)
+    instead of ``## ADDED Requirements`` / ``### Requirement:``. Archive would
+    otherwise refuse the merge and leave the change stuck.
+    """
+    matches = list(_H3_RE.finditer(content or ""))
+    if not matches:
+        return []
+    reqs: list[_Requirement] = []
+    for i, m in enumerate(matches):
+        raw_title = (m.group("title") or "").strip()
+        if not raw_title:
+            continue
+        if raw_title.lower().startswith("requirement:"):
+            title = raw_title.split(":", 1)[1].strip() or raw_title
+        else:
+            title = raw_title
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(content)
+        rest = content[m.end() : end].strip("\n")
+        block = f"### Requirement: {title}\n"
+        if rest:
+            block += f"\n{rest}\n"
+        else:
+            block += "\n"
+        reqs.append(_Requirement(title=title, body=block))
+    return reqs
+
+
+def _requirements_from_spec_body(content: str) -> list[_Requirement]:
+    reqs = _split_requirements(content)
+    if reqs:
+        return reqs
+    return _split_h3_as_requirements(content)
+
+
 def _normalize_title(title: str) -> str:
     return re.sub(r"\s+", " ", title.strip().lower())
 
@@ -56,8 +95,9 @@ def _parse_delta_sections(delta: str) -> list[tuple[str, list[_Requirement]]]:
     """
     matches = list(_SECTION_RE.finditer(delta))
     if not matches:
-        # Whole file treated as ADDED if it has requirements
-        return [("ADDED", _split_requirements(delta))]
+        # Whole file treated as ADDED if it has Requirement: or ### headings
+        reqs = _requirements_from_spec_body(delta)
+        return [("ADDED", reqs)] if reqs else []
 
     ordered: list[tuple[str, list[_Requirement]]] = []
     for i, m in enumerate(matches):
@@ -65,7 +105,7 @@ def _parse_delta_sections(delta: str) -> list[tuple[str, list[_Requirement]]]:
         start = m.end()
         end = matches[i + 1].start() if i + 1 < len(matches) else len(delta)
         body = delta[start:end]
-        ordered.append((kind, _split_requirements(body)))
+        ordered.append((kind, _requirements_from_spec_body(body)))
     return ordered
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- **SDD archive** — a full domain spec with ``### F-1. Title`` (no
+  ``## ADDED Requirements`` / ``### Requirement:``) merges into
+  ``openspec/specs`` instead of refusing the archive. Common after RU/agent fill.
+
 ### Added
 
 - **Telegram / MAX** — per-profile default `max_steps` is set from `/menu` →

--- a/tests/test_sdd.py
+++ b/tests/test_sdd.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from core.sdd.apply_mode import apply_mode_prompt_text, normalize_apply_mode, save_apply_mode
-from core.sdd.merge import merge_delta_into_main, patch_delta_spec
+from core.sdd.merge import count_delta_requirements, merge_delta_into_main, patch_delta_spec
 from core.sdd.paths import confined_under, validate_change_id
 from core.sdd.store import SpecStore
 from core.sdd.tasks import parse_tasks_markdown, set_task_assignee, set_task_done
@@ -116,6 +116,43 @@ def test_set_task_done_and_assignee():
     assert tasks[0].assignee == "ui-dev"
     assert tasks[0].reason == "UI only"
     assert tasks[0].done is True
+
+
+def test_merge_plain_h3_domain_spec_as_added() -> None:
+    """RU/agent fill uses ``### F-1. Title`` instead of OpenSpec delta headings."""
+    main = "# core\n\n"
+    delta = """# Спецификация домена: Stars-ключ для не-участников
+
+## Требования
+
+### F-1. Интерактивное меню бота
+Бот должен отвечать на `/start` inline-клавиатурой.
+
+### F-2. Покупка за Stars
+При нажатии «Купить ключ за Stars» бот отправляет инвойс.
+
+#### Scenario: Pay
+- **GIVEN** a user
+- **WHEN** they pay
+- **THEN** a key is issued
+"""
+    assert count_delta_requirements(delta) == 2
+    out = merge_delta_into_main(main, delta)
+    assert "### Requirement: F-1. Интерактивное меню бота" in out
+    assert "### Requirement: F-2. Покупка за Stars" in out
+    assert "inline-клавиатурой" in out
+    assert "#### Scenario: Pay" in out
+    assert out.count("### Requirement:") == 2
+
+
+def test_count_delta_requirements_still_uses_openspec_headings() -> None:
+    delta = """## ADDED Requirements
+
+### Requirement: Login
+The system SHALL login.
+"""
+    assert count_delta_requirements(delta) == 1
+    assert count_delta_requirements("# empty\n") == 0
 
 
 def test_merge_delta_added_modified_removed():
@@ -276,6 +313,47 @@ def test_archive_nested_spec_merges_into_parent_domain(tmp_path: Path):
     assert "Top level" in main
     assert "Nested note" in main
     assert archived["merged_specs"] == ["openspec/specs/auth/spec.md"]
+
+
+def test_archive_merges_h3_domain_spec_without_openspec_delta(tmp_path: Path) -> None:
+    store = SpecStore(tmp_path)
+    store.init(example_domain="core")
+    store.create_change("stars-key-for-non-members", domain="core")
+    store.write_artifact(
+        "stars-key-for-non-members",
+        "proposal",
+        "# Proposal\n\n## Why\nStars key.\n\n## What\nSell it.\n\n## Impact\nSpecs.\n",
+    )
+    spec = (
+        tmp_path
+        / "openspec"
+        / "changes"
+        / "stars-key-for-non-members"
+        / "specs"
+        / "core"
+        / "spec.md"
+    )
+    spec.write_text(
+        "# Спецификация домена: Stars-ключ\n\n"
+        "## Требования\n\n"
+        "### F-1. Интерактивное меню бота\n"
+        "Бот должен отвечать на `/start`.\n\n"
+        "### NF-1. Цена\n"
+        "Цена задаётся env `STARS_KEY_PRICE`.\n",
+        encoding="utf-8",
+    )
+    store.write_artifact(
+        "stars-key-for-non-members",
+        "tasks",
+        "# Tasks\n\n- [x] 1.1 Done\n  - **assignee:** `main`\n  - **reason:** ok\n",
+    )
+    archived = store.archive("stars-key-for-non-members")
+    assert archived["ok"] is True, archived
+    assert archived["requirements_merged"] == 2
+    main = (tmp_path / "openspec" / "specs" / "core" / "spec.md").read_text(encoding="utf-8")
+    assert "### Requirement: F-1. Интерактивное меню бота" in main
+    assert "STARS_KEY_PRICE" in main
+    assert not (tmp_path / "openspec" / "changes" / "stars-key-for-non-members").exists()
 
 
 def test_archive_warns_on_open_tasks(tmp_path: Path):


### PR DESCRIPTION
## Summary

SDD archive refused changes whose domain spec used \`### F-1. Title\` / \`## Требования\` instead of OpenSpec \`## ADDED Requirements\` / \`### Requirement:\`. That left \`stars-key-for-non-members\` stuck on holix-studio.ru Plans.

Archive now treats those h3 blocks as ADDED requirements and merges them into \`openspec/specs\`.

No version bump and no GitHub release in this PR.

## Tests

- \`tests/test_sdd.py\` — count/merge/archive of the RU h3 spec shape
- \`./scripts/lint.sh\` green locally